### PR TITLE
Fix circular dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ winapi = { version = "0.3", features = ["consoleapi", "handleapi", "minwindef", 
 env_logger = "0.6"
 tempdir = "0.3"
 assert_matches = "1.2"
-rustyline-derive = { version = "0.1.0", path = "rustyline-derive" }
+rustyline-derive = { version = "0.2.0", path = "rustyline-derive" }
 
 [features]
 default = ["with-dirs"]

--- a/rustyline-derive/Cargo.toml
+++ b/rustyline-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustyline-derive"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["gwenn"]
 edition = "2018"
 description = "Rustyline macros implementation of #[derive(Completer, Helper, Hinter, Highlighter)]"
@@ -19,6 +19,5 @@ maintenance = { status = "actively-developed" }
 proc-macro = true
 
 [dependencies]
-rustyline = { version = "5.0", path = ".." }
 syn = "1.0"
 quote = "1.0"


### PR DESCRIPTION
https://stackoverflow.com/questions/54088182/cyclic-package-dependency-while-implementing-proc-macro
> Your derive crate should not depend of anything because it only
handles code generation.