### PR TITLE
Make completion::ESCAPE_CHAR public

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -68,13 +68,13 @@ pub struct FilenameCompleter {
 static DEFAULT_BREAK_CHARS: [char; 18] = [' ', '\t', '\n', '"', '\\', '\'', '`', '@', '$', '>',
                                           '<', '=', ';', '|', '&', '{', '(', '\0'];
 #[cfg(unix)]
-static ESCAPE_CHAR: Option<char> = Some('\\');
+pub static ESCAPE_CHAR: Option<char> = Some('\\');
 // Remove \ to make file completion works on windows
 #[cfg(windows)]
 static DEFAULT_BREAK_CHARS: [char; 17] = [' ', '\t', '\n', '"', '\'', '`', '@', '$', '>', '<',
                                           '=', ';', '|', '&', '{', '(', '\0'];
 #[cfg(windows)]
-static ESCAPE_CHAR: Option<char> = None;
+pub static ESCAPE_CHAR: Option<char> = None;
 
 impl FilenameCompleter {
     pub fn new() -> FilenameCompleter {


### PR DESCRIPTION
This is necessary to correctly use the `unescape` function on every platform (i.e. to extract the path after it has been completed).