### PR TITLE
Add support for using Ctrl/Alt/Meta with non-character keys

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,68 +1,101 @@
-
 #[derive(Debug, Clone, PartialEq, Copy)]
-pub enum KeyPress {
-    UnknownEscSeq,
+pub enum Key {
     Backspace,
     Char(char),
-    Ctrl(char),
     Delete,
     Down,
     End,
     Enter, // Ctrl('M')
     Esc,
     Home,
+    Insert,
     Left,
-    Meta(char),
     Null,
     PageDown,
     PageUp,
     Right,
     Tab, // Ctrl('I')
+    Unknown,
     Up,
+}
+
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub struct KeyPress {
+    pub key: Key,
+    pub alt: bool,
+    pub ctrl: bool,
+    pub shift: bool,
+    pub sup: bool,
+}
+
+macro_rules! key {
+    ($key:tt) => (key!(Key::Char($key)));
+    ($($key:tt)*) => (KeyPress { key: $($key)*, alt: false, ctrl: false, shift: false, sup: false });
+}
+
+macro_rules! alt {
+    ($key:tt) => (alt!(Key::Char($key)));
+    ($($key:tt)*) => (KeyPress { key: $($key)*, alt: true, ctrl: false, shift: false, sup: false });
+}
+
+macro_rules! ctrl {
+    ($key:tt) => (ctrl!(Key::Char($key)));
+    ($($key:tt)*) => (KeyPress { key: $($key)*, alt: false, ctrl: true, shift: false, sup: false });
+}
+
+macro_rules! shift {
+    ($key:tt) => (shift!(Key::Char($key)));
+    ($($key:tt)*) => (KeyPress { key: $($key)*, alt: false, ctrl: false, shift: true, sup: false });
+}
+
+macro_rules! sup {
+    ($key:tt) => (sup!(Key::Char($key)));
+    ($($key:tt)*) => (KeyPress { key: $($key)*, alt: false, ctrl: false, shift: false, sup: true });
 }
 
 #[allow(match_same_arms)]
 pub fn char_to_key_press(c: char) -> KeyPress {
     if !c.is_control() {
-        return KeyPress::Char(c);
+        return key!(c);
     }
+
     match c {
-        '\x00' => KeyPress::Null,
-        '\x01' => KeyPress::Ctrl('A'),
-        '\x02' => KeyPress::Ctrl('B'),
-        '\x03' => KeyPress::Ctrl('C'),
-        '\x04' => KeyPress::Ctrl('D'),
-        '\x05' => KeyPress::Ctrl('E'),
-        '\x06' => KeyPress::Ctrl('F'),
-        '\x07' => KeyPress::Ctrl('G'),
-        '\x08' => KeyPress::Backspace, // '\b'
-        '\x09' => KeyPress::Tab,
-        '\x0a' => KeyPress::Ctrl('J'), // '\n' (10)
-        '\x0b' => KeyPress::Ctrl('K'),
-        '\x0c' => KeyPress::Ctrl('L'),
-        '\x0d' => KeyPress::Enter, // '\r' (13)
-        '\x0e' => KeyPress::Ctrl('N'),
-        '\x10' => KeyPress::Ctrl('P'),
-        '\x12' => KeyPress::Ctrl('R'),
-        '\x13' => KeyPress::Ctrl('S'),
-        '\x14' => KeyPress::Ctrl('T'),
-        '\x15' => KeyPress::Ctrl('U'),
-        '\x16' => KeyPress::Ctrl('V'),
-        '\x17' => KeyPress::Ctrl('W'),
-        '\x19' => KeyPress::Ctrl('Y'),
-        '\x1a' => KeyPress::Ctrl('Z'),
-        '\x1b' => KeyPress::Esc,
-        '\x7f' => KeyPress::Backspace, // TODO Validate
-        _ => KeyPress::Null,
+        '\x00' => key!(Key::Null),
+        '\x01' => ctrl!('A'),
+        '\x02' => ctrl!('B'),
+        '\x03' => ctrl!('C'),
+        '\x04' => ctrl!('D'),
+        '\x05' => ctrl!('E'),
+        '\x06' => ctrl!('F'),
+        '\x07' => ctrl!('G'),
+        '\x08' => key!(Key::Backspace), // '\b'
+        '\x09' => key!(Key::Tab),
+        '\x0a' => ctrl!('J'), // '\n' (10)
+        '\x0b' => ctrl!('K'),
+        '\x0c' => ctrl!('L'),
+        '\x0d' => key!(Key::Enter), // '\r' (13)
+        '\x0e' => ctrl!('N'),
+        '\x10' => ctrl!('P'),
+        '\x12' => ctrl!('R'),
+        '\x13' => ctrl!('S'),
+        '\x14' => ctrl!('T'),
+        '\x15' => ctrl!('U'),
+        '\x16' => ctrl!('V'),
+        '\x17' => ctrl!('W'),
+        '\x19' => ctrl!('Y'),
+        '\x1a' => ctrl!('Z'),
+        '\x1b' => key!(Key::Esc),
+        '\x7f' => key!(Key::Backspace), // TODO Validate
+        _ => key!(Key::Null),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{char_to_key_press, KeyPress};
+    use super::{char_to_key_press, Key, KeyPress};
 
     #[test]
     fn char_to_key() {
-        assert_eq!(KeyPress::Esc, char_to_key_press('\x1b'));
+        assert_eq!(key!(Key::Esc), char_to_key_press('\x1b'));
     }
 }

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -7,7 +7,7 @@ use std::sync::atomic;
 use kernel32;
 use winapi;
 
-use consts::{self, KeyPress};
+use consts::{self, Key, KeyPress};
 use ::error;
 use ::Result;
 use super::{RawMode, RawReader, Term};
@@ -125,15 +125,15 @@ impl RawReader for ConsoleRawReader {
             let utf16 = key_event.UnicodeChar;
             if utf16 == 0 {
                 match key_event.wVirtualKeyCode as i32 {
-                    winapi::VK_LEFT => return Ok(KeyPress::Left),
-                    winapi::VK_RIGHT => return Ok(KeyPress::Right),
-                    winapi::VK_UP => return Ok(KeyPress::Up),
-                    winapi::VK_DOWN => return Ok(KeyPress::Down),
-                    winapi::VK_DELETE => return Ok(KeyPress::Delete),
-                    winapi::VK_HOME => return Ok(KeyPress::Home),
-                    winapi::VK_END => return Ok(KeyPress::End),
-                    winapi::VK_PRIOR => return Ok(KeyPress::PageUp),
-                    winapi::VK_NEXT => return Ok(KeyPress::PageDown),
+                    winapi::VK_LEFT => return Ok(key!(Key::Left)),
+                    winapi::VK_RIGHT => return Ok(key!(Key::Right)),
+                    winapi::VK_UP => return Ok(key!(Key::Up)),
+                    winapi::VK_DOWN => return Ok(key!(Key::Down)),
+                    winapi::VK_DELETE => return Ok(key!(Key::Delete)),
+                    winapi::VK_HOME => return Ok(key!(Key::Home)),
+                    winapi::VK_END => return Ok(key!(Key::End)),
+                    winapi::VK_PRIOR => return Ok(key!(Key::PageUp)),
+                    winapi::VK_NEXT => return Ok(key!(Key::PageDown)),
                     _ => continue,
                 };
             } else if utf16 == 27 {
@@ -149,15 +149,15 @@ impl RawReader for ConsoleRawReader {
                 let c = try!(orc.unwrap());
                 if meta {
                     match c {
-                        'b' | 'B' => return Ok(KeyPress::Meta('B')),
-                        'c' | 'C' => return Ok(KeyPress::Meta('C')),
-                        'd' | 'D' => return Ok(KeyPress::Meta('D')),
-                        'f' | 'F' => return Ok(KeyPress::Meta('F')),
-                        'l' | 'L' => return Ok(KeyPress::Meta('L')),
-                        't' | 'T' => return Ok(KeyPress::Meta('T')),
-                        'u' | 'U' => return Ok(KeyPress::Meta('U')),
-                        'y' | 'Y' => return Ok(KeyPress::Meta('Y')),
-                        _ => return Ok(KeyPress::UnknownEscSeq),
+                        'b' | 'B' => return Ok(alt!(Key::Char('B')) ),
+                        'c' | 'C' => return Ok(alt!(Key::Char('C')) ),
+                        'd' | 'D' => return Ok(alt!(Key::Char('D')) ),
+                        'f' | 'F' => return Ok(alt!(Key::Char('F')) ),
+                        'l' | 'L' => return Ok(alt!(Key::Char('L')) ),
+                        't' | 'T' => return Ok(alt!(Key::Char('T')) ),
+                        'u' | 'U' => return Ok(alt!(Key::Char('U')) ),
+                        'y' | 'Y' => return Ok(alt!(Key::Char('Y')) ),
+                        _ => return Ok(key!(Key::Unknown)),
                     }
                 } else {
                     return Ok(consts::char_to_key_press(c));


### PR DESCRIPTION
Currently, key modifiers can only be used in conjunction with keys which map to a printable character. This pull request is a refactor that allows key modifiers to be used with any key, such as arrow keys, tab, etc.