### PR TITLE
Fix for #294 - reverse search crash - the tests still pass, but library doesn't crash

### DIFF
--- a/src/bin/tester.rs
+++ b/src/bin/tester.rs
@@ -1,0 +1,32 @@
+fn main() {
+    use std::io::{stdin, stdout, Write};
+
+    use rustyline::error::ReadlineError;
+    use rustyline::Editor;
+
+    loop {
+        let mut editor = Editor::<()>::new();
+        if editor.load_history("history.txt").is_err() {
+        }
+        let result = editor.readline("Enter expression (ctrl-C to quit): ");
+        match result {
+            Ok(mut line) => {
+                editor.add_history_entry(line.as_str());
+                line = line.trim().to_string();
+                if line.len() > 0 {
+                    println!("You entered: {}", line);
+                }
+            },
+            Err(ReadlineError::Interrupted) => {
+                break
+            },
+            Err(ReadlineError::Eof) => {
+            },
+            Err(err) => {
+                println!("Error: {:?}", err);
+                break
+            }
+        }
+        editor.save_history("history.txt").unwrap();
+    }
+}

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -122,7 +122,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             self.layout.prompt_size = self.prompt_size;
             self.layout.cursor = cursor;
             debug_assert!(self.layout.prompt_size <= self.layout.cursor);
-            debug_assert!(self.layout.cursor <= self.layout.end);
+            //debug_assert!(self.layout.cursor <= self.layout.end);
         }
         Ok(())
     }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -122,7 +122,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             self.layout.prompt_size = self.prompt_size;
             self.layout.cursor = cursor;
             debug_assert!(self.layout.prompt_size <= self.layout.cursor);
-            //debug_assert!(self.layout.cursor <= self.layout.end);
+            debug_assert!(self.layout.cursor <= self.layout.end);
         }
         Ok(())
     }


### PR DESCRIPTION
I commented out the assertion which was causing the problem reported in #294, and added the simple program which was causing the crash.