### PR TITLE
feature toggle dirs to legacy support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "kkawakam/rustyline" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-dirs = "1.0"
+dirs = { version = "1.0", optional = true }
 libc = "0.2"
 log = "0.4"
 unicode-width = "0.1"
@@ -35,3 +35,7 @@ winapi = { version = "0.3", features = ["consoleapi", "handleapi", "minwindef", 
 env_logger = "0.6"
 tempdir = "0.3"
 assert_matches = "1.2"
+
+[features]
+default = ["with-dirs"]
+with-dirs = ["dirs"]

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -282,10 +282,8 @@ fn filename_complete(
     break_chars: &[u8],
     quote: Quote,
 ) -> Result<Vec<Pair>> {
-    #[cfg(feature = "dirs")]
-    {
-        use dirs::home_dir;
-    }
+    #[cfg(feature = "with-dirs")]
+    use dirs::home_dir;
     use std::env::current_dir;
 
     let sep = path::MAIN_SEPARATOR;
@@ -308,7 +306,7 @@ fn filename_complete(
                 dir_path.to_path_buf()
             }
         }
-        #[cfg(not(feature = "dir"))]
+        #[cfg(not(feature = "with-dirs"))]
         {
             dir_path.to_path_buf()
         }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -282,7 +282,10 @@ fn filename_complete(
     break_chars: &[u8],
     quote: Quote,
 ) -> Result<Vec<Pair>> {
-    use dirs::home_dir;
+    #[cfg(feature = "dirs")]
+    {
+        use dirs::home_dir;
+    }
     use std::env::current_dir;
 
     let sep = path::MAIN_SEPARATOR;
@@ -294,12 +297,19 @@ fn filename_complete(
     let dir_path = Path::new(dir_name);
     let dir = if dir_path.starts_with("~") {
         // ~[/...]
-        if let Some(home) = home_dir() {
-            match dir_path.strip_prefix("~") {
-                Ok(rel_path) => home.join(rel_path),
-                _ => home,
+        #[cfg(feature = "with-dirs")]
+        {
+            if let Some(home) = home_dir() {
+                match dir_path.strip_prefix("~") {
+                    Ok(rel_path) => home.join(rel_path),
+                    _ => home,
+                }
+            } else {
+                dir_path.to_path_buf()
             }
-        } else {
+        }
+        #[cfg(not(feature = "dir"))]
+        {
             dir_path.to_path_buf()
         }
     } else if dir_path.is_relative() {


### PR DESCRIPTION
added a quick feature toggle for the [dirs](https://github.com/soc/dirs-rs) dependency. dirs is not legacy os (xp, server 2003, etc) compatible so it breaks any executable run on those platforms. the only feature `rustyline` loses is home directory completion, which i feel is a fine trade off.