### PR TITLE
Add LineUp/LineDown movement commands

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -517,6 +517,24 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         }
     }
 
+    /// Moves the cursor to the same column in the line above
+    pub fn edit_move_line_up(&mut self, n: RepeatCount) -> Result<()> {
+        if self.line.move_to_line_up(n) {
+            self.move_cursor()
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Moves the cursor to the same column in the line above
+    pub fn edit_move_line_down(&mut self, n: RepeatCount) -> Result<()> {
+        if self.line.move_to_line_down(n) {
+            self.move_cursor()
+        } else {
+            Ok(())
+        }
+    }
+
     pub fn edit_move_to(&mut self, cs: CharSearch, n: RepeatCount) -> Result<()> {
         if self.line.move_to(cs, n) {
             self.move_cursor()

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -242,6 +242,10 @@ pub enum Movement {
     BackwardChar(RepeatCount),
     /// forward-char
     ForwardChar(RepeatCount),
+    /// move to the same column on the previous line
+    LineUp(RepeatCount),
+    /// move to the same column on the next line
+    LineDown(RepeatCount),
 }
 
 impl Movement {
@@ -263,6 +267,8 @@ impl Movement {
             }
             Movement::BackwardChar(previous) => Movement::BackwardChar(repeat_count(previous, new)),
             Movement::ForwardChar(previous) => Movement::ForwardChar(repeat_count(previous, new)),
+            Movement::LineUp(previous) => Movement::LineUp(repeat_count(previous, new)),
+            Movement::LineDown(previous) => Movement::LineDown(repeat_count(previous, new)),
         }
     }
 }
@@ -690,10 +696,12 @@ impl InputState {
             KeyPress::Char(' ') => Cmd::Move(Movement::ForwardChar(n)),
             KeyPress::Ctrl('L') => Cmd::ClearScreen,
             KeyPress::Char('+') |
-            KeyPress::Char('j') | // TODO: move to the start of the line.
+            KeyPress::Char('j') => Cmd::Move(Movement::LineDown(n)),
+            // TODO: move to the start of the line.
             KeyPress::Ctrl('N') => Cmd::NextHistory,
             KeyPress::Char('-') |
-            KeyPress::Char('k') | // TODO: move to the start of the line.
+            KeyPress::Char('k') => Cmd::Move(Movement::LineUp(n)),
+            // TODO: move to the start of the line.
             KeyPress::Ctrl('P') => Cmd::PreviousHistory,
             KeyPress::Ctrl('R') => {
                 self.input_mode = InputMode::Insert; // TODO Validate

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -812,6 +812,8 @@ impl InputState {
                 Some(Movement::BackwardChar(n))
             }
             KeyPress::Char('l') | KeyPress::Char(' ') => Some(Movement::ForwardChar(n)),
+            KeyPress::Char('j') | KeyPress::Char('+') => Some(Movement::LineDown(n)),
+            KeyPress::Char('k') | KeyPress::Char('-') => Some(Movement::LineUp(n)),
             KeyPress::Char('w') => {
                 // 'cw' is 'ce'
                 if key == KeyPress::Char('c') {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,8 +508,6 @@ fn readline_edit<H: Helper>(
                 let c = rdr.next_char()?;
                 s.edit_insert(c, 1)?
             }
-            #[cfg(not(unix))]
-            Cmd::QuotedInsert => {}
             Cmd::Yank(n, anchor) => {
                 // retrieve (yank) last item killed
                 let mut kill_ring = editor.kill_ring.lock().unwrap();
@@ -605,14 +603,7 @@ fn readline_edit<H: Helper>(
                 s.refresh_line()?;
                 continue;
             }
-            #[cfg(not(unix))]
-            Cmd::Suspend => {}
-            Cmd::Move(Movement::WholeLine) => {} // not an actual movement
-            Cmd::Complete | Cmd::CompleteBackward | Cmd::CompleteHint |
-            Cmd::ForwardSearchHistory | Cmd::ReverseSearchHistory |
-            Cmd::Abort | Cmd::Insert(_, _) | Cmd::SelfInsert(_, _) |
-            Cmd::Noop | Cmd::Unknown
-            => {
+            Cmd::Noop | _ => {
                 // Ignore the character typed.
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,6 +508,8 @@ fn readline_edit<H: Helper>(
                 let c = rdr.next_char()?;
                 s.edit_insert(c, 1)?
             }
+            #[cfg(not(unix))]
+            Cmd::QuotedInsert => {}
             Cmd::Yank(n, anchor) => {
                 // retrieve (yank) last item killed
                 let mut kill_ring = editor.kill_ring.lock().unwrap();
@@ -603,6 +605,8 @@ fn readline_edit<H: Helper>(
                 s.refresh_line()?;
                 continue;
             }
+            #[cfg(not(unix))]
+            Cmd::Suspend => {}
             Cmd::Move(Movement::WholeLine) => {} // not an actual movement
             Cmd::Complete | Cmd::CompleteBackward | Cmd::CompleteHint |
             Cmd::ForwardSearchHistory | Cmd::ReverseSearchHistory |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,12 @@ fn readline_edit<H: Helper>(
                 // move forwards one word
                 s.edit_move_to_next_word(at, word_def, n)?
             }
+            Cmd::Move(Movement::LineUp(n)) => {
+                s.edit_move_line_up(n)?
+            }
+            Cmd::Move(Movement::LineDown(n)) => {
+                s.edit_move_line_down(n)?
+            }
             Cmd::DowncaseWord => {
                 // lowercase word after point
                 s.edit_word(WordAction::LOWERCASE)?
@@ -597,7 +603,12 @@ fn readline_edit<H: Helper>(
                 s.refresh_line()?;
                 continue;
             }
-            Cmd::Noop | _ => {
+            Cmd::Move(Movement::WholeLine) => {} // not an actual movement
+            Cmd::Complete | Cmd::CompleteBackward | Cmd::CompleteHint |
+            Cmd::ForwardSearchHistory | Cmd::ReverseSearchHistory |
+            Cmd::Abort | Cmd::Insert(_, _) | Cmd::SelfInsert(_, _) |
+            Cmd::Noop | Cmd::Unknown
+            => {
                 // Ignore the character typed.
             }
         }

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -566,14 +566,15 @@ impl LineBuffer {
                     if dest_end == self.buf.len() { break; }
                     dest_start = dest_end+1;
                     dest_end = self.buf[dest_start..].find('\n')
+                        .map(|v| dest_start + v)
                         .unwrap_or(self.buf.len());
                 }
-                let new_off = self.buf[dest_start..dest_end]
+                self.pos = self.buf[dest_start..dest_end]
                     .grapheme_indices(true)
                     .nth(column)
-                    .map(|(idx, _)| idx)
+                    .map(|(idx, _)| dest_start + idx)
                     .unwrap_or(dest_end); // if there's no enough columns
-                self.pos = dest_start + new_off;
+                debug_assert!(self.pos <= self.buf.len());
                 return true;
             }
             None => return false,

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -495,12 +495,11 @@ impl LineBuffer {
                         .unwrap_or(0);
                 }
 
-                let new_off = self.buf[dest_start..dest_end]
+                self.pos = self.buf[dest_start..dest_end]
                     .grapheme_indices(true)
                     .nth(column)
-                    .map(|(idx, _)| idx)
+                    .map(|(idx, _)| dest_start + idx)
                     .unwrap_or(off); // if there's no enough columns
-                self.pos = dest_start + new_off;
                 return true;
             }
             None => return false,

--- a/src/test/vi_cmd.rs
+++ b/src/test/vi_cmd.rs
@@ -429,6 +429,63 @@ fn j() {
     for key in &[
         KeyPress::Char('j'),
         KeyPress::Char('+'),
+    ] {
+        assert_cursor(
+            EditMode::Vi,
+            ("Hel", "lo,\nworld!"),
+            // NOTE: escape moves backwards on char
+            &[KeyPress::Esc, *key, KeyPress::Enter],
+            ("Hello,\nwo", "rld!"),
+        );
+        assert_cursor(
+            EditMode::Vi,
+            ("", "One\nTwo\nThree"),
+            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            ("One\nTwo\n", "Three"),
+        );
+        assert_cursor(
+            EditMode::Vi,
+            ("Hel", "lo,\nworld!"),
+            // NOTE: escape moves backwards on char
+            &[KeyPress::Esc, KeyPress::Char('7'), *key, KeyPress::Enter],
+            ("Hello,\nwo", "rld!"),
+        );
+    }
+}
+
+#[test]
+fn k() {
+    for key in &[
+        KeyPress::Char('k'),
+        KeyPress::Char('-'),
+    ] {
+        assert_cursor(
+            EditMode::Vi,
+            ("Hello,\nworl", "d!"),
+            // NOTE: escape moves backwards on char
+            &[KeyPress::Esc, *key, KeyPress::Enter],
+            ("Hel", "lo,\nworld!"),
+        );
+        assert_cursor(
+            EditMode::Vi,
+            ("One\nTwo\nT", "hree"),
+            // NOTE: escape moves backwards on char
+            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            ("", "One\nTwo\nThree"),
+        );
+        assert_cursor(
+            EditMode::Vi,
+            ("Hello,\nworl", "d!"),
+            // NOTE: escape moves backwards on char
+            &[KeyPress::Esc, KeyPress::Char('5'), *key, KeyPress::Enter],
+            ("Hel", "lo,\nworld!"),
+        );
+    }
+}
+
+#[test]
+fn ctrl_n() {
+    for key in &[
         KeyPress::Ctrl('N'),
     ] {
         assert_history(
@@ -448,10 +505,8 @@ fn j() {
 }
 
 #[test]
-fn k() {
+fn ctrl_p() {
     for key in &[
-        KeyPress::Char('k'),
-        KeyPress::Char('-'),
         KeyPress::Ctrl('P'),
     ] {
         assert_history(

--- a/src/test/vi_cmd.rs
+++ b/src/test/vi_cmd.rs
@@ -480,6 +480,12 @@ fn k() {
             &[KeyPress::Esc, KeyPress::Char('5'), *key, KeyPress::Enter],
             ("Hel", "lo,\nworld!"),
         );
+        assert_cursor(
+            EditMode::Vi,
+            ("first line\nshort\nlong line", ""),
+            &[KeyPress::Esc, *key, KeyPress::Enter],
+            ("first line\nshort", "\nlong line"),
+        );
     }
 }
 


### PR DESCRIPTION
This PR also changes `j/k` and `+/-` in vi mode to use these movements

For the vi command mode, Ctrl+N and Ctrl+P switch history. And Up/Down array keys switch history in insert mode.

The emacs mode is left intact in this PR.

This partially fixes #317