### PR TITLE
Fix Windows width calculation

### DIFF
--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -3,12 +3,11 @@ use std::io::{self, Write};
 use std::mem;
 use std::sync::atomic;
 
-use unicode_width::UnicodeWidthChar;
 use winapi::shared::minwindef::{DWORD, WORD};
 use winapi::um::winnt::{CHAR, HANDLE};
 use winapi::um::{consoleapi, handleapi, processenv, winbase, wincon, winuser};
 
-use super::{truncate, Position, RawMode, RawReader, Renderer, Term};
+use super::{truncate, width, Position, RawMode, RawReader, Renderer, Term};
 use crate::config::OutputStreamType;
 use crate::config::{ColorMode, Config};
 use crate::error;
@@ -378,13 +377,14 @@ impl Renderer for ConsoleRenderer {
     /// Characters with 2 column width are correctly handled (not split).
     fn calculate_position(&self, s: &str, orig: Position) -> Position {
         let mut pos = orig;
+        let mut esc_seq = 0;
         for c in s.chars() {
             let cw = if c == '\n' {
                 pos.col = 0;
                 pos.row += 1;
                 None
             } else {
-                c.width()
+                Some(width(&format!("{}", c), &mut esc_seq))
             };
             if let Some(cw) = cw {
                 pos.col += cw;
@@ -437,7 +437,7 @@ impl Renderer for ConsoleRenderer {
     }
 }
 
-static SIGWINCH: atomic::AtomicBool = atomic::ATOMIC_BOOL_INIT;
+static SIGWINCH: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
 #[cfg(not(test))]
 pub type Terminal = Console;


### PR DESCRIPTION
This fixes the Windows prompt width calculation by using the same width calculation Unix uses. This code might have originally been in place to work around a Windows shortcoming, but it seems that current versions of Windows calculate width the same way Unix does

Before:

![beforefix](https://user-images.githubusercontent.com/547158/57554534-d7560080-73c5-11e9-8571-a0f9606c57b3.png)

After:

![afterfix](https://user-images.githubusercontent.com/547158/57554541-db821e00-73c5-11e9-912f-a02606a7544c.png)
