### PR TITLE
Fix bug in `HistoryHinter` when `ctx.history_index()` is 0

### DIFF
--- a/src/hint.rs
+++ b/src/hint.rs
@@ -23,7 +23,7 @@ pub struct HistoryHinter {}
 impl Hinter for HistoryHinter {
     fn hint(&self, line: &str, pos: usize, ctx: &Context) -> Option<String> {
         let start = if ctx.history_index() == ctx.history().len() {
-            ctx.history_index() - 1
+            ctx.history_index().saturating_sub(1)
         } else {
             ctx.history_index()
         };


### PR DESCRIPTION
Running the example without a `history.txt` file on the current master lead to the following error: 
```
thread 'main' panicked at 'attempt to subtract with overflow', src\hint.rs:26:13 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace. error: process didn't exit successfully: `target\debug\examples\example.exe` (exit code: 101)
```