### PR TITLE
Add smart up and down commands

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -513,20 +513,22 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
     }
 
     /// Moves the cursor to the same column in the line above
-    pub fn edit_move_line_up(&mut self, n: RepeatCount) -> Result<()> {
+    pub fn edit_move_line_up(&mut self, n: RepeatCount) -> Result<bool> {
         if self.line.move_to_line_up(n) {
-            self.move_cursor()
+            self.move_cursor()?;
+            Ok(true)
         } else {
-            Ok(())
+            Ok(false)
         }
     }
 
     /// Moves the cursor to the same column in the line above
-    pub fn edit_move_line_down(&mut self, n: RepeatCount) -> Result<()> {
+    pub fn edit_move_line_down(&mut self, n: RepeatCount) -> Result<bool> {
         if self.line.move_to_line_down(n) {
-            self.move_cursor()
+            self.move_cursor()?;
+            Ok(true)
         } else {
-            Ok(())
+            Ok(false)
         }
     }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -88,6 +88,12 @@ pub enum Cmd {
     Yank(RepeatCount, Anchor),
     /// yank-pop
     YankPop,
+    /// moves cursor to the line above or switches to prev history entry if
+    /// the cursor is already on the first line
+    LineUpOrPreviousHistory,
+    /// moves cursor to the line below or switches to next history entry if
+    /// the cursor is already on the last line
+    LineDownOrNextHistory,
 }
 
 impl Cmd {
@@ -891,8 +897,8 @@ impl InputState {
             }
             KeyPress::Ctrl('J') |
             KeyPress::Enter => Cmd::AcceptLine,
-            KeyPress::Down => Cmd::NextHistory,
-            KeyPress::Up => Cmd::PreviousHistory,
+            KeyPress::Down => Cmd::LineDownOrNextHistory,
+            KeyPress::Up => Cmd::LineUpOrPreviousHistory,
             KeyPress::Ctrl('R') => Cmd::ReverseSearchHistory,
             KeyPress::Ctrl('S') => Cmd::ForwardSearchHistory, // most terminals override Ctrl+S to suspend execution
             KeyPress::Ctrl('T') => Cmd::TransposeChars,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,16 @@ fn readline_edit<H: Helper>(
                 // Fetch the previous command from the history list.
                 s.edit_history_next(true)?
             }
+            Cmd::LineUpOrPreviousHistory => {
+                if !s.edit_move_line_up(1)? {
+                    s.edit_history_next(true)?
+                }
+            }
+            Cmd::LineDownOrNextHistory => {
+                if !s.edit_move_line_down(1)? {
+                    s.edit_history_next(false)?
+                }
+            }
             Cmd::HistorySearchBackward => s.edit_history_search(Direction::Reverse)?,
             Cmd::HistorySearchForward => s.edit_history_search(Direction::Forward)?,
             Cmd::TransposeChars => {
@@ -603,10 +613,10 @@ fn readline_edit<H: Helper>(
                 s.edit_move_to_next_word(at, word_def, n)?
             }
             Cmd::Move(Movement::LineUp(n)) => {
-                s.edit_move_line_up(n)?
+                s.edit_move_line_up(n)?;
             }
             Cmd::Move(Movement::LineDown(n)) => {
-                s.edit_move_line_down(n)?
+                s.edit_move_line_down(n)?;
             }
             Cmd::DowncaseWord => {
                 // lowercase word after point


### PR DESCRIPTION
While not ubiquitous, it's quite common and intuitive for `Up/Down` arrow keys to navigate between lines in the multi-line prompt, and only switch history if the cursor is on the first/last (or the only) line of the input.

This PR adds both the commands that do that and change Up/Down arrow keys. Note: Ctrl+N/P remain the same as well as `j/k` in vim mode.