### PR TITLE
Fix spelling in documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Katsu Kawakami & rustyline authors
+Copyright (c) 2015 Katsu Kawakami & Rustyline authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Readline implementation in Rust that is based on [Antirez' Linenoise](https://gi
 
 **Note**:
 * Powershell ISE is not supported, check [issue #56](https://github.com/kkawakam/rustyline/issues/56)
-* Mintty (Cygwin/Mingw) is not supported
+* Mintty (Cygwin/MinGW) is not supported
 
 ## Example
 ```rust
@@ -54,7 +54,7 @@ fn main() {
     rl.save_history("history.txt").unwrap();
 }
 ```
-                          
+
 ## crates.io
 You can use this package in your project by adding the following
 to your `Cargo.toml`:
@@ -92,10 +92,10 @@ Ctrl-J, Ctrl-M, Enter | Finish the line entry
 Ctrl-R       | Reverse Search history (Ctrl-S forward, Ctrl-G cancel)
 Ctrl-T       | Transpose previous character with current character
 Ctrl-U       | Delete from start of line to cursor
-Ctrl-V       | Insert any special character without perfoming its associated action (#65)
+Ctrl-V       | Insert any special character without performing its associated action (#65)
 Ctrl-W       | Delete word leading up to cursor (using white space as a word boundary)
 Ctrl-Y       | Paste from Yank buffer
-Ctrl-Z       | Suspend (unix only)
+Ctrl-Z       | Suspend (Unix only)
 Ctrl-_       | Undo
 
 ### Emacs mode (default mode)
@@ -106,7 +106,7 @@ Ctrl-A, Home | Move cursor to the beginning of line
 Ctrl-B, Left | Move cursor one character left
 Ctrl-E, End  | Move cursor to end of line
 Ctrl-F, Right| Move cursor one character right
-Ctrl-H, BackSpace | Delete character before cursor
+Ctrl-H, Backspace | Delete character before cursor
 Ctrl-I, Tab  | Next completion
 Ctrl-K       | Delete from cursor to end of line
 Ctrl-L       | Clear screen
@@ -124,12 +124,12 @@ Meta-L       | Lower-case the next word
 Meta-T       | Transpose words
 Meta-U       | Upper-case the next word
 Meta-Y       | See Ctrl-Y
-Meta-BackSpace | Kill from the start of the current word, or, if between words, to the start of the previous word
+Meta-Backspace | Kill from the start of the current word, or, if between words, to the start of the previous word
 Meta-0, 1, ..., - | Specify the digit to the argument. `–` starts a negative argument.
 
 [Readline Emacs Editing Mode Cheat Sheet](http://www.catonmat.net/download/readline-emacs-editing-mode-cheat-sheet.pdf)
 
-### Vi command mode
+### vi command mode
 
 Keystroke    | Action
 ---------    | ------
@@ -149,9 +149,9 @@ d<movement>  | Delete text of a movement command
 D, Ctrl-K    | Delete to the end of the line
 e            | Move to the end of the current word
 E            | Move to the end of the current non-blank word
-f<char>      | Move right to the next occurance of `char`
-F<char>      | Move left to the previous occurance of `char`
-h, Ctrl-H, BackSpace | Move one character left
+f<char>      | Move right to the next occurrence of `char`
+F<char>      | Move left to the previous occurrence of `char`
+h, Ctrl-H, Backspace | Move one character left
 l, Space     | Move one character right
 Ctrl-L       | Clear screen
 i            | Insert before cursor
@@ -163,8 +163,8 @@ P            | Insert the yanked text before the cursor
 r            | Replaces a single character under the cursor (without leaving command mode)
 s            | Delete a single character under the cursor and enter input mode
 S            | Change current line (equivalent to 0c$)
-t<char>      | Move right to the next occurance of `char`, then one char backward
-T<char>      | Move left to the previous occurance of `char`, then one char forward
+t<char>      | Move right to the next occurrence of `char`, then one char backward
+T<char>      | Move left to the previous occurrence of `char`, then one char forward
 u            | Undo
 w            | Move one word or token right
 W            | Move one non-blank word right
@@ -172,15 +172,15 @@ x            | Delete a single character under the cursor
 X            | Delete a character before the cursor
 y<movement>  | Yank a movement into buffer (copy)
 
-### Vi insert mode
+### vi insert mode
 
 Keystroke    | Action
 ---------    | ------
-Ctrl-H, BackSpace | Delete character before cursor
+Ctrl-H, Backspace | Delete character before cursor
 Ctrl-I, Tab  | Next completion
 Esc          | Switch to command mode
 
-[Readline VI Editing Mode Cheat Sheet](http://www.catonmat.net/download/bash-vi-editing-mode-cheat-sheet.pdf)
+[Readline vi Editing Mode Cheat Sheet](http://www.catonmat.net/download/bash-vi-editing-mode-cheat-sheet.pdf)
 
 [Terminal codes (ANSI/VT100)](http://wiki.bash-hackers.org/scripting/terminalcodes)
 
@@ -207,24 +207,23 @@ $ bind -p
 
 Library            | Lang    | OS     | Term  | Unicode | History       | Completion | Keymap        | Kill Ring | Undo | Colors     | Hint/Auto suggest |
 --------           | ----    | --     | ----  | ------- | -------       | ---------- | -------       | --------- | ---- | ------     | ----------------- |
-[Go-prompt][]      | Go      | Ux/win | ANSI  | Yes     | Yes           | any        | Emacs/prog    | No        | No   | Yes   | Yes               |
-[Haskeline][]      | Haskell | Ux/Win | Any   | Yes     | Yes           | any        | Emacs/Vi/conf | Yes       | Yes  | ?          | ?                 |
-[Linenoise][]      | C       | Ux     | ANSI  | No      | Yes           | only line  | Emacs         | No        | No   | Ux         | Yes               |
-[Linenoise-ng][]   | C       | Ux/Win | ANSI  | Yes     | Yes           | only line  | Emacs         | Yes       | No   | ?          | ?                 |
-[Linefeed][]       | Rust    | Ux/Win | Any   |         | Yes           | any        | Emacs/conf    | Yes       | No   | ?          | No                |
-[Liner][]          | Rust    | Ux     | ANSI  |         | No inc search | only word  | Emacs/Vi/prog | No        | Yes  | Ux         | History based     |
-[Prompt-toolkit][] | Python  | Ux/Win | ANSI  | Yes     | Yes           | any        | Emacs/Vi/conf | Yes       | Yes  | Ux/Win     | Yes               |
-[Rb-readline][]    | Ruby    | Ux/Win | ANSI  | Yes     | Yes           | only word  | Emacs/Vi/conf | Yes       | Yes  | ?          | No                |
-[Replxx][]         | C/C++   | Ux/Win | ANSI  | Yes     | Yes           | only line  | Emacs         | Yes       | No   | Ux/Win     | Yes               |
-Rustyline          | Rust    | Ux/Win | ANSI  | Yes     | Yes           | any        | Emacs/Vi/bind | Yes       | Yes  | Ux/Win 10+ | Yes               |
+[go-prompt][]      | Go      | Ux/win | ANSI  | Yes     | Yes           | any        | Emacs/prog    | No        | No   | Yes   | Yes               |
+[Haskeline][]      | Haskell | Ux/Win | Any   | Yes     | Yes           | any        | Emacs/vi/conf | Yes       | Yes  | ?          | ?                 |
+[linefeed][]       | Rust    | Ux/Win | Any   |         | Yes           | any        | Emacs/conf    | Yes       | No   | ?          | No                |
+[linenoise][]      | C       | Ux     | ANSI  | No      | Yes           | only line  | Emacs         | No        | No   | Ux         | Yes               |
+[linenoise-ng][]   | C       | Ux/Win | ANSI  | Yes     | Yes           | only line  | Emacs         | Yes       | No   | ?          | ?                 |
+[Liner][]          | Rust    | Ux     | ANSI  |         | No inc search | only word  | Emacs/vi/prog | No        | Yes  | Ux         | History based     |
+[prompt_toolkit][] | Python  | Ux/Win | ANSI  | Yes     | Yes           | any        | Emacs/vi/conf | Yes       | Yes  | Ux/Win     | Yes               |
+[rb-readline][]    | Ruby    | Ux/Win | ANSI  | Yes     | Yes           | only word  | Emacs/vi/conf | Yes       | Yes  | ?          | No                |
+[replxx][]         | C/C++   | Ux/Win | ANSI  | Yes     | Yes           | only line  | Emacs         | Yes       | No   | Ux/Win     | Yes               |
+Rustyline          | Rust    | Ux/Win | ANSI  | Yes     | Yes           | any        | Emacs/vi/bind | Yes       | Yes  | Ux/Win 10+ | Yes               |
 
-[Go-prompt]: https://github.com/c-bata/go-prompt
+[go-prompt]: https://github.com/c-bata/go-prompt
 [Haskeline]: https://github.com/judah/haskeline
-[Linefeed]: https://github.com/murarth/linefeed
-[Linenoise]: https://github.com/antirez/linenoise
-[Linenoise-ng]: https://github.com/arangodb/linenoise-ng
+[linefeed]: https://github.com/murarth/linefeed
+[linenoise]: https://github.com/antirez/linenoise
+[linenoise-ng]: https://github.com/arangodb/linenoise-ng
 [Liner]: https://github.com/redox-os/liner
-[Prompt-toolkit]: https://github.com/jonathanslenders/python-prompt-toolkit
-[Rb-readline]: https://github.com/ConnorAtherton/rb-readline
-[Replxx]: https://github.com/AmokHuginnsson/replxx
-
+[prompt_toolkit]: https://github.com/jonathanslenders/python-prompt-toolkit
+[rb-readline]: https://github.com/ConnorAtherton/rb-readline
+[replxx]: https://github.com/AmokHuginnsson/replxx

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@ Config
 
 Cursor
 - [ ] insert versus overwrite versus command mode
-- [ ] In Vi command mode, prevent user from going to end of line. (#94)
+- [ ] In vi command mode, prevent user from going to end of line. (#94)
 
 Grapheme
 - [ ] grapheme & input auto-wrap are buggy
@@ -83,6 +83,6 @@ Unix
 - [ ] async stdin (https://github.com/Rufflewind/tokio-file-unix)
 
 Windows
-- [ ] is_atty is not working with cygwin/msys (https://github.com/softprops/atty works but then how to make `enable_raw_mode` works ?)
+- [ ] is_atty is not working with Cygwin/MSYS (https://github.com/softprops/atty works but then how to make `enable_raw_mode` works ?)
 - [X] UTF-16 surrogate pair
-- [ ] handle ansi escape code (https://docs.rs/console/0.6.1/console/fn.strip_ansi_codes.html ? https://github.com/mattn/go-colorable/blob/master/colorable_windows.go)
+- [ ] handle ANSI escape code (https://docs.rs/console/0.6.1/console/fn.strip_ansi_codes.html ? https://github.com/mattn/go-colorable/blob/master/colorable_windows.go)

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -7,7 +7,7 @@ use super::Result;
 use line_buffer::LineBuffer;
 use memchr::memchr;
 
-// TODO: let the implementers choose/find word boudaries ???
+// TODO: let the implementers choose/find word boundaries ???
 // (line, pos) is like (rl_line_buffer, rl_point) to make contextual completion
 // ("select t.na| from tbl as t")
 // TODO: make &self &mut self ???

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,7 +93,7 @@ impl Config {
 
     /// Tell if colors should be enabled.
     ///
-    /// By default, they are except if stdout is not a tty.
+    /// By default, they are except if stdout is not a TTY.
     pub fn color_mode(&self) -> ColorMode {
         self.color_mode
     }
@@ -243,7 +243,7 @@ impl Builder {
 
     /// Forces colorization on or off.
     ///
-    /// By default, colorization is on except if stdout is not a tty.
+    /// By default, colorization is on except if stdout is not a TTY.
     pub fn color_mode(mut self, color_mode: ColorMode) -> Builder {
         self.set_color_mode(color_mode);
         self
@@ -325,7 +325,7 @@ pub trait Configurer {
 
     /// Forces colorization on or off.
     ///
-    /// By default, colorization is on except if stdout is not a tty.
+    /// By default, colorization is on except if stdout is not a TTY.
     fn set_color_mode(&mut self, color_mode: ColorMode) {
         self.config_mut().set_color_mode(color_mode);
     }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -5,8 +5,8 @@ use memchr::memchr;
 use std::borrow::Cow::{self, Borrowed, Owned};
 use std::cell::Cell;
 
-/// Syntax highlighter with [ansi color](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters).
-/// Rustyline will try to handle escape sequence for ansi color on windows
+/// Syntax highlighter with [ANSI color](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters).
+/// Rustyline will try to handle escape sequence for ANSI color on windows
 /// when not supported natively (windows <10).
 ///
 /// Currently, the highlighted version *must* have the same display width as
@@ -31,7 +31,7 @@ pub trait Highlighter {
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
         Borrowed(hint)
     }
-    /// Takes the completion `canditate` and
+    /// Takes the completion `candidate` and
     /// returns the highlighted version (with ANSI color).
     ///
     /// Currently, used only with `CompletionType::List`.
@@ -76,7 +76,7 @@ impl Highlighter for MatchingBracketHighlighter {
         if line.len() <= 1 {
             return Borrowed(line);
         }
-        // highlight matching brace/bracket/parenthese if it exists
+        // highlight matching brace/bracket/parenthesis if it exists
         if let Some((bracket, pos)) = self.bracket.get() {
             if let Some((matching, idx)) = find_matching_bracket(line, pos, bracket) {
                 let mut copy = line.to_owned();
@@ -88,7 +88,7 @@ impl Highlighter for MatchingBracketHighlighter {
     }
 
     fn highlight_char<'l>(&self, line: &'l str, pos: usize) -> bool {
-        // will highlight matching brace/bracket/parenthese if it exists
+        // will highlight matching brace/bracket/parenthesis if it exists
         self.bracket.set(check_bracket(line, pos));
         self.bracket.get().is_some()
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -274,7 +274,7 @@ enum InputMode {
     Replace,
 }
 
-/// Tranform key(s) to commands based on current input mode
+/// Transform key(s) to commands based on current input mode
 pub struct InputState {
     mode: EditMode,
     custom_bindings: Arc<RwLock<HashMap<KeyPress, Cmd>>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ fn reverse_incremental_search<R: RawReader>(
     Ok(Some(cmd))
 }
 
-/// Handles reading and editting the readline buffer.
+/// Handles reading and editing the readline buffer.
 /// It will also handle special inputs in an appropriate fashion
 /// (e.g., C-c will exit readline)
 fn readline_edit<H: Helper>(

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -377,7 +377,7 @@ impl RawReader for PosixRawReader {
 }
 
 impl Receiver for Utf8 {
-    /// Called whenever a codepoint is parsed successfully
+    /// Called whenever a code point is parsed successfully
     fn codepoint(&mut self, c: char) {
         self.c = Some(c);
         self.valid = true;
@@ -538,7 +538,7 @@ impl Renderer for PosixRenderer {
     }
 
     /// Control characters are treated as having zero width.
-    /// Characters with 2 column width are correctly handled (not splitted).
+    /// Characters with 2 column width are correctly handled (not split).
     fn calculate_position(&self, s: &str, orig: Position) -> Position {
         let mut pos = orig;
         let mut esc_seq = 0;
@@ -679,7 +679,7 @@ impl Term for PosixTerminal {
             | InputFlags::INPCK
             | InputFlags::ISTRIP
             | InputFlags::IXON);
-        // we don't want raw output, it turns newlines into straight linefeeds
+        // we don't want raw output, it turns newlines into straight line feeds
         // disable all output processing
         // raw.c_oflag = raw.c_oflag & !(OutputFlags::OPOST);
 

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -368,7 +368,7 @@ impl Renderer for ConsoleRenderer {
         Ok(())
     }
 
-    /// Characters with 2 column width are correctly handled (not splitted).
+    /// Characters with 2 column width are correctly handled (not split).
     fn calculate_position(&self, s: &str, orig: Position) -> Position {
         let mut pos = orig;
         for c in s.chars() {

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -127,7 +127,7 @@ impl Changeset {
         while self.undo_group_level > 0 {
             self.undo_group_level -= 1;
             if let Some(&Change::Begin) = self.undos.last() {
-                // emtpy Begin..End
+                // empty Begin..End
                 self.undos.pop();
             } else {
                 self.undos.push(Change::End);


### PR DESCRIPTION
I noticed some misspelled words in doc comments, so I ran `aspell` on the whole code base.

There are some more minor things that would be nice, like capitalizing "Unix" throughout, but I left these alone because it would be an annoying diff.

The README is a little cleaner now. Project names in the comparison table are capitalized according to how their respective authors do it. Just a little respectful gesture. Also, they are sorted alphabetically.