### PR TITLE
Update nix dependency to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ unicode-segmentation = "1.0"
 memchr = "2.0"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.12"
+nix = "0.13"
 utf8parse = "0.1"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
This is a semver breaking change, because the nix::Error type is exposed in the publicly exposed rustyline::ReadlineError enum.