### PR TITLE
Add ability to get constant reference to history from Editor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1105,9 +1105,13 @@ impl<C: Completer> Editor<C> {
     pub fn clear_history(&mut self) {
         self.history.clear()
     }
-    /// Return a reference to the history object.
+    /// Return a mutable reference to the history object.
     pub fn get_history(&mut self) -> &mut History {
         &mut self.history
+    }
+    /// Return an immutable reference to the history object.
+    pub fn get_history_const(&self) -> &History {
+        &self.history
     }
 
     /// Register a callback function to be called for tab-completion.


### PR DESCRIPTION
In one of my projects, I'd like to be able to call editor.get_history().get(i), where the caller only has an immutable reference to the editor.

This PR adds get_history_const(), a function that returns an immutable reference to the history.

## Alternatives

- change `get_history` to return an immutable reference and add `get_history_mut`

The convention in the standard library seems to be that the the immutable version is just get_history() while the mutable version is get_history_mut(), e.g. [Slice](https://doc.rust-lang.org/std/primitive.slice.html#method.get_mut), [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.get_mut), [HashMap](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.get_mut). Switching the behavior of get_history() is a breaking change, which may or may not be worth the hassle of deprecating get_history() in favor of get_history_mut() and then also having to deprecate get_history_const() back to get_history().