### PR TITLE
Editor::dimensions returns terminal size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,6 +840,17 @@ impl<H: Helper> Editor<H> {
         let mut kill_ring = self.kill_ring.lock().unwrap();
         kill_ring.reset();
     }
+
+    /// If output stream is a tty, this function returns its width and height as
+    /// a number of characters.
+    pub fn dimensions(&mut self) -> Option<(usize, usize)> {
+        if self.term.is_output_tty() {
+            let out = self.term.create_writer();
+            Some((out.get_columns(), out.get_rows()))
+        } else {
+            None
+        }
+    }
 }
 
 impl<H: Helper> config::Configurer for Editor<H> {

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -154,6 +154,8 @@ pub trait Term {
     fn is_unsupported(&self) -> bool;
     /// check if stdin is connected to a terminal.
     fn is_stdin_tty(&self) -> bool;
+    /// check if output stream is connected to a terminal.
+    fn is_output_tty(&self) -> bool;
     /// Enable RAW mode for the terminal.
     fn enable_raw_mode(&mut self) -> Result<Self::Mode>;
     /// Create a RAW reader

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -159,6 +159,10 @@ impl Term for DummyTerminal {
         true
     }
 
+    fn is_output_tty(&self) -> bool {
+        false
+    }
+
     // Interactive loop:
 
     fn enable_raw_mode(&mut self) -> Result<Mode> {

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -717,6 +717,10 @@ impl Term for PosixTerminal {
         self.stdin_isatty
     }
 
+    fn is_output_tty(&self) -> bool {
+        self.stdstream_isatty
+    }
+
     // Interactive loop:
 
     fn enable_raw_mode(&mut self) -> Result<Self::Mode> {

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -513,6 +513,10 @@ impl Term for Console {
         self.stdin_isatty
     }
 
+    fn is_output_tty(&self) -> bool {
+        self.stdstream_isatty
+    }
+
     // pub fn install_sigwinch_handler(&mut self) {
     // See ReadConsoleInputW && WINDOW_BUFFER_SIZE_EVENT
     // }


### PR DESCRIPTION
Fix #204 