### PR TITLE
Prepare for 1.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.10.0
+  - 1.11.0
   - beta
   - nightly
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustyline"
-version = "0.2.3"
+version = "1.0.0"
 authors = ["Katsu Kawakami <kkawa1570@gmail.com>"]
 description = "Rustyline, a readline implementation based on Antirez's Linenoise"
 documentation = "http://kkawakam.github.io/rustyline/rustyline"

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # RustyLine
 [![Build Status](https://travis-ci.org/kkawakam/rustyline.svg?branch=master)](https://travis-ci.org/kkawakam/rustyline)
+[![Build status](https://ci.appveyor.com/api/projects/status/ls7sty8nt25rdfkq/branch/master?svg=true)](https://ci.appveyor.com/project/kkawakam/rustyline/branch/master)
 [![Clippy Linting Result](https://clippy.bashy.io/github/kkawakam/rustyline/master/badge.svg)](https://clippy.bashy.io/github/kkawakam/rustyline/master/log)
 [![](http://meritbadge.herokuapp.com/rustyline)](https://crates.io/crates/rustyline)
-[![Build status](https://ci.appveyor.com/api/projects/status/ls7sty8nt25rdfkq/branch/master?svg=true)](https://ci.appveyor.com/project/kkawakam/rustyline/branch/master)
 
 Readline implementation in Rust that is based on [Antirez' Linenoise](https://github.com/antirez/linenoise)
 
 [Documentation](https://kkawakam.github.io/rustyline)
 
-
 **Supported Platforms**
 * Linux
-* Windows - Work in Progress (Issue #37), modifier keys do not work
+* Windows
+   * cmd.exe
+   * Powershell
+
+**Note**: Powershell ISE is not supported, check [issue #56](https://github.com/kkawakam/rustyline/issues/56)
 
 ## Build
-This project uses Cargo and Rust Nightly
+This project uses Cargo and Rust stable
 ```bash
 cargo build --release
 ```
@@ -63,7 +66,7 @@ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustyline = "0.2.3"
+rustyline = "1.0.0"
 ```
 
 ## Features

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - TARGET: 1.10.0-x86_64-pc-windows-msvc
-  - TARGET: 1.10.0-x86_64-pc-windows-gnu
+  - TARGET: 1.11.0-x86_64-pc-windows-msvc
+  - TARGET: 1.11.0-x86_64-pc-windows-gnu
   - TARGET: beta-x86_64-pc-windows-msvc
   - TARGET: beta-x86_64-pc-windows-gnu
 install:


### PR DESCRIPTION
* Update travis and appveyor to use latest stable release (1.11.0)
* Update cargo.toml for a 1.0.0 rustyline release
