### PR TITLE
feat: Allow edit line grow

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -47,16 +47,15 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         helper: Option<&'out H>,
         ctx: Context<'out>,
     ) -> State<'out, 'prompt, H> {
-        let capacity = MAX_LINE;
         let prompt_size = out.calculate_position(prompt, Position::default());
         State {
             out,
             prompt,
             prompt_size,
-            line: LineBuffer::with_capacity(capacity),
+            line: LineBuffer::with_capacity(MAX_LINE),
             cursor: prompt_size,
             old_rows: 0,
-            saved_line_for_history: LineBuffer::with_capacity(capacity),
+            saved_line_for_history: LineBuffer::with_capacity(MAX_LINE),
             byte_buffer: [0; 4],
             changes: Rc::new(RefCell::new(Changeset::new())),
             helper,
@@ -96,13 +95,14 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
 
     pub fn backup(&mut self) {
         self.saved_line_for_history
-            .update(self.line.as_str(), self.line.pos());
+            .update(self.line.as_str(), self.line.pos(), false);
     }
 
     pub fn restore(&mut self) {
         self.line.update(
             self.saved_line_for_history.as_str(),
             self.saved_line_for_history.pos(),
+            true
         );
     }
 
@@ -254,32 +254,28 @@ impl<'out, 'prompt, H: Helper> fmt::Debug for State<'out, 'prompt, H> {
 impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
     /// Insert the character `ch` at cursor current position.
     pub fn edit_insert(&mut self, ch: char, n: RepeatCount) -> Result<()> {
-        if let Some(push) = self.line.insert(ch, n) {
-            if push {
-                let prompt_size = self.prompt_size;
-                let no_previous_hint = self.hint.is_none();
-                self.hint();
-                if n == 1
-                    && self.cursor.col + ch.width().unwrap_or(0) < self.out.get_columns()
-                    && (self.hint.is_none() && no_previous_hint) // TODO refresh only current line
-                    && !self.highlight_char()
-                {
-                    // Avoid a full update of the line in the trivial case.
-                    let cursor = self
-                        .out
-                        .calculate_position(&self.line[..self.line.pos()], self.prompt_size);
-                    self.cursor = cursor;
-                    let bits = ch.encode_utf8(&mut self.byte_buffer);
-                    let bits = bits.as_bytes();
-                    self.out.write_and_flush(bits)
-                } else {
-                    self.refresh(self.prompt, prompt_size, true, Info::Hint)
-                }
+        if self.line.insert(ch, n) {
+            let prompt_size = self.prompt_size;
+            let no_previous_hint = self.hint.is_none();
+            self.hint();
+            if n == 1
+                && self.cursor.col + ch.width().unwrap_or(0) < self.out.get_columns()
+                && (self.hint.is_none() && no_previous_hint) // TODO refresh only current line
+                && !self.highlight_char()
+            {
+                // Avoid a full update of the line in the trivial case.
+                let cursor = self
+                    .out
+                    .calculate_position(&self.line[..self.line.pos()], self.prompt_size);
+                self.cursor = cursor;
+                let bits = ch.encode_utf8(&mut self.byte_buffer);
+                let bits = bits.as_bytes();
+                self.out.write_and_flush(bits)
             } else {
-                self.refresh_line()
+                self.refresh(self.prompt, prompt_size, true, Info::Hint)
             }
         } else {
-            Ok(())
+            self.refresh_line()
         }
     }
 
@@ -493,7 +489,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         if self.ctx.history_index < history.len() {
             let buf = history.get(self.ctx.history_index).unwrap();
             self.changes.borrow_mut().begin();
-            self.line.update(buf, buf.len());
+            self.line.update(buf, buf.len(), true);
             self.changes.borrow_mut().end();
         } else {
             // Restore current edited line
@@ -526,7 +522,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             self.ctx.history_index = history_index;
             let buf = history.get(history_index).unwrap();
             self.changes.borrow_mut().begin();
-            self.line.update(buf, buf.len());
+            self.line.update(buf, buf.len(), true);
             self.changes.borrow_mut().end();
             self.refresh_line()
         } else {
@@ -554,7 +550,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             self.ctx.history_index = 0;
             let buf = history.get(self.ctx.history_index).unwrap();
             self.changes.borrow_mut().begin();
-            self.line.update(buf, buf.len());
+            self.line.update(buf, buf.len(), true);
             self.changes.borrow_mut().end();
         } else {
             self.ctx.history_index = history.len();

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -102,7 +102,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         self.line.update(
             self.saved_line_for_history.as_str(),
             self.saved_line_for_history.pos(),
-            true
+            true,
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ fn complete_line<H: Helper>(
                 s.refresh_line()?;
             } else {
                 // Restore current edited line
-                s.line.update(&backup, backup_pos);
+                s.line.update(&backup, backup_pos, true);
                 s.refresh_line()?;
             }
 
@@ -115,7 +115,7 @@ fn complete_line<H: Helper>(
                 Cmd::Abort => {
                     // Re-show original buffer
                     if i < candidates.len() {
-                        s.line.update(&backup, backup_pos);
+                        s.line.update(&backup, backup_pos, true);
                         s.refresh_line()?;
                     }
                     s.changes.borrow_mut().truncate(mark);
@@ -334,7 +334,7 @@ fn reverse_incremental_search<H: Helper>(
                 }
                 Cmd::Abort => {
                     // Restore current edited line (before search)
-                    s.line.update(&backup, backup_pos);
+                    s.line.update(&backup, backup_pos, true);
                     s.refresh_line()?;
                     s.changes.borrow_mut().truncate(mark);
                     return Ok(None);
@@ -351,7 +351,7 @@ fn reverse_incremental_search<H: Helper>(
                 history_idx = idx;
                 let entry = history.get(idx).unwrap();
                 let pos = entry.find(&search_buf).unwrap();
-                s.line.update(entry, pos);
+                s.line.update(entry, pos, true);
                 true
             }
             _ => false,
@@ -387,7 +387,7 @@ fn readline_edit<H: Helper>(
 
     if let Some((left, right)) = initial {
         s.line
-            .update((left.to_owned() + right).as_ref(), left.len());
+            .update((left.to_owned() + right).as_ref(), left.len(), true);
     }
 
     let mut rdr = editor.term.create_reader(&editor.config)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ fn complete_line<H: Helper>(
                 s.refresh_line()?;
             } else {
                 // Restore current edited line
-                s.line.update(&backup, backup_pos, true);
+                s.line.update(&backup, backup_pos);
                 s.refresh_line()?;
             }
 
@@ -115,7 +115,7 @@ fn complete_line<H: Helper>(
                 Cmd::Abort => {
                     // Re-show original buffer
                     if i < candidates.len() {
-                        s.line.update(&backup, backup_pos, true);
+                        s.line.update(&backup, backup_pos);
                         s.refresh_line()?;
                     }
                     s.changes.borrow_mut().truncate(mark);
@@ -334,7 +334,7 @@ fn reverse_incremental_search<H: Helper>(
                 }
                 Cmd::Abort => {
                     // Restore current edited line (before search)
-                    s.line.update(&backup, backup_pos, true);
+                    s.line.update(&backup, backup_pos);
                     s.refresh_line()?;
                     s.changes.borrow_mut().truncate(mark);
                     return Ok(None);
@@ -351,7 +351,7 @@ fn reverse_incremental_search<H: Helper>(
                 history_idx = idx;
                 let entry = history.get(idx).unwrap();
                 let pos = entry.find(&search_buf).unwrap();
-                s.line.update(entry, pos, true);
+                s.line.update(entry, pos);
                 true
             }
             _ => false,
@@ -387,7 +387,7 @@ fn readline_edit<H: Helper>(
 
     if let Some((left, right)) = initial {
         s.line
-            .update((left.to_owned() + right).as_ref(), left.len(), true);
+            .update((left.to_owned() + right).as_ref(), left.len());
     }
 
     let mut rdr = editor.term.create_reader(&editor.config)?;

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -80,7 +80,7 @@ impl LineBuffer {
     }
 
     /// Set whether to allow dynamic allocation
-    pub fn can_growth(mut self, can_growth: bool) -> Self {
+    pub(crate) fn can_growth(mut self, can_growth: bool) -> Self {
         self.can_growth = can_growth;
         self
     }

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -204,9 +204,9 @@ fn width(s: &str, esc_seq: &mut u8) -> usize {
         0
     } else if *esc_seq == 2 {
         if s == ";" || (s.as_bytes()[0] >= b'0' && s.as_bytes()[0] <= b'9') {
-        /*} else if s == "m" {
+            /*} else if s == "m" {
             // last
-            *esc_seq = 0;*/
+             *esc_seq = 0;*/
         } else {
             // not supported
             *esc_seq = 0;


### PR DESCRIPTION
1. Allow `LineBuffer` growth, but default max capture is 4096
2. ~Disable history line growth, because it may cause memory leak~
3. fmt
4. API compatible

fix #254 

There are some `clippy` wanning errors I have not dealt with, mainly in the style aspect, need to respect the author's opinion.

By the way, I didn't notice the obvious Caton when copying big data now.