### PR TITLE
Force push master documentation to gh-pages

### DIFF
--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -17,4 +17,4 @@ touch .
 
 git add -A .
 git commit -m "rebuild pages at ${rev}"
-git push -q upstream HEAD:gh-pages > /dev/null 2>&1
+git push -f -q upstream HEAD:gh-pages > /dev/null 2>&1


### PR DESCRIPTION
~~We don't really need the master docs deployed to the gh-pages branch and it is causing bloat in the repo.~~
Force push to gh-pages when deploying master branch documentation.

Fixes #112 