### PR TITLE
Add skim as optional fuzzy completion option for unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ memchr = "2.0"
 [target.'cfg(unix)'.dependencies]
 nix = "0.16"
 utf8parse = "0.2"
+skim = { version = "0.7", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "minwindef", "processenv", "winbase", "wincon", "winuser"] }
@@ -43,9 +44,10 @@ rustyline-derive = { version = "0.3.0", path = "rustyline-derive" }
 [features]
 default = ["with-dirs"]
 with-dirs = ["dirs"]
+with-fuzzy = ["skim"]
 
 [package.metadata.docs.rs]
-features = ["with-dirs"]
+features = ["with-dirs", "with-fuzzy"]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,6 +188,13 @@ pub enum CompletionType {
     /// When more than one match, list all matches
     /// (like in Bash/Readline).
     List,
+
+    /// Complete the match using fuzzy search and selection
+    /// (like fzf and plugins)
+    /// Currently only available for unix platforms as dependency on skim->tuikit
+    /// Compile with `--features=fuzzy` to enable
+    #[cfg(all(unix, feature = "with-fuzzy"))]
+    Fuzzy,
 }
 
 /// Style of editing / Standard keymaps


### PR DESCRIPTION
Implements #323 

This PR adds optional support for Fuzzy Completion mode using [skim](https://github.com/lotabout/skim) as the backend. Unfortunately skim uses [tuikit](https://github.com/lotabout/tuikit) for it's terminal UI which doesn't support Windows systems yet, so I've included compile conditionals for `unix` as well as the optional feature `with-fuzzy` for the time being.

**To demo:**

- Use CompletionType::Fuzzy, instead of List or Circular. e.g. replace the [example here](https://github.com/kkawakam/rustyline/blob/master/examples/example.rs#L71)
- Run: `cargo run --example example --features=with-fuzzy`
- Use tab as normal to autocomplete the file system.

**Snapshots:**

Simple autocomplete while filtering:

<img width="742" alt="image" src="https://user-images.githubusercontent.com/12645162/73120815-b7ec1b80-3fc6-11ea-93a7-f50ef1251831.png">

Complete subdirectory and add selected completion

<img width="405" alt="image" src="https://user-images.githubusercontent.com/12645162/73120826-d81bda80-3fc6-11ea-8a0d-b4e0a7c81ccb.png">
<img width="450" alt="image" src="https://user-images.githubusercontent.com/12645162/73120829-e4a03300-3fc6-11ea-9333-9606d60d2b2b.png">
