### PR TITLE
Adds support for "blinking" matching delimiters `({[`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     completion_prompt_limit: usize,
     /// Duration (milliseconds) Rustyline will wait for a character when reading an ambiguous key sequence.
     keyseq_timeout: i32,
+    /// Maximum duration (milliseconds) Rustyline will use for animating the blink on a matching delimiter.
+    matching_delimiter_timeout: i32,
 }
 
 impl Config {
@@ -48,6 +50,10 @@ impl Config {
     pub fn keyseq_timeout(&self) -> i32 {
         self.keyseq_timeout
     }
+
+    pub fn matching_delimiter_timeout(&self) -> i32 {
+        self.matching_delimiter_timeout
+    }
 }
 
 impl Default for Config {
@@ -59,6 +65,7 @@ impl Default for Config {
             completion_type: CompletionType::Circular, // TODO Validate
             completion_prompt_limit: 100,
             keyseq_timeout: 500,
+            matching_delimiter_timeout: 500,
         }
     }
 }
@@ -127,6 +134,11 @@ impl Builder {
     /// Set `keyseq_timeout` in milliseconds.
     pub fn keyseq_timeout(mut self, keyseq_timeout_ms: i32) -> Builder {
         self.p.keyseq_timeout = keyseq_timeout_ms;
+        self
+    }
+
+    pub fn matching_delimiter_timeout(mut self, matching_delimiter_timeout_ms: i32) -> Builder {
+        self.p.matching_delimiter_timeout = matching_delimiter_timeout_ms;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,6 +816,7 @@ fn readline_edit<C: Completer>(prompt: &str,
             try!(rdr.next_char_ready(editor.config.matching_delimiter_timeout()));
             s.snapshot();
             try!(s.refresh_line());
+            s.blinking = false;
         }
 
         let rk = rdr.next_key(editor.config.keyseq_timeout());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,8 +311,6 @@ fn edit_insert(s: &mut State, ch: char) -> Result<()> {
     }
 }
 
-const MATCHING_DELIMITER_BLINK_DELAY: u64 = 500;
-
 // Briefly move the cursor to the delimiter that matches `ch` if one exists.
 fn edit_blink_matching_delimeter(s: &mut State, ch: char) -> Result<()> {
     match ch {

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -276,6 +276,21 @@ impl LineBuffer {
         Some(pos)
     }
 
+    /// Moves the cursor to the matching delimiter.
+    pub fn move_to_matching_delimiter(&mut self, delimiter: char) -> bool {
+        matching_delimiter_for(delimiter).and_then(|matching_delimiter| {
+            // TODO need to handle nesting, right now just scans backwards to first closer
+            match self.prev_word_pos(self.pos, |ch| ch == matching_delimiter) {
+                Some(pos) if pos == 0 => false,
+                Some(pos) => {
+                    self.pos = pos - 1;
+                    true
+                }
+                None => false
+            }.into()
+        }).unwrap_or(false)
+    }
+
     /// Moves the cursor to the beginning of previous word.
     pub fn move_to_prev_word(&mut self) -> bool {
         if let Some(pos) = self.prev_word_pos(self.pos, |ch| !ch.is_alphanumeric()) {
@@ -453,6 +468,15 @@ fn insert_str(buf: &mut String, idx: usize, s: &str) {
                   len - idx);
         ptr::copy_nonoverlapping(s.as_ptr(), v.as_mut_ptr().offset(idx as isize), amt);
         v.set_len(len + amt);
+    }
+}
+
+fn matching_delimiter_for(ch: char) -> Option<char> {
+    match ch {
+        ')' => Some('('),
+        ']' => Some('['),
+        '}' => Some('{'),
+        _ => None
     }
 }
 

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -14,6 +14,10 @@ pub trait RawReader: Sized {
     /// For CTRL-V support
     #[cfg(unix)]
     fn next_char(&mut self) -> Result<char>;
+    /// Indicates if there is a character ready to be read.
+    /// Supports escape sequences and delimiter matching.
+    #[cfg(unix)]
+    fn next_char_ready(&mut self, timeout_ms: i32) -> Result<usize>;
 }
 
 /// Terminal contract

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -16,7 +16,6 @@ pub trait RawReader: Sized {
     fn next_char(&mut self) -> Result<char>;
     /// Indicates if there is a character ready to be read.
     /// Supports escape sequences and delimiter matching.
-    #[cfg(unix)]
     fn next_char_ready(&mut self, timeout_ms: i32) -> Result<usize>;
 }
 

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -31,6 +31,11 @@ impl<'a> RawReader for Iter<'a, KeyPress> {
     fn next_char(&mut self) -> Result<char> {
         unimplemented!();
     }
+
+    #[cfg(unix)]
+    fn next_char_ready(&mut self, _: i32) -> Result<usize> {
+        unimplemented!();
+    }
 }
 
 impl RawReader for IntoIter<KeyPress> {
@@ -42,6 +47,11 @@ impl RawReader for IntoIter<KeyPress> {
     }
     #[cfg(unix)]
     fn next_char(&mut self) -> Result<char> {
+        unimplemented!();
+    }
+
+    #[cfg(unix)]
+    fn next_char_ready(&mut self, _: i32) -> Result<usize> {
         unimplemented!();
     }
 }

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -32,7 +32,6 @@ impl<'a> RawReader for Iter<'a, KeyPress> {
         unimplemented!();
     }
 
-    #[cfg(unix)]
     fn next_char_ready(&mut self, _: i32) -> Result<usize> {
         unimplemented!();
     }
@@ -50,7 +49,6 @@ impl RawReader for IntoIter<KeyPress> {
         unimplemented!();
     }
 
-    #[cfg(unix)]
     fn next_char_ready(&mut self, _: i32) -> Result<usize> {
         unimplemented!();
     }

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -179,9 +179,7 @@ impl RawReader for PosixRawReader {
 
         let mut key = consts::char_to_key_press(c);
         if key == KeyPress::Esc {
-            let mut fds =
-                [poll::PollFd::new(STDIN_FILENO, poll::POLLIN, poll::EventFlags::empty())];
-            match poll::poll(&mut fds, timeout_ms) {
+            match self.next_char_ready(timeout_ms) {
                 Ok(n) if n == 0 => {
                     // single escape
                 }
@@ -200,6 +198,16 @@ impl RawReader for PosixRawReader {
         match self.chars.next() {
             Some(c) => Ok(try!(c)),
             None => Err(error::ReadlineError::Eof),
+        }
+    }
+
+    // Indicates if there
+    fn next_char_ready(&mut self, timeout_ms: i32) -> Result<usize> {
+        let mut fds =
+            [poll::PollFd::new(STDIN_FILENO, poll::POLLIN, poll::EventFlags::empty())];
+        match poll::poll(&mut fds, timeout_ms) {
+            Ok(n) => Ok(n as usize),
+            Err(e) => Err(e.into()),
         }
     }
 }

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -201,7 +201,7 @@ impl RawReader for PosixRawReader {
         }
     }
 
-    // Indicates if there
+    // Polls for unread input, up to `timeout_ms`.
     fn next_char_ready(&mut self, timeout_ms: i32) -> Result<usize> {
         let mut fds =
             [poll::PollFd::new(STDIN_FILENO, poll::POLLIN, poll::EventFlags::empty())];

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -167,13 +167,11 @@ impl RawReader for ConsoleRawReader {
     }
 
     fn next_char_ready(&mut self, timeout_ms: i32) -> Result<usize> {
-        let t = as_millis(timeout);
-
-        match unsafe { kernel32::WaitForSingleObject(self.handle, timeout_ms) } {
+        match unsafe { kernel32::WaitForSingleObject(self.handle, timeout_ms as u32) } {
             winapi::WAIT_OBJECT_0 => Ok(1),
             winapi::WAIT_TIMEOUT => Ok(0),
             winapi::WAIT_FAILED |
-            _ => Err(io::Error::last_os_error()),
+            _ => try!(Err(io::Error::last_os_error())),
         }
     }
 }

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -165,6 +165,17 @@ impl RawReader for ConsoleRawReader {
             }
         }
     }
+
+    fn next_char_ready(&mut self, timeout_ms: i32) -> Result<usize> {
+        let t = as_millis(timeout);
+
+        match unsafe { kernel32::WaitForSingleObject(self.handle, timeout_ms) } {
+            winapi::WAIT_OBJECT_0 => Ok(1),
+            winapi::WAIT_TIMEOUT => Ok(0),
+            winapi::WAIT_FAILED |
+            _ => Err(io::Error::last_os_error()),
+        }
+    }
 }
 
 impl Iterator for ConsoleRawReader {


### PR DESCRIPTION
Briefly moves the cursor to a matching delimiter when one is typed, then returns the cursor to its original position either after a configurable timeout or the user supplies more input.

Resolves #111 