### PR TITLE
Add support for building on unknown targets like wasm32-unknown-unknown

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -139,6 +139,10 @@ const DEFAULT_BREAK_CHARS: [u8; 17] = [
 ];
 #[cfg(windows)]
 const ESCAPE_CHAR: Option<char> = None;
+#[cfg(not(any(windows, unix)))]
+const DEFAULT_BREAK_CHARS: [u8; 0] = [];
+#[cfg(not(any(windows, unix)))]
+const ESCAPE_CHAR: Option<char> = None;
 
 // In double quotes, not all break_chars need to be escaped
 // https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
@@ -146,6 +150,8 @@ const ESCAPE_CHAR: Option<char> = None;
 const DOUBLE_QUOTES_SPECIAL_CHARS: [u8; 4] = [b'"', b'$', b'\\', b'`'];
 #[cfg(windows)]
 const DOUBLE_QUOTES_SPECIAL_CHARS: [u8; 1] = [b'"']; // TODO Validate: only '"' ?
+#[cfg(not(any(windows, unix)))]
+const DOUBLE_QUOTES_SPECIAL_CHARS: [u8; 0] = [];
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Quote {

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -139,9 +139,9 @@ const DEFAULT_BREAK_CHARS: [u8; 17] = [
 ];
 #[cfg(windows)]
 const ESCAPE_CHAR: Option<char> = None;
-#[cfg(not(any(windows, unix)))]
+#[cfg(target_arch = "wasm32")]
 const DEFAULT_BREAK_CHARS: [u8; 0] = [];
-#[cfg(not(any(windows, unix)))]
+#[cfg(target_arch = "wasm32")]
 const ESCAPE_CHAR: Option<char> = None;
 
 // In double quotes, not all break_chars need to be escaped
@@ -150,7 +150,7 @@ const ESCAPE_CHAR: Option<char> = None;
 const DOUBLE_QUOTES_SPECIAL_CHARS: [u8; 4] = [b'"', b'$', b'\\', b'`'];
 #[cfg(windows)]
 const DOUBLE_QUOTES_SPECIAL_CHARS: [u8; 1] = [b'"']; // TODO Validate: only '"' ?
-#[cfg(not(any(windows, unix)))]
+#[cfg(target_arch = "wasm32")]
 const DOUBLE_QUOTES_SPECIAL_CHARS: [u8; 0] = [];
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,7 +162,7 @@ pub enum BellStyle {
 /// `Audible` by default on unix (overriden by current Terminal settings).
 /// `None` on windows.
 impl Default for BellStyle {
-    #[cfg(windows)]
+    #[cfg(any(windows, target_arch = "wasm32"))]
     fn default() -> Self {
         BellStyle::None
     }
@@ -170,11 +170,6 @@ impl Default for BellStyle {
     #[cfg(unix)]
     fn default() -> Self {
         BellStyle::Audible
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    fn default() -> Self {
-        BellStyle::None
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,6 +171,11 @@ impl Default for BellStyle {
     fn default() -> Self {
         BellStyle::Audible
     }
+
+    #[cfg(not(any(unix, windows)))]
+    fn default() -> Self {
+        BellStyle::None
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/history.rs
+++ b/src/history.rs
@@ -253,6 +253,10 @@ fn umask() -> u16 {
 fn umask() -> libc::mode_t {
     unsafe { libc::umask(libc::S_IXUSR | libc::S_IRWXG | libc::S_IRWXO) }
 }
+#[cfg(not(any(windows, unix)))]
+fn umask() -> u16 {
+    0
+}
 #[cfg(windows)]
 fn restore_umask(_: u16) {}
 #[cfg(unix)]
@@ -261,6 +265,8 @@ fn restore_umask(old_umask: libc::mode_t) {
         libc::umask(old_umask);
     }
 }
+#[cfg(not(any(windows, unix)))]
+fn restore_umask(_: u16) {}
 
 #[cfg(windows)]
 fn fix_perm(_: &File) {}
@@ -271,6 +277,8 @@ fn fix_perm(file: &File) {
         libc::fchmod(file.as_raw_fd(), libc::S_IRUSR | libc::S_IWUSR);
     }
 }
+#[cfg(not(any(windows, unix)))]
+fn fix_perm(_: &File) {}
 
 #[cfg(test)]
 mod tests {

--- a/src/history.rs
+++ b/src/history.rs
@@ -245,7 +245,7 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
     }
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_arch = "wasm32"))]
 fn umask() -> u16 {
     0
 }
@@ -253,11 +253,7 @@ fn umask() -> u16 {
 fn umask() -> libc::mode_t {
     unsafe { libc::umask(libc::S_IXUSR | libc::S_IRWXG | libc::S_IRWXO) }
 }
-#[cfg(not(any(windows, unix)))]
-fn umask() -> u16 {
-    0
-}
-#[cfg(windows)]
+#[cfg(any(windows, target_arch = "wasm32"))]
 fn restore_umask(_: u16) {}
 #[cfg(unix)]
 fn restore_umask(old_umask: libc::mode_t) {
@@ -265,10 +261,8 @@ fn restore_umask(old_umask: libc::mode_t) {
         libc::umask(old_umask);
     }
 }
-#[cfg(not(any(windows, unix)))]
-fn restore_umask(_: u16) {}
 
-#[cfg(windows)]
+#[cfg(any(windows, target_arch = "wasm32"))]
 fn fix_perm(_: &File) {}
 #[cfg(unix)]
 fn fix_perm(file: &File) {
@@ -277,8 +271,6 @@ fn fix_perm(file: &File) {
         libc::fchmod(file.as_raw_fd(), libc::S_IRUSR | libc::S_IWUSR);
     }
 }
-#[cfg(not(any(windows, unix)))]
-fn fix_perm(_: &File) {}
 
 #[cfg(test)]
 mod tests {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -36,7 +36,7 @@ pub enum KeyPress {
     Up,
 }
 
-#[cfg_attr(not(any(unix, windows)), allow(dead_code))]
+#[cfg(any(windows, unix))]
 pub fn char_to_key_press(c: char) -> KeyPress {
     if !c.is_control() {
         return KeyPress::Char(c);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -36,6 +36,7 @@ pub enum KeyPress {
     Up,
 }
 
+#[cfg_attr(not(any(unix, windows)), allow(dead_code))]
 pub fn char_to_key_press(c: char) -> KeyPress {
     if !c.is_control() {
         return KeyPress::Char(c);

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -217,7 +217,7 @@ mod unix;
 #[cfg(unix)]
 pub use self::unix::*;
 
-#[cfg(any(test, not(any(windows, unix))))]
+#[cfg(any(test, target_arch = "wasm32"))]
 mod test;
-#[cfg(any(test, not(any(windows, unix))))]
+#[cfg(any(test, target_arch = "wasm32"))]
 pub use self::test::*;

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -217,7 +217,7 @@ mod unix;
 #[cfg(unix)]
 pub use self::unix::*;
 
-#[cfg(test)]
+#[cfg(any(test, not(any(windows, unix))))]
 mod test;
-#[cfg(test)]
+#[cfg(any(test, not(any(windows, unix))))]
 pub use self::test::*;

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -185,7 +185,7 @@ impl Term for DummyTerminal {
     }
 
     fn create_writer(&self) -> Sink {
-        Sink {}
+        Sink::new()
     }
 }
 


### PR DESCRIPTION
With this PR, rustyline builds on `wasm32-unknown-unknown` target with no warnings:

```console
$ cargo build --target wasm32-unknown-unknown
   Compiling cfg-if v0.1.9
   Compiling log v0.4.8
   Compiling memchr v2.2.1
   Compiling libc v0.2.62
   Compiling unicode-width v0.1.6
   Compiling unicode-segmentation v1.3.0
   Compiling dirs-sys v0.3.4
   Compiling dirs v2.0.2
   Compiling rustyline v5.0.2 (/Users/lopopolo/dev/repos/rustyline)
    Finished dev [unoptimized + debuginfo] target(s) in 3.31s
```

This PR uses the `test` tty for unsupported platforms. The standard approach for getting a crate "working on Wasm" is to make it at least compile, even if it does not behave correctly (e.g. the implementation may panic). See https://github.com/BurntSushi/same-file/issues/42#issuecomment-447615062.

This enables building a workspace that includes rustyline for multiple targets, even if the crate using rustyline is not intended to be used on wasm platforms.