### PR TITLE
Add AcceptOrNewLine command

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -226,13 +226,10 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             let corrected = self.changes.borrow_mut().end();
             let validated = match result {
                 ValidationResult::Incomplete => {
-                    self.edit_move_end()?;
-                    self.edit_insert('\n', 1)?;
                     false
                 }
                 ValidationResult::Valid(msg) => {
                     // Accept the line regardless of where the cursor is.
-                    self.edit_move_end()?;
                     if corrected || self.has_hint() || msg.is_some() {
                         // Force a refresh without hints to leave the previous
                         // line as the user typed it after a newline.

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -94,6 +94,9 @@ pub enum Cmd {
     /// moves cursor to the line below or switches to next history entry if
     /// the cursor is already on the last line
     LineDownOrNextHistory,
+    /// accepts the line when cursor is at the end of the text (non including
+    /// trailing whitespace), inserts newline character otherwise
+    AcceptOrInsertLine,
 }
 
 impl Cmd {

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -294,6 +294,11 @@ impl LineBuffer {
         }
     }
 
+    /// Is cursor at the end of input (whitespaces after cursor is discarded)
+    pub fn is_end_of_input(&self) -> bool {
+        self.pos >= self.buf.trim_end().len()
+    }
+
     /// Delete the character at the right of the cursor without altering the
     /// cursor position. Basically this is what happens with the "Delete"
     /// keyboard key.


### PR DESCRIPTION
This command might be used to insert a newline by default if cursor is
not on the end of line.

This is useful for where multiple lines are not occassional but are used
most of the time (i.e. SQL, Lisp...). The `AcceptLine` only inserts
newline when the input is non-valid, so inserting a thing into the fully
valid chunk of text is cumbersome.