### PR TITLE
fix autocomplete cancel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,7 +550,6 @@ fn complete_line<R: RawReader>(rdr: &mut R,
                 // Restore current edited line
                 s.snapshot();
                 try!(s.refresh_line());
-                s.snapshot();
             }
 
             key = try!(rdr.next_key(false));
@@ -561,12 +560,10 @@ fn complete_line<R: RawReader>(rdr: &mut R,
                         try!(beep());
                     }
                 }
-                KeyPress::Esc => {
+                KeyPress::Esc if i < candidates.len() => {
                     // Re-show original buffer
                     s.snapshot();
-                    if i < candidates.len() {
-                        try!(s.refresh_line());
-                    }
+                    try!(s.refresh_line());
                     return Ok(None);
                 }
                 _ => {


### PR DESCRIPTION
When you cycle through all the options and return to the original uncompleted input, we should update the State.