### PR TITLE
Introduce with_config construstor to ease migration

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -19,7 +19,7 @@ fn main() {
         .completion_type(CompletionType::List)
         .build();
     let c = FilenameCompleter::new();
-    let mut rl = Editor::new(config);
+    let mut rl = Editor::with_config(config);
     rl.set_completer(Some(c));
     if rl.load_history("history.txt").is_err() {
         println!("No previous history.");

--- a/src/history.rs
+++ b/src/history.rs
@@ -25,7 +25,10 @@ pub struct History {
 }
 
 impl History {
-    pub fn new(config: Config) -> History {
+    pub fn new() -> History {
+        Self::with_config(Config::default())
+    }
+    pub fn with_config(config: Config) -> History {
         History {
             entries: VecDeque::new(),
             max_len: config.max_history_size(),
@@ -205,8 +208,8 @@ mod tests {
     use super::{Direction, History};
     use config::Config;
 
-    fn init() -> super::History {
-        let mut history = History::new(Config::default());
+    fn init() -> History {
+        let mut history = History::new();
         assert!(history.add("line1"));
         assert!(history.add("line2"));
         assert!(history.add("line3"));
@@ -215,9 +218,7 @@ mod tests {
 
     #[test]
     fn new() {
-        let config = Config::default();
-        let history = History::new(config);
-        assert_eq!(config.max_history_size(), history.max_len);
+        let history = History::new();
         assert_eq!(0, history.entries.len());
     }
 
@@ -226,7 +227,8 @@ mod tests {
         let config = Config::builder()
             .history_ignore_space(true)
             .build();
-        let mut history = History::new(config);
+        let mut history = History::with_config(config);
+        assert_eq!(config.max_history_size(), history.max_len);
         assert!(history.add("line1"));
         assert!(history.add("line2"));
         assert!(!history.add("line2"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,7 @@
 //! Usage
 //!
 //! ```
-//! let config = rustyline::Config::default();
-//! let mut rl = rustyline::Editor::<()>::new(config);
+//! let mut rl = rustyline::Editor::<()>::new();
 //! let readline = rl.readline(">> ");
 //! match readline {
 //!     Ok(line) => println!("Line: {:?}",line),
@@ -1061,11 +1060,15 @@ pub struct Editor<C: Completer> {
 }
 
 impl<C: Completer> Editor<C> {
-    pub fn new(config: Config) -> Editor<C> {
+    pub fn new() -> Editor<C> {
+        Self::with_config(Config::default())
+    }
+
+    pub fn with_config(config: Config) -> Editor<C> {
         let term = Terminal::new();
         Editor {
             term: term,
-            history: History::new(config),
+            history: History::with_config(config),
             completer: None,
             kill_ring: KillRing::new(60),
             config: config,
@@ -1115,8 +1118,7 @@ impl<C: Completer> Editor<C> {
     }
 
     /// ```
-    /// let config = rustyline::Config::default();
-    /// let mut rl = rustyline::Editor::<()>::new(config);
+    /// let mut rl = rustyline::Editor::<()>::new();
     /// for readline in rl.iter("> ") {
     ///     match readline {
     ///         Ok(line) => {
@@ -1202,8 +1204,7 @@ mod test {
     }
 
     fn init_editor(keys: &[KeyPress]) -> Editor<()> {
-        let config = Config::default();
-        let mut editor = Editor::<()>::new(config);
+        let mut editor = Editor::<()>::new();
         editor.term.keys.extend(keys.iter().cloned());
         editor
     }
@@ -1213,7 +1214,7 @@ mod test {
         let mut out = ::std::io::sink();
         let line = "current edited line";
         let mut s = init_state(&mut out, line, 6, 80);
-        let mut history = History::new(Config::default());
+        let mut history = History::new();
         history.add("line0");
         history.add("line1");
         s.history_index = history.len();


### PR DESCRIPTION
Only the projects using:
 - `History.search`
 - `History.ignore_space`
 - `History.ignore_dups`
 - `Editor.history_ignore_space`
 - `Editor.history_ignore_dups`
 - `Editor.set_history_max_len`
 - `History::default`
 - `Editor::default`

will now be impacted when upgrading from 1.0 to 2.0...