### PR TITLE
fix is_unsupported_term() does not detect unsupported term correctly

### DIFF
--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -69,11 +69,12 @@ fn is_unsupported_term() -> bool {
     use std::ascii::AsciiExt;
     match std::env::var("TERM") {
         Ok(term) => {
-            let mut unsupported = false;
             for iter in &UNSUPPORTED_TERM {
-                unsupported = (*iter).eq_ignore_ascii_case(&term)
+                if (*iter).eq_ignore_ascii_case(&term) {
+                    return true
+                }
             }
-            unsupported
+            false
         }
         Err(_) => false,
     }
@@ -296,5 +297,17 @@ impl PosixTerminal {
     /// Clear the screen. Used to handle ctrl+l
     pub fn clear_screen(&mut self, w: &mut Write) -> Result<()> {
         clear_screen(w)
+    }
+}
+
+#[cfg(all(unix,test))]
+mod test {
+    #[test]
+    fn test_unsupported_term() {
+        ::std::env::set_var("TERM", "xterm");
+        assert_eq!(false, super::is_unsupported_term());
+
+        ::std::env::set_var("TERM", "dumb");
+        assert_eq!(true, super::is_unsupported_term());
     }
 }


### PR DESCRIPTION
* expected
  * when `TERM`  is set to `dumb` or `cons25`, `is_unsupported_term()` returns `true`
* actual
  * when `TERM`  is set to `dumb` or `cons25`, `is_unsupported_term()` returns `false`

* fix
  * when `term` is matched to one of `UNSUPPORTED_TERM` in `is_unsupported_term()` , returns `true` immediately.