### PR TITLE
Allow customization of the output stream

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -5,6 +5,7 @@ use log::{Level, LevelFilter, Metadata, Record, SetLoggerError};
 use std::borrow::Cow::{self, Borrowed, Owned};
 
 use rustyline::completion::{Completer, FilenameCompleter, Pair};
+use rustyline::config::OutputStreamType;
 use rustyline::error::ReadlineError;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
@@ -56,6 +57,7 @@ fn main() {
         .history_ignore_space(true)
         .completion_type(CompletionType::List)
         .edit_mode(EditMode::Emacs)
+        .output_stream(OutputStreamType::Stdout)
         .build();
     let h = MyHelper(FilenameCompleter::new());
     let mut rl = Editor::with_config(config);

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,8 @@ pub struct Config {
     auto_add_history: bool,
     /// if colors should be enabled.
     color_mode: ColorMode,
+    /// Whether to use stdout or stderr
+    output_stream: OutputStreamType,
 }
 
 impl Config {
@@ -99,6 +101,14 @@ impl Config {
     pub(crate) fn set_color_mode(&mut self, color_mode: ColorMode) {
         self.color_mode = color_mode;
     }
+
+    pub fn output_stream(&self) -> OutputStreamType {
+        self.output_stream
+    }
+
+    pub(crate) fn set_output_stream(&mut self, stream: OutputStreamType) {
+        self.output_stream = stream;
+    }
 }
 
 impl Default for Config {
@@ -113,6 +123,7 @@ impl Default for Config {
             edit_mode: EditMode::Emacs,
             auto_add_history: false,
             color_mode: ColorMode::Enabled,
+            output_stream: OutputStreamType::Stdout,
         }
     }
 }
@@ -147,6 +158,13 @@ pub enum ColorMode {
     Enabled,
     Forced,
     Disabled,
+}
+
+/// Should the editor use stdout or stderr
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputStreamType {
+    Stderr,
+    Stdout,
 }
 
 /// Configuration builder
@@ -231,6 +249,14 @@ impl Builder {
         self
     }
 
+    /// Whether to use stdout or stderr.
+    ///
+    /// Be default, use stdout
+    pub fn output_stream(mut self, stream: OutputStreamType) -> Builder {
+        self.set_output_stream(stream);
+        self
+    }
+
     pub fn build(self) -> Config {
         self.p
     }
@@ -302,5 +328,12 @@ pub trait Configurer {
     /// By default, colorization is on except if stdout is not a tty.
     fn set_color_mode(&mut self, color_mode: ColorMode) {
         self.config_mut().set_color_mode(color_mode);
+    }
+
+    /// Whether to use stdout or stderr
+    ///
+    /// By default, use stdout
+    fn set_output_stream(&mut self, stream: OutputStreamType) {
+        self.config_mut().set_output_stream(stream);
     }
 }

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-use config::{ColorMode, Config};
+use config::{ColorMode, Config, OutputStreamType};
 use highlight::Highlighter;
 use keys::KeyPress;
 use line_buffer::LineBuffer;
@@ -139,7 +139,7 @@ pub trait Term {
     type Writer: Renderer; // rl_outstream
     type Mode: RawMode;
 
-    fn new(color_mode: ColorMode) -> Self;
+    fn new(color_mode: ColorMode, stream: OutputStreamType) -> Self;
     /// Check if current terminal can provide a rich line-editing user
     /// interface.
     fn is_unsupported(&self) -> bool;

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -4,7 +4,7 @@ use std::slice::Iter;
 use std::vec::IntoIter;
 
 use super::{truncate, Position, RawMode, RawReader, Renderer, Term};
-use config::{ColorMode, Config};
+use config::{ColorMode, Config, OutputStreamType};
 use error::ReadlineError;
 use highlight::Highlighter;
 use keys::KeyPress;
@@ -129,7 +129,7 @@ impl Term for DummyTerminal {
     type Reader = IntoIter<KeyPress>;
     type Writer = Sink;
 
-    fn new(color_mode: ColorMode) -> DummyTerminal {
+    fn new(color_mode: ColorMode, _stream: OutputStreamType) -> DummyTerminal {
         DummyTerminal {
             keys: Vec::new(),
             cursor: 0,


### PR DESCRIPTION
This allows the use of stderr instead of stdout (stdout remains the default, though).