### PR TITLE
Make config builder clonable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -214,7 +214,7 @@ pub enum OutputStreamType {
 }
 
 /// Configuration builder
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Builder {
     p: Config,
 }


### PR DESCRIPTION
Fix #322