### PR TITLE
fix nightly build issues with as_ref()

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -81,7 +81,7 @@ fn main() {
         let readline = rl.readline(PROMPT);
         match readline {
             Ok(line) => {
-                rl.add_history_entry(line.as_ref());
+                rl.add_history_entry(line.clone());
                 println!("Line: {}", line);
             }
             Err(ReadlineError::Interrupted) => {

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -82,8 +82,8 @@ fn main() {
         match readline {
             Ok(line) => {
                 let line: String = line;
-                rl.add_history_entry(&line);
-                println!("Line: {}", line);
+                println!("Line: {}", &line);
+                rl.add_history_entry(line);
             }
             Err(ReadlineError::Interrupted) => {
                 println!("CTRL-C");

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -81,6 +81,7 @@ fn main() {
         let readline = rl.readline(PROMPT);
         match readline {
             Ok(line) => {
+                let line: String = line;
                 rl.add_history_entry(&line);
                 println!("Line: {}", line);
             }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -81,7 +81,7 @@ fn main() {
         let readline = rl.readline(PROMPT);
         match readline {
             Ok(line) => {
-                rl.add_history_entry(line.clone());
+                rl.add_history_entry(&line);
                 println!("Line: {}", line);
             }
             Err(ReadlineError::Interrupted) => {

--- a/src/history.rs
+++ b/src/history.rs
@@ -148,7 +148,7 @@ impl History {
         let file = File::open(&path)?;
         let rdr = BufReader::new(file);
         for line in rdr.lines() {
-            self.add(line?.as_ref()); // TODO truncate to MAX_LINE
+            self.add(line?.clone()); // TODO truncate to MAX_LINE
         }
         Ok(())
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -148,7 +148,7 @@ impl History {
         let file = File::open(&path)?;
         let rdr = BufReader::new(file);
         for line in rdr.lines() {
-            self.add(line?.clone()); // TODO truncate to MAX_LINE
+            self.add(&line?); // TODO truncate to MAX_LINE
         }
         Ok(())
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -148,7 +148,7 @@ impl History {
         let file = File::open(&path)?;
         let rdr = BufReader::new(file);
         for line in rdr.lines() {
-            self.add(&line?); // TODO truncate to MAX_LINE
+            self.add(line?.as_str()); // TODO truncate to MAX_LINE
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,7 +624,8 @@ fn readline_raw<H: Helper>(
     let user_input = readline_edit(prompt, initial, editor, &original_mode);
     if editor.config.auto_add_history() {
         if let Ok(line) = &user_input {
-            editor.add_history_entry(line.clone());
+            let line: &str = line;
+            editor.add_history_entry(line);
         }
     }
     drop(guard); // disable_raw_mode(original_mode)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -623,8 +623,8 @@ fn readline_raw<H: Helper>(
     let guard = Guard(&original_mode);
     let user_input = readline_edit(prompt, initial, editor, &original_mode);
     if editor.config.auto_add_history() {
-        if let Ok(ref line) = user_input {
-            editor.add_history_entry(line.as_ref());
+        if let Ok(line) = &user_input {
+            editor.add_history_entry(line.clone());
         }
     }
     drop(guard); // disable_raw_mode(original_mode)?;

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -437,7 +437,7 @@ impl Renderer for ConsoleRenderer {
     }
 }
 
-static SIGWINCH: atomic::AtomicBool = atomic::ATOMIC_BOOL_INIT;
+static SIGWINCH: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
 #[cfg(not(test))]
 pub type Terminal = Console;


### PR DESCRIPTION
fixes #217

I spent part of the day trying to see what change to Rust introduced this issue, but came blank. ~I've replaced `string.as_ref()` with a clone, which fixes the issue. If `clone` is a problem, we could resolve this later (though I was able to fix the error in a different way which was a bit longer).~ Found a better fix of passing a `&str`, and annotating it as such where necessary.

cc @gwenn