### PR TITLE
Replace deprecated ATOMIC_BOOL_INIT

### DIFF
--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -437,7 +437,7 @@ impl Renderer for ConsoleRenderer {
     }
 }
 
-static SIGWINCH: atomic::AtomicBool = atomic::ATOMIC_BOOL_INIT;
+static SIGWINCH: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
 #[cfg(not(test))]
 pub type Terminal = Console;


### PR DESCRIPTION
help: use of deprecated item 'std::sync::atomic::ATOMIC_BOOL_INIT': the `new` function is now preferred