### PR TITLE
Use into() instead of casting to c_ulong because of different types in some targets

### DIFF
--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -33,7 +33,8 @@ fn get_win_size() -> (usize, usize) {
     unsafe {
         let mut size: libc::winsize = zeroed();
         // https://github.com/rust-lang/libc/pull/704
-        match libc::ioctl(STDOUT_FILENO, libc::TIOCGWINSZ as libc::c_ulong, &mut size) {
+        // FIXME: ".into()" used as a temporary fix for a libc bug
+        match libc::ioctl(STDOUT_FILENO, libc::TIOCGWINSZ.into(), &mut size) {
             0 => (size.ws_col as usize, size.ws_row as usize), // TODO getCursorPosition
             _ => (80, 24),
         }


### PR DESCRIPTION
For example, in `x86_64-unknown-linux-musl`, `ioctl` takes `c_int`. It is better to use `into()` to work around this issue than using `as c_ulong`.

https://rust-lang.github.io/libc/x86_64-unknown-linux-musl/libc/fn.ioctl.html
```
pub unsafe extern "C" fn ioctl(fd: c_int, request: c_int, ...) -> c_int
```