### PR TITLE
fix autocomplete cancel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,6 +570,9 @@ fn complete_line<R: RawReader>(rdr: &mut R,
                     return Ok(None);
                 }
                 _ => {
+                    if i == candidates.len() {
+                        s.snapshot();
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
When you cycle through all the options and return to your original
uncompleted input, we should update the State.

remake of #95 