### PR TITLE
Update README for master doc & run test with rust 1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.11.0
+  - 1.12.0
   - beta
   - nightly
 script:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 Readline implementation in Rust that is based on [Antirez' Linenoise](https://github.com/antirez/linenoise)
 
-[Documentation](https://docs.rs/rustyline)
+[Documentation (Releases)](https://docs.rs/rustyline)
+[Documentation (Master)](https://kkawakam.github.io/rustyline/rustyline/)
 
 **Supported Platforms**
 * Linux

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 Readline implementation in Rust that is based on [Antirez' Linenoise](https://github.com/antirez/linenoise)
 
 [Documentation (Releases)](https://docs.rs/rustyline)
+
 [Documentation (Master)](https://kkawakam.github.io/rustyline/rustyline/)
 
 **Supported Platforms**

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - TARGET: 1.11.0-x86_64-pc-windows-msvc
-  - TARGET: 1.11.0-x86_64-pc-windows-gnu
+  - TARGET: 1.12.0-x86_64-pc-windows-msvc
+  - TARGET: 1.12.0-x86_64-pc-windows-gnu
   - TARGET: beta-x86_64-pc-windows-msvc
   - TARGET: beta-x86_64-pc-windows-gnu
 install:


### PR DESCRIPTION
Adding a link to the readme for the master doc and reving the rust version used in testing for both appveyor + travis.