### PR TITLE
Split KeyPress into separate Key and Modifier types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ unicode-segmentation = "1.0"
 memchr = "2.0"
 bitflags = "1.2"
 smallvec = "1.2"
+qp-trie = "0.7"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ unicode-width = "0.1"
 unicode-segmentation = "1.0"
 memchr = "2.0"
 bitflags = "1.2"
+smallvec = "1.2"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4"
 unicode-width = "0.1"
 unicode-segmentation = "1.0"
 memchr = "2.0"
+bitflags = "1.2"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -105,8 +105,8 @@ fn main() -> rustyline::Result<()> {
     };
     let mut rl = Editor::with_config(config);
     rl.set_helper(Some(h));
-    rl.bind_sequence(KeyPress::Meta('N'), Cmd::HistorySearchForward);
-    rl.bind_sequence(KeyPress::Meta('P'), Cmd::HistorySearchBackward);
+    rl.bind_sequence(KeyPress::meta('N'), Cmd::HistorySearchForward);
+    rl.bind_sequence(KeyPress::meta('P'), Cmd::HistorySearchBackward);
     if rl.load_history("history.txt").is_err() {
         println!("No previous history.");
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -505,7 +505,7 @@ impl InputState {
             }
             key_press!(META, '<') => Cmd::BeginningOfHistory,
             key_press!(META, '>') => Cmd::EndOfHistory,
-            key_press!(META, 'B') | key_press!(META, 'b') => {
+            key_press!(META, 'B') | key_press!(META, 'b') | key_press!(META, Left) => {
                 if positive {
                     Cmd::Move(Movement::BackwardWord(n, Word::Emacs))
                 } else {
@@ -520,7 +520,7 @@ impl InputState {
                     Cmd::Kill(Movement::BackwardWord(n, Word::Emacs))
                 }
             }
-            key_press!(META, 'F') | key_press!(META, 'f') => {
+            key_press!(META, 'F') | key_press!(META, 'f') | key_press!(META, Right) => {
                 if positive {
                     Cmd::Move(Movement::ForwardWord(n, At::AfterEnd, Word::Emacs))
                 } else {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -327,7 +327,7 @@ pub fn char_to_key_press(c: char) -> KeyPress {
         '\x07' => KeyPress::ctrl('G'),
         '\x08' => KeyPress::BACKSPACE, // '\b'
         '\x09' => KeyPress::TAB,       // '\t'
-        '\x0a' => KeyPress::ctrl('J'), // '\n' (1)
+        '\x0a' => KeyPress::ctrl('J'), // '\n' (10)
         '\x0b' => KeyPress::ctrl('K'),
         '\x0c' => KeyPress::ctrl('L'),
         '\x0d' => KeyPress::ENTER, // '\r' (13)

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,19 +1,14 @@
 //! Key constants
 
-// #[non_exhaustive]
+/// A key, independent of any modifiers. See KeyPress for the equivalent with modifers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum KeyPress {
+pub enum Key {
+    Char(char),
     UnknownEscSeq,
     Backspace, // Ctrl('H')
     BackTab,
     BracketedPasteStart,
     BracketedPasteEnd,
-    Char(char),
-    ControlDown,
-    ControlLeft,
-    ControlRight,
-    ControlUp,
-    Ctrl(char),
     Delete,
     Down,
     End,
@@ -23,68 +18,436 @@ pub enum KeyPress {
     Home,
     Insert,
     Left,
-    Meta(char),
     Null,
     PageDown,
     PageUp,
     Right,
-    ShiftDown,
-    ShiftLeft,
-    ShiftRight,
-    ShiftUp,
     Tab, // Ctrl('I')
     Up,
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+impl From<char> for Key {
+    #[inline]
+    fn from(c: char) -> Self {
+        Self::Char(c)
+    }
+}
+
+impl Key {
+    #[inline]
+    pub const fn with_mods(self, mods: KeyMods) -> KeyPress {
+        KeyPress::new(self, mods)
+    }
+
+    #[inline]
+    pub const fn shift(self) -> KeyPress {
+        self.with_mods(KeyMods::SHIFT)
+    }
+
+    #[inline]
+    pub const fn ctrl(self) -> KeyPress {
+        self.with_mods(KeyMods::CTRL)
+    }
+
+    #[inline]
+    pub const fn meta(self) -> KeyPress {
+        self.with_mods(KeyMods::META)
+    }
+}
+
+bitflags::bitflags! {
+    /// The set of modifier keys that were triggered along with a key press.
+    pub struct KeyMods: u8 {
+        const CTRL  = 0b0001;
+        const META  = 0b0010;
+        const SHIFT = 0b0100;
+        // TODO: Should there be an `ALT`?
+
+        const NONE = 0;
+        const CTRL_SHIFT = Self::CTRL.bits | Self::META.bits;
+        const META_SHIFT = Self::META.bits | Self::SHIFT.bits;
+        const CTRL_META = Self::META.bits | Self::CTRL.bits;
+        const CTRL_META_SHIFT = Self::META.bits | Self::CTRL.bits | Self::SHIFT.bits;
+    }
+}
+
+impl KeyMods {
+    #[inline]
+    pub fn ctrl_meta_shift(ctrl: bool, meta: bool, shift: bool) -> Self {
+        (if ctrl { Self::CTRL } else { Self::NONE })
+            | (if meta { Self::META } else { Self::NONE })
+            | (if shift { Self::SHIFT } else { Self::NONE })
+    }
+}
+
+/// A key press is key and some modifiers. Note that there's overlap between
+/// keys (ctrl-H and delete, for example), and not all keys may be represented.
+///
+/// See the [`key_press!`] macro which allows using these in a pattern (e.g. a
+/// match / if let binding) conveniently, but can also be used to construct
+/// KeyPress values.
+///
+/// ## Notes
+/// - for a `Key::Char` with modifiers, the upper-case character should be used.
+///   e.g. `key_press!(CTRL, 'A')` and not `key_press!(CTRL, 'a')`.
+/// - Upper-case letters generally will not have `KeyMods::SHIFT` associated with
+///   them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KeyPress {
+    pub key: Key,
+    pub mods: KeyMods,
+}
+
+impl From<Key> for KeyPress {
+    #[inline]
+    fn from(k: Key) -> Self {
+        Self::new(k, KeyMods::NONE)
+    }
+}
+impl From<char> for KeyPress {
+    #[inline]
+    fn from(k: char) -> Self {
+        Self::new(k.into(), KeyMods::NONE)
+    }
+}
+
+impl KeyPress {
+    #[inline]
+    pub const fn new(key: Key, mods: KeyMods) -> Self {
+        Self { key, mods }
+    }
+
+    #[inline]
+    pub fn normal(k: impl Into<Key>) -> Self {
+        Self::new(k.into(), KeyMods::NONE)
+    }
+
+    #[inline]
+    pub fn ctrl(k: impl Into<Key>) -> Self {
+        Self::new(k.into(), KeyMods::CTRL)
+    }
+
+    #[inline]
+    pub fn shift(k: impl Into<Key>) -> Self {
+        Self::new(k.into(), KeyMods::SHIFT)
+    }
+
+    #[inline]
+    pub fn meta(k: impl Into<Key>) -> Self {
+        Self::new(k.into(), KeyMods::META)
+    }
+
+    // These are partially here because make updating a lot easier (just turn
+    // `KeyPress::Home` into `KeyPress::HOME`). OTOH,
+
+    /// Constant value representing an unmodified press of `Key::Backspace`.
+    pub const BACKSPACE: Self = Self::new(Key::Backspace, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::BackTab`.
+    pub const BACK_TAB: Self = Self::new(Key::BackTab, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Delete`.
+    pub const DELETE: Self = Self::new(Key::Delete, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Down`.
+    pub const DOWN: Self = Self::new(Key::Down, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::End`.
+    pub const END: Self = Self::new(Key::End, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Enter`.
+    pub const ENTER: Self = Self::new(Key::Enter, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Esc`.
+    pub const ESC: Self = Self::new(Key::Esc, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Home`.
+    pub const HOME: Self = Self::new(Key::Home, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Insert`.
+    pub const INSERT: Self = Self::new(Key::Insert, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Left`.
+    pub const LEFT: Self = Self::new(Key::Left, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::PageDown`.
+    pub const PAGE_DOWN: Self = Self::new(Key::PageDown, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::PageUp`.
+    pub const PAGE_UP: Self = Self::new(Key::PageUp, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Right`.
+    pub const RIGHT: Self = Self::new(Key::Right, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Tab`.
+    pub const TAB: Self = Self::new(Key::Tab, KeyMods::NONE);
+
+    /// Constant value representing an unmodified press of `Key::Up`.
+    pub const UP: Self = Self::new(Key::Up, KeyMods::NONE);
+}
+
+/// Macro to work around the fact that you can't use the result of a function as
+/// a pattern. This basically exists so that you can match on the result.
+///
+/// # Usage:
+/// ```
+/// # use rustyline::{key_press, KeyPress};
+/// fn handle_key_press(k: KeyPress) {
+///     match k {
+///         key_press!('c') => println!("C was pressed"),
+///         key_press!(CTRL, 'o') => println!("CTRL-o was pressed"),
+///         key_press!(Right) => println!("Right was pressed"),
+///         key_press!(SHIFT, Left) => println!("Shift-left were pressed"),
+///         key_press!(Char(c)) => println!("the char {} was pressed", c),
+///         key_press!(META, c @ '0'..='9') | key_press!(c @ 'a'..='z') => {
+///             # let _ = c;
+///             println!("You get the idea...");
+///         }
+///         _ => {}
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! key_press {
+    // This is written pretty weirdly but I couldn't find a less verbose way of
+    // doing it (keep in mind that the macro expander doesn't backtrack and
+    // accepts the first thing that could match). It also makes the code many,
+    // many times more readable, IMO.
+
+    // That said... This macro itself? Not that readable.
+
+    (Backspace) => { $crate::KeyPress { key: $crate::Key::Backspace, mods: $crate::KeyMods::NONE } };
+    (BackTab) => { $crate::KeyPress { key: $crate::Key::BackTab, mods: $crate::KeyMods::NONE } };
+    (Delete) => { $crate::KeyPress { key: $crate::Key::Delete, mods: $crate::KeyMods::NONE } };
+    (Down) => { $crate::KeyPress { key: $crate::Key::Down, mods: $crate::KeyMods::NONE } };
+    (End) => { $crate::KeyPress { key: $crate::Key::End, mods: $crate::KeyMods::NONE } };
+    (Enter) => { $crate::KeyPress { key: $crate::Key::Enter, mods: $crate::KeyMods::NONE } };
+    (Esc) => { $crate::KeyPress { key: $crate::Key::Esc, mods: $crate::KeyMods::NONE } };
+    (Home) => { $crate::KeyPress { key: $crate::Key::Home, mods: $crate::KeyMods::NONE } };
+    (Insert) => { $crate::KeyPress { key: $crate::Key::Insert, mods: $crate::KeyMods::NONE } };
+    (Left) => { $crate::KeyPress { key: $crate::Key::Left, mods: $crate::KeyMods::NONE } };
+    (PageDown) => { $crate::KeyPress { key: $crate::Key::PageDown, mods: $crate::KeyMods::NONE } };
+    (PageUp) => { $crate::KeyPress { key: $crate::Key::PageUp, mods: $crate::KeyMods::NONE } };
+    (Right) => { $crate::KeyPress { key: $crate::Key::Right, mods: $crate::KeyMods::NONE } };
+    (Tab) => { $crate::KeyPress { key: $crate::Key::Tab, mods: $crate::KeyMods::NONE } };
+    (Up) => { $crate::KeyPress { key: $crate::Key::Up, mods: $crate::KeyMods::NONE } };
+    (Null) => { $crate::KeyPress { key: $crate::Key::Null, mods: $crate::KeyMods::NONE }};
+    (UnknownEscSeq) => { $crate::KeyPress { key: $crate::Key::UnknownEscSeq, mods: $crate::KeyMods::NONE } };
+    (BracketedPasteStart) => { $crate::KeyPress { key: $crate::Key::BracketedPasteStart, mods: $crate::KeyMods::NONE }};
+    (BracketedPasteEnd) => { $crate::KeyPress { key: $crate::Key::BracketedPasteEnd, mods: $crate::KeyMods::NONE }};
+
+    (Char($($c:tt)*)) => { $crate::KeyPress { key: $crate::Key::Char($($c)*), mods: $crate::KeyMods::NONE } };
+    (F($($c:tt)*)) => { $crate::KeyPress { key: $crate::Key::F($($c)*), mods: $crate::KeyMods::NONE } };
+
+    (SHIFT, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $crate::KeyMods::SHIFT } };
+    (CTRL, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $crate::KeyMods::CTRL } };
+    (META, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $crate::KeyMods::META } };
+
+    (NONE, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $crate::KeyMods::NONE } };
+    (CTRL_SHIFT, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $crate::KeyMods::CTRL_SHIFT } };
+    (META_SHIFT, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $crate::KeyMods::META_SHIFT } };
+    (CTRL_META, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $crate::KeyMods::CTRL_META } };
+    (CTRL_META_SHIFT, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $crate::KeyMods::CTRL_META_SHIFT } };
+    (_, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: _ } };
+
+    // To easy to accidentally bind this if you get `SHIFT_CTRL` and `CTRL_SHIFT` mixed up...
+    // ($mods:pat, $($t:tt)*) => { $crate::KeyPress { key: $crate::key_press!(@__just_key $($t)*), mods: $mods } };
+
+    ($ch:literal) => { $crate::KeyPress { key: $crate::Key::Char($ch), mods: $crate::KeyMods::NONE } };
+
+    // Allow patterns like `key_press(d @ '0'..='9')`, but explicitly forbid
+    // idents as it's confusing (when does `if let key_press!(c) = some_key {}`
+    // match?)
+    ($ch:ident) => { compile_error!("`key_press!(c)` is ambiguous, try `key_press!(Char(c))`?") };
+
+    ($ch:pat) => { $crate::KeyPress { key: $crate::Key::Char($ch), mods: $crate::KeyMods::NONE } };
+
+    // Has to be duplicated. (Forwarding the above to this causes it to fail to
+    // match...)
+    (@__just_key Backspace) => { $crate::Key::Backspace };
+    (@__just_key BackTab) => { $crate::Key::BackTab };
+    (@__just_key Delete) => { $crate::Key::Delete };
+    (@__just_key Down) => { $crate::Key::Down };
+    (@__just_key End) => { $crate::Key::End };
+    (@__just_key Enter) => { $crate::Key::Enter };
+    (@__just_key Esc) => { $crate::Key::Esc };
+    (@__just_key Home) => { $crate::Key::Home };
+    (@__just_key Insert) => { $crate::Key::Insert };
+    (@__just_key Left) => { $crate::Key::Left };
+    (@__just_key PageDown) => { $crate::Key::PageDown };
+    (@__just_key PageUp) => { $crate::Key::PageUp };
+    (@__just_key Right) => { $crate::Key::Right };
+    (@__just_key Tab) => { $crate::Key::Tab };
+    (@__just_key Up) => { $crate::Key::Up };
+    (@__just_key Null) => { $crate::Key::Null };
+    (@__just_key UnknownEscSeq) => { $crate::Key::UnknownEscSeq };
+    (@__just_key BracketedPasteStart) => { $crate::Key::BracketedPasteStart };
+    (@__just_key BracketedPasteEnd) => { $crate::Key::BracketedPasteEnd };
+    (@__just_key Char($($c:tt)*)) => { $crate::Key::Char($($c)*) };
+    (@__just_key F($($c:tt)*)) => { $crate::Key::F($($c)*) };
+
+    (@__just_key $ch:literal) => { $crate::Key::Char($ch) };
+
+    (@__just_key $ch:ident) => { compile_error!("`key_press!(<some mod>, c)` is ambiguous, try `key_press!(<some mod>, Char(c))`?") };
+
+    (@__just_key $ch:pat) => { $crate::Key::Char($ch) };
 }
 
 #[cfg(any(windows, unix))]
 pub fn char_to_key_press(c: char) -> KeyPress {
     if !c.is_control() {
-        return KeyPress::Char(c);
+        return c.into();
     }
     #[allow(clippy::match_same_arms)]
     match c {
-        '\x00' => KeyPress::Ctrl(' '),
-        '\x01' => KeyPress::Ctrl('A'),
-        '\x02' => KeyPress::Ctrl('B'),
-        '\x03' => KeyPress::Ctrl('C'),
-        '\x04' => KeyPress::Ctrl('D'),
-        '\x05' => KeyPress::Ctrl('E'),
-        '\x06' => KeyPress::Ctrl('F'),
-        '\x07' => KeyPress::Ctrl('G'),
-        '\x08' => KeyPress::Backspace, // '\b'
-        '\x09' => KeyPress::Tab,       // '\t'
-        '\x0a' => KeyPress::Ctrl('J'), // '\n' (10)
-        '\x0b' => KeyPress::Ctrl('K'),
-        '\x0c' => KeyPress::Ctrl('L'),
-        '\x0d' => KeyPress::Enter, // '\r' (13)
-        '\x0e' => KeyPress::Ctrl('N'),
-        '\x0f' => KeyPress::Ctrl('O'),
-        '\x10' => KeyPress::Ctrl('P'),
-        '\x12' => KeyPress::Ctrl('R'),
-        '\x13' => KeyPress::Ctrl('S'),
-        '\x14' => KeyPress::Ctrl('T'),
-        '\x15' => KeyPress::Ctrl('U'),
-        '\x16' => KeyPress::Ctrl('V'),
-        '\x17' => KeyPress::Ctrl('W'),
-        '\x18' => KeyPress::Ctrl('X'),
-        '\x19' => KeyPress::Ctrl('Y'),
-        '\x1a' => KeyPress::Ctrl('Z'),
-        '\x1b' => KeyPress::Esc, // Ctrl-[
-        '\x1c' => KeyPress::Ctrl('\\'),
-        '\x1d' => KeyPress::Ctrl(']'),
-        '\x1e' => KeyPress::Ctrl('^'),
-        '\x1f' => KeyPress::Ctrl('_'),
-        '\x7f' => KeyPress::Backspace, // Rubout
-        _ => KeyPress::Null,
+        '\x00' => KeyPress::ctrl(' '),
+        '\x01' => KeyPress::ctrl('A'),
+        '\x02' => KeyPress::ctrl('B'),
+        '\x03' => KeyPress::ctrl('C'),
+        '\x04' => KeyPress::ctrl('D'),
+        '\x05' => KeyPress::ctrl('E'),
+        '\x06' => KeyPress::ctrl('F'),
+        '\x07' => KeyPress::ctrl('G'),
+        '\x08' => KeyPress::BACKSPACE, // '\b'
+        '\x09' => KeyPress::TAB,       // '\t'
+        '\x0a' => KeyPress::ctrl('J'), // '\n' (1)
+        '\x0b' => KeyPress::ctrl('K'),
+        '\x0c' => KeyPress::ctrl('L'),
+        '\x0d' => KeyPress::ENTER, // '\r' (13)
+        '\x0e' => KeyPress::ctrl('N'),
+        '\x0f' => KeyPress::ctrl('O'),
+        '\x10' => KeyPress::ctrl('P'),
+        '\x12' => KeyPress::ctrl('R'),
+        '\x13' => KeyPress::ctrl('S'),
+        '\x14' => KeyPress::ctrl('T'),
+        '\x15' => KeyPress::ctrl('U'),
+        '\x16' => KeyPress::ctrl('V'),
+        '\x17' => KeyPress::ctrl('W'),
+        '\x18' => KeyPress::ctrl('X'),
+        '\x19' => KeyPress::ctrl('Y'),
+        '\x1a' => KeyPress::ctrl('Z'),
+        '\x1b' => KeyPress::ESC, // Ctrl-[
+        '\x1c' => KeyPress::ctrl('\\'),
+        '\x1d' => KeyPress::ctrl(']'),
+        '\x1e' => KeyPress::ctrl('^'),
+        '\x1f' => KeyPress::ctrl('_'),
+        '\x7f' => KeyPress::BACKSPACE, // Rubout
+        _ => Key::Null.into(),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{char_to_key_press, KeyPress};
-
+    use super::{char_to_key_press, Key, KeyMods, KeyPress};
+    use assert_matches::assert_matches;
     #[test]
     fn char_to_key() {
-        assert_eq!(KeyPress::Esc, char_to_key_press('\x1b'));
+        assert_eq!(KeyPress::ESC, char_to_key_press('\x1b'));
+    }
+    #[test]
+    fn test_macro_keyidents() {
+        assert_matches!(Key::Backspace.into(), key_press!(Backspace));
+        assert_matches!(Key::BackTab.into(), key_press!(BackTab));
+        assert_matches!(Key::Delete.into(), key_press!(Delete));
+        assert_matches!(Key::Down.into(), key_press!(Down));
+        assert_matches!(Key::End.into(), key_press!(End));
+        assert_matches!(Key::Enter.into(), key_press!(Enter));
+        assert_matches!(Key::Esc.into(), key_press!(Esc));
+        assert_matches!(Key::Home.into(), key_press!(Home));
+        assert_matches!(Key::Insert.into(), key_press!(Insert));
+        assert_matches!(Key::Left.into(), key_press!(Left));
+        assert_matches!(Key::PageDown.into(), key_press!(PageDown));
+        assert_matches!(Key::PageUp.into(), key_press!(PageUp));
+        assert_matches!(Key::Right.into(), key_press!(Right));
+        assert_matches!(Key::Tab.into(), key_press!(Tab));
+        assert_matches!(Key::Up.into(), key_press!(Up));
+        assert_matches!(Key::Null.into(), key_press!(Null));
+        assert_matches!(Key::UnknownEscSeq.into(), key_press!(UnknownEscSeq));
+
+        assert_matches!(Key::Char('c').into(), key_press!(Char('c')));
+
+        assert_matches!(Key::F(3).into(), key_press!(F(3)));
+        assert_matches!(
+            Key::BracketedPasteStart.into(),
+            key_press!(BracketedPasteStart)
+        );
+        assert_matches!(Key::BracketedPasteEnd.into(), key_press!(BracketedPasteEnd));
+    }
+
+    #[test]
+    fn test_macro_patterns() {
+        assert_matches!(KeyPress::from('x'), key_press!(Char(_c)));
+        assert_matches!(KeyPress::from('x'), key_press!(Char(..)));
+        assert_matches!(KeyPress::from('x'), key_press!(Char('a'..='z')));
+        assert_matches!(KeyPress::from('x'), key_press!('a'..='z'));
+        assert_matches!(KeyPress::from('x'), key_press!('x'));
+        assert_matches!(KeyPress::from('x'), key_press!(letter @ 'a' ..= 'z') if letter == 'x');
+    }
+
+    #[test]
+    fn test_macro_mods() {
+        assert_matches!(
+            KeyPress::new('x'.into(), KeyMods::SHIFT),
+            key_press!(SHIFT, 'x')
+        );
+        assert_matches!(
+            KeyPress::new('x'.into(), KeyMods::CTRL),
+            key_press!(CTRL, 'x')
+        );
+        assert_matches!(
+            KeyPress::new('x'.into(), KeyMods::META),
+            key_press!(META, 'x')
+        );
+        assert_matches!(
+            KeyPress::new('x'.into(), KeyMods::NONE),
+            key_press!(NONE, 'x')
+        );
+
+        assert_matches!(
+            KeyPress::new('x'.into(), KeyMods::CTRL_SHIFT),
+            key_press!(CTRL_SHIFT, 'x')
+        );
+        assert_matches!(
+            KeyPress::new('x'.into(), KeyMods::META_SHIFT),
+            key_press!(META_SHIFT, 'x')
+        );
+        assert_matches!(
+            KeyPress::new('x'.into(), KeyMods::CTRL_META),
+            key_press!(CTRL_META, 'x')
+        );
+        assert_matches!(
+            KeyPress::new('x'.into(), KeyMods::CTRL_META_SHIFT),
+            key_press!(CTRL_META_SHIFT, 'x')
+        );
+    }
+    #[test]
+    fn test_macro_mod_key_idents() {
+        assert_matches!(Key::Backspace.into(), key_press!(NONE, Backspace));
+        assert_matches!(Key::BackTab.into(), key_press!(NONE, BackTab));
+        assert_matches!(Key::Delete.into(), key_press!(NONE, Delete));
+        assert_matches!(Key::Down.into(), key_press!(NONE, Down));
+        assert_matches!(Key::End.into(), key_press!(NONE, End));
+        assert_matches!(Key::Enter.into(), key_press!(NONE, Enter));
+        assert_matches!(Key::Esc.into(), key_press!(NONE, Esc));
+        assert_matches!(Key::Home.into(), key_press!(NONE, Home));
+        assert_matches!(Key::Insert.into(), key_press!(NONE, Insert));
+        assert_matches!(Key::Left.into(), key_press!(NONE, Left));
+        assert_matches!(Key::PageDown.into(), key_press!(NONE, PageDown));
+        assert_matches!(Key::PageUp.into(), key_press!(NONE, PageUp));
+        assert_matches!(Key::Right.into(), key_press!(NONE, Right));
+        assert_matches!(Key::Tab.into(), key_press!(NONE, Tab));
+        assert_matches!(Key::Up.into(), key_press!(NONE, Up));
+        assert_matches!(Key::Null.into(), key_press!(NONE, Null));
+        assert_matches!(Key::UnknownEscSeq.into(), key_press!(NONE, UnknownEscSeq));
+
+        assert_matches!(Key::Char('c').into(), key_press!(NONE, Char('c')));
+
+        assert_matches!(Key::F(3).into(), key_press!(NONE, F(3)));
+        assert_matches!(
+            Key::BracketedPasteStart.into(),
+            key_press!(NONE, BracketedPasteStart)
+        );
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -55,6 +55,21 @@ impl Key {
     pub const fn meta(self) -> KeyPress {
         self.with_mods(KeyMods::META)
     }
+
+    #[inline]
+    pub const fn meta_shift(self) -> KeyPress {
+        self.with_mods(KeyMods::META_SHIFT)
+    }
+
+    #[inline]
+    pub const fn ctrl_shift(self) -> KeyPress {
+        self.with_mods(KeyMods::CTRL_SHIFT)
+    }
+
+    #[inline]
+    pub const fn ctrl_meta_shift(self) -> KeyPress {
+        self.with_mods(KeyMods::CTRL_META_SHIFT)
+    }
 }
 
 bitflags::bitflags! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@
 //! }
 //! ```
 // #![feature(non_exhaustive)]
-
+#[macro_use]
+mod keys;
 pub mod completion;
 pub mod config;
 mod edit;
@@ -25,7 +26,6 @@ pub mod highlight;
 pub mod hint;
 pub mod history;
 mod keymap;
-mod keys;
 mod kill_ring;
 mod layout;
 pub mod line_buffer;
@@ -55,7 +55,7 @@ use crate::hint::Hinter;
 use crate::history::{Direction, History};
 pub use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
 use crate::keymap::{InputState, Refresher};
-pub use crate::keys::KeyPress;
+pub use crate::keys::{Key, KeyMods, KeyPress};
 use crate::kill_ring::{KillRing, Mode};
 use crate::line_buffer::WordAction;
 use crate::validate::Validator;

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -2,7 +2,7 @@
 use super::{assert_cursor, assert_line, assert_line_with_initial, init_editor};
 use crate::config::EditMode;
 use crate::error::ReadlineError;
-use crate::keys::KeyPress;
+use crate::keys::{Key, KeyPress};
 
 #[test]
 fn home_key() {
@@ -10,13 +10,13 @@ fn home_key() {
         assert_cursor(
             *mode,
             ("", ""),
-            &[KeyPress::Home, KeyPress::Enter],
+            &[Key::Home.into(), Key::Enter.into()],
             ("", ""),
         );
         assert_cursor(
             *mode,
             ("Hi", ""),
-            &[KeyPress::Home, KeyPress::Enter],
+            &[Key::Home.into(), Key::Enter.into()],
             ("", "Hi"),
         );
         if *mode == EditMode::Vi {
@@ -24,7 +24,7 @@ fn home_key() {
             assert_cursor(
                 *mode,
                 ("Hi", ""),
-                &[KeyPress::Esc, KeyPress::Home, KeyPress::Enter],
+                &[Key::Esc.into(), Key::Home.into(), Key::Enter.into()],
                 ("", "Hi"),
             );
         }
@@ -34,17 +34,17 @@ fn home_key() {
 #[test]
 fn end_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_cursor(*mode, ("", ""), &[KeyPress::End, KeyPress::Enter], ("", ""));
+        assert_cursor(*mode, ("", ""), &[KeyPress::END, KeyPress::ENTER], ("", ""));
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[KeyPress::End, KeyPress::Enter],
+            &[KeyPress::END, KeyPress::ENTER],
             ("Hi", ""),
         );
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[KeyPress::End, KeyPress::Enter],
+            &[KeyPress::END, KeyPress::ENTER],
             ("Hi", ""),
         );
         if *mode == EditMode::Vi {
@@ -52,7 +52,7 @@ fn end_key() {
             assert_cursor(
                 *mode,
                 ("", "Hi"),
-                &[KeyPress::Esc, KeyPress::End, KeyPress::Enter],
+                &[KeyPress::ESC, KeyPress::END, KeyPress::ENTER],
                 ("Hi", ""),
             );
         }
@@ -65,19 +65,19 @@ fn left_key() {
         assert_cursor(
             *mode,
             ("Hi", ""),
-            &[KeyPress::Left, KeyPress::Enter],
+            &[KeyPress::LEFT, KeyPress::ENTER],
             ("H", "i"),
         );
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[KeyPress::Left, KeyPress::Enter],
+            &[KeyPress::LEFT, KeyPress::ENTER],
             ("", "Hi"),
         );
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[KeyPress::Left, KeyPress::Enter],
+            &[KeyPress::LEFT, KeyPress::ENTER],
             ("", "Hi"),
         );
         if *mode == EditMode::Vi {
@@ -85,7 +85,7 @@ fn left_key() {
             assert_cursor(
                 *mode,
                 ("Bye", ""),
-                &[KeyPress::Esc, KeyPress::Left, KeyPress::Enter],
+                &[KeyPress::ESC, KeyPress::LEFT, KeyPress::ENTER],
                 ("B", "ye"),
             );
         }
@@ -98,25 +98,25 @@ fn right_key() {
         assert_cursor(
             *mode,
             ("", ""),
-            &[KeyPress::Right, KeyPress::Enter],
+            &[KeyPress::RIGHT, KeyPress::ENTER],
             ("", ""),
         );
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[KeyPress::Right, KeyPress::Enter],
+            &[KeyPress::RIGHT, KeyPress::ENTER],
             ("H", "i"),
         );
         assert_cursor(
             *mode,
             ("B", "ye"),
-            &[KeyPress::Right, KeyPress::Enter],
+            &[KeyPress::RIGHT, KeyPress::ENTER],
             ("By", "e"),
         );
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[KeyPress::Right, KeyPress::Enter],
+            &[KeyPress::RIGHT, KeyPress::ENTER],
             ("Hi", ""),
         );
         if *mode == EditMode::Vi {
@@ -124,7 +124,7 @@ fn right_key() {
             assert_cursor(
                 *mode,
                 ("", "Hi"),
-                &[KeyPress::Esc, KeyPress::Right, KeyPress::Enter],
+                &[KeyPress::ESC, KeyPress::RIGHT, KeyPress::ENTER],
                 ("H", "i"),
             );
         }
@@ -134,22 +134,22 @@ fn right_key() {
 #[test]
 fn enter_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[KeyPress::Enter], "");
-        assert_line(*mode, &[KeyPress::Char('a'), KeyPress::Enter], "a");
-        assert_line_with_initial(*mode, ("Hi", ""), &[KeyPress::Enter], "Hi");
-        assert_line_with_initial(*mode, ("", "Hi"), &[KeyPress::Enter], "Hi");
-        assert_line_with_initial(*mode, ("H", "i"), &[KeyPress::Enter], "Hi");
+        assert_line(*mode, &[KeyPress::ENTER], "");
+        assert_line(*mode, &[KeyPress::normal('a'), KeyPress::ENTER], "a");
+        assert_line_with_initial(*mode, ("Hi", ""), &[KeyPress::ENTER], "Hi");
+        assert_line_with_initial(*mode, ("", "Hi"), &[KeyPress::ENTER], "Hi");
+        assert_line_with_initial(*mode, ("H", "i"), &[KeyPress::ENTER], "Hi");
         if *mode == EditMode::Vi {
             // vi command mode
-            assert_line(*mode, &[KeyPress::Esc, KeyPress::Enter], "");
+            assert_line(*mode, &[KeyPress::ESC, KeyPress::ENTER], "");
             assert_line(
                 *mode,
-                &[KeyPress::Char('a'), KeyPress::Esc, KeyPress::Enter],
+                &[KeyPress::normal('a'), KeyPress::ESC, KeyPress::ENTER],
                 "a",
             );
-            assert_line_with_initial(*mode, ("Hi", ""), &[KeyPress::Esc, KeyPress::Enter], "Hi");
-            assert_line_with_initial(*mode, ("", "Hi"), &[KeyPress::Esc, KeyPress::Enter], "Hi");
-            assert_line_with_initial(*mode, ("H", "i"), &[KeyPress::Esc, KeyPress::Enter], "Hi");
+            assert_line_with_initial(*mode, ("Hi", ""), &[KeyPress::ESC, KeyPress::ENTER], "Hi");
+            assert_line_with_initial(*mode, ("", "Hi"), &[KeyPress::ESC, KeyPress::ENTER], "Hi");
+            assert_line_with_initial(*mode, ("H", "i"), &[KeyPress::ESC, KeyPress::ENTER], "Hi");
         }
     }
 }
@@ -157,14 +157,14 @@ fn enter_key() {
 #[test]
 fn newline_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[KeyPress::Ctrl('J')], "");
-        assert_line(*mode, &[KeyPress::Char('a'), KeyPress::Ctrl('J')], "a");
+        assert_line(*mode, &[KeyPress::ctrl('J')], "");
+        assert_line(*mode, &[KeyPress::normal('a'), KeyPress::ctrl('J')], "a");
         if *mode == EditMode::Vi {
             // vi command mode
-            assert_line(*mode, &[KeyPress::Esc, KeyPress::Ctrl('J')], "");
+            assert_line(*mode, &[KeyPress::ESC, KeyPress::ctrl('J')], "");
             assert_line(
                 *mode,
-                &[KeyPress::Char('a'), KeyPress::Esc, KeyPress::Ctrl('J')],
+                &[KeyPress::normal('a'), KeyPress::ESC, KeyPress::ctrl('J')],
                 "a",
             );
         }
@@ -174,36 +174,36 @@ fn newline_key() {
 #[test]
 fn eof_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        let mut editor = init_editor(*mode, &[KeyPress::Ctrl('D')]);
+        let mut editor = init_editor(*mode, &[KeyPress::ctrl('D')]);
         let err = editor.readline(">>");
         assert_matches!(err, Err(ReadlineError::Eof));
     }
     assert_line(
         EditMode::Emacs,
-        &[KeyPress::Char('a'), KeyPress::Ctrl('D'), KeyPress::Enter],
+        &[KeyPress::normal('a'), KeyPress::ctrl('D'), KeyPress::ENTER],
         "a",
     );
     assert_line(
         EditMode::Vi,
-        &[KeyPress::Char('a'), KeyPress::Ctrl('D')],
+        &[KeyPress::normal('a'), KeyPress::ctrl('D')],
         "a",
     );
     assert_line(
         EditMode::Vi,
-        &[KeyPress::Char('a'), KeyPress::Esc, KeyPress::Ctrl('D')],
+        &[KeyPress::normal('a'), KeyPress::ESC, KeyPress::ctrl('D')],
         "a",
     );
     assert_line_with_initial(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('D'), KeyPress::Enter],
+        &[KeyPress::ctrl('D'), KeyPress::ENTER],
         "i",
     );
-    assert_line_with_initial(EditMode::Vi, ("", "Hi"), &[KeyPress::Ctrl('D')], "Hi");
+    assert_line_with_initial(EditMode::Vi, ("", "Hi"), &[KeyPress::ctrl('D')], "Hi");
     assert_line_with_initial(
         EditMode::Vi,
         ("", "Hi"),
-        &[KeyPress::Esc, KeyPress::Ctrl('D')],
+        &[KeyPress::ESC, KeyPress::ctrl('D')],
         "Hi",
     );
 }
@@ -211,16 +211,16 @@ fn eof_key() {
 #[test]
 fn interrupt_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        let mut editor = init_editor(*mode, &[KeyPress::Ctrl('C')]);
+        let mut editor = init_editor(*mode, &[KeyPress::ctrl('C')]);
         let err = editor.readline(">>");
         assert_matches!(err, Err(ReadlineError::Interrupted));
 
-        let mut editor = init_editor(*mode, &[KeyPress::Ctrl('C')]);
+        let mut editor = init_editor(*mode, &[KeyPress::ctrl('C')]);
         let err = editor.readline_with_initial(">>", ("Hi", ""));
         assert_matches!(err, Err(ReadlineError::Interrupted));
         if *mode == EditMode::Vi {
             // vi command mode
-            let mut editor = init_editor(*mode, &[KeyPress::Esc, KeyPress::Ctrl('C')]);
+            let mut editor = init_editor(*mode, &[KeyPress::ESC, KeyPress::ctrl('C')]);
             let err = editor.readline_with_initial(">>", ("Hi", ""));
             assert_matches!(err, Err(ReadlineError::Interrupted));
         }
@@ -233,13 +233,13 @@ fn delete_key() {
         assert_cursor(
             *mode,
             ("a", ""),
-            &[KeyPress::Delete, KeyPress::Enter],
+            &[KeyPress::DELETE, KeyPress::ENTER],
             ("a", ""),
         );
         assert_cursor(
             *mode,
             ("", "a"),
-            &[KeyPress::Delete, KeyPress::Enter],
+            &[KeyPress::DELETE, KeyPress::ENTER],
             ("", ""),
         );
         if *mode == EditMode::Vi {
@@ -247,7 +247,7 @@ fn delete_key() {
             assert_cursor(
                 *mode,
                 ("", "a"),
-                &[KeyPress::Esc, KeyPress::Delete, KeyPress::Enter],
+                &[KeyPress::ESC, KeyPress::DELETE, KeyPress::ENTER],
                 ("", ""),
             );
         }
@@ -260,13 +260,13 @@ fn ctrl_t() {
         assert_cursor(
             *mode,
             ("a", "b"),
-            &[KeyPress::Ctrl('T'), KeyPress::Enter],
+            &[KeyPress::ctrl('T'), KeyPress::ENTER],
             ("ba", ""),
         );
         assert_cursor(
             *mode,
             ("ab", "cd"),
-            &[KeyPress::Ctrl('T'), KeyPress::Enter],
+            &[KeyPress::ctrl('T'), KeyPress::ENTER],
             ("acb", "d"),
         );
         if *mode == EditMode::Vi {
@@ -274,7 +274,7 @@ fn ctrl_t() {
             assert_cursor(
                 *mode,
                 ("ab", ""),
-                &[KeyPress::Esc, KeyPress::Ctrl('T'), KeyPress::Enter],
+                &[KeyPress::ESC, KeyPress::ctrl('T'), KeyPress::ENTER],
                 ("ba", ""),
             );
         }
@@ -287,13 +287,13 @@ fn ctrl_u() {
         assert_cursor(
             *mode,
             ("start of line ", "end"),
-            &[KeyPress::Ctrl('U'), KeyPress::Enter],
+            &[KeyPress::ctrl('U'), KeyPress::ENTER],
             ("", "end"),
         );
         assert_cursor(
             *mode,
             ("", "end"),
-            &[KeyPress::Ctrl('U'), KeyPress::Enter],
+            &[KeyPress::ctrl('U'), KeyPress::ENTER],
             ("", "end"),
         );
         if *mode == EditMode::Vi {
@@ -301,7 +301,7 @@ fn ctrl_u() {
             assert_cursor(
                 *mode,
                 ("start of line ", "end"),
-                &[KeyPress::Esc, KeyPress::Ctrl('U'), KeyPress::Enter],
+                &[KeyPress::ESC, KeyPress::ctrl('U'), KeyPress::ENTER],
                 ("", " end"),
             );
         }
@@ -315,7 +315,7 @@ fn ctrl_v() {
         assert_cursor(
             *mode,
             ("", ""),
-            &[KeyPress::Ctrl('V'), KeyPress::Char('\t'), KeyPress::Enter],
+            &[KeyPress::ctrl('V'), KeyPress::normal('\t'), KeyPress::ENTER],
             ("\t", ""),
         );
         if *mode == EditMode::Vi {
@@ -324,10 +324,10 @@ fn ctrl_v() {
                 *mode,
                 ("", ""),
                 &[
-                    KeyPress::Esc,
-                    KeyPress::Ctrl('V'),
-                    KeyPress::Char('\t'),
-                    KeyPress::Enter,
+                    KeyPress::ESC,
+                    KeyPress::ctrl('V'),
+                    KeyPress::normal('\t'),
+                    KeyPress::ENTER,
                 ],
                 ("\t", ""),
             );
@@ -341,13 +341,13 @@ fn ctrl_w() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[KeyPress::Ctrl('W'), KeyPress::Enter],
+            &[KeyPress::ctrl('W'), KeyPress::ENTER],
             ("", "world"),
         );
         assert_cursor(
             *mode,
             ("Hello, world.", ""),
-            &[KeyPress::Ctrl('W'), KeyPress::Enter],
+            &[KeyPress::ctrl('W'), KeyPress::ENTER],
             ("Hello, ", ""),
         );
         if *mode == EditMode::Vi {
@@ -355,7 +355,7 @@ fn ctrl_w() {
             assert_cursor(
                 *mode,
                 ("Hello, world.", ""),
-                &[KeyPress::Esc, KeyPress::Ctrl('W'), KeyPress::Enter],
+                &[KeyPress::ESC, KeyPress::ctrl('W'), KeyPress::ENTER],
                 ("Hello, ", "."),
             );
         }
@@ -368,7 +368,7 @@ fn ctrl_y() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[KeyPress::Ctrl('W'), KeyPress::Ctrl('Y'), KeyPress::Enter],
+            &[KeyPress::ctrl('W'), KeyPress::ctrl('Y'), KeyPress::ENTER],
             ("Hello, ", "world"),
         );
     }
@@ -380,7 +380,7 @@ fn ctrl__() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[KeyPress::Ctrl('W'), KeyPress::Ctrl('_'), KeyPress::Enter],
+            &[KeyPress::ctrl('W'), KeyPress::ctrl('_'), KeyPress::ENTER],
             ("Hello, ", "world"),
         );
         if *mode == EditMode::Vi {
@@ -389,10 +389,10 @@ fn ctrl__() {
                 *mode,
                 ("Hello, ", "world"),
                 &[
-                    KeyPress::Esc,
-                    KeyPress::Ctrl('W'),
-                    KeyPress::Ctrl('_'),
-                    KeyPress::Enter,
+                    KeyPress::ESC,
+                    KeyPress::ctrl('W'),
+                    KeyPress::ctrl('_'),
+                    KeyPress::ENTER,
                 ],
                 ("Hello,", " world"),
             );

--- a/src/test/emacs.rs
+++ b/src/test/emacs.rs
@@ -8,13 +8,13 @@ fn ctrl_a() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('A'), KeyPress::Enter],
+        &[KeyPress::ctrl('A'), KeyPress::ENTER],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("test test\n123", "foo"),
-        &[KeyPress::Ctrl('A'), KeyPress::Enter],
+        &[KeyPress::ctrl('A'), KeyPress::ENTER],
         ("test test\n", "123foo"),
     );
 }
@@ -24,13 +24,13 @@ fn ctrl_e() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('E'), KeyPress::Enter],
+        &[KeyPress::ctrl('E'), KeyPress::ENTER],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo", "test test\n123"),
-        &[KeyPress::Ctrl('E'), KeyPress::Enter],
+        &[KeyPress::ctrl('E'), KeyPress::ENTER],
         ("footest test", "\n123"),
     );
 }
@@ -40,23 +40,23 @@ fn ctrl_b() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('B'), KeyPress::Enter],
+        &[KeyPress::ctrl('B'), KeyPress::ENTER],
         ("H", "i"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Meta('2'), KeyPress::Ctrl('B'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::ctrl('B'), KeyPress::ENTER],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
         &[
-            KeyPress::Meta('-'),
-            KeyPress::Meta('2'),
-            KeyPress::Ctrl('B'),
-            KeyPress::Enter,
+            KeyPress::meta('-'),
+            KeyPress::meta('2'),
+            KeyPress::ctrl('B'),
+            KeyPress::ENTER,
         ],
         ("Hi", ""),
     );
@@ -67,23 +67,23 @@ fn ctrl_f() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('F'), KeyPress::Enter],
+        &[KeyPress::ctrl('F'), KeyPress::ENTER],
         ("H", "i"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Meta('2'), KeyPress::Ctrl('F'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::ctrl('F'), KeyPress::ENTER],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
         &[
-            KeyPress::Meta('-'),
-            KeyPress::Meta('2'),
-            KeyPress::Ctrl('F'),
-            KeyPress::Enter,
+            KeyPress::meta('-'),
+            KeyPress::meta('2'),
+            KeyPress::ctrl('F'),
+            KeyPress::ENTER,
         ],
         ("", "Hi"),
     );
@@ -94,23 +94,23 @@ fn ctrl_h() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('H'), KeyPress::Enter],
+        &[KeyPress::ctrl('H'), KeyPress::ENTER],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Meta('2'), KeyPress::Ctrl('H'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::ctrl('H'), KeyPress::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
         &[
-            KeyPress::Meta('-'),
-            KeyPress::Meta('2'),
-            KeyPress::Ctrl('H'),
-            KeyPress::Enter,
+            KeyPress::meta('-'),
+            KeyPress::meta('2'),
+            KeyPress::ctrl('H'),
+            KeyPress::ENTER,
         ],
         ("", ""),
     );
@@ -121,19 +121,19 @@ fn backspace() {
     assert_cursor(
         EditMode::Emacs,
         ("", ""),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[KeyPress::BACKSPACE, KeyPress::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[KeyPress::BACKSPACE, KeyPress::ENTER],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[KeyPress::BACKSPACE, KeyPress::ENTER],
         ("", "Hi"),
     );
 }
@@ -143,37 +143,37 @@ fn ctrl_k() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[KeyPress::ctrl('K'), KeyPress::ENTER],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[KeyPress::ctrl('K'), KeyPress::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("B", "ye"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[KeyPress::ctrl('K'), KeyPress::ENTER],
         ("B", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "foo\nbar"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[KeyPress::ctrl('K'), KeyPress::ENTER],
         ("Hi", "\nbar"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "\nbar"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[KeyPress::ctrl('K'), KeyPress::ENTER],
         ("Hi", "bar"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "bar"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[KeyPress::ctrl('K'), KeyPress::ENTER],
         ("Hi", ""),
     );
 }
@@ -183,37 +183,37 @@ fn ctrl_u() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[KeyPress::ctrl('U'), KeyPress::ENTER],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[KeyPress::ctrl('U'), KeyPress::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("B", "ye"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[KeyPress::ctrl('U'), KeyPress::ENTER],
         ("", "ye"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo\nbar", "Hi"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[KeyPress::ctrl('U'), KeyPress::ENTER],
         ("foo\n", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo\n", "Hi"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[KeyPress::ctrl('U'), KeyPress::ENTER],
         ("foo", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo", "Hi"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[KeyPress::ctrl('U'), KeyPress::ENTER],
         ("", "Hi"),
     );
 }
@@ -223,10 +223,10 @@ fn ctrl_n() {
         EditMode::Emacs,
         &["line1", "line2"],
         &[
-            KeyPress::Ctrl('P'),
-            KeyPress::Ctrl('P'),
-            KeyPress::Ctrl('N'),
-            KeyPress::Enter,
+            KeyPress::ctrl('P'),
+            KeyPress::ctrl('P'),
+            KeyPress::ctrl('N'),
+            KeyPress::ENTER,
         ],
         "",
         ("line2", ""),
@@ -238,7 +238,7 @@ fn ctrl_p() {
     assert_history(
         EditMode::Emacs,
         &["line1"],
-        &[KeyPress::Ctrl('P'), KeyPress::Enter],
+        &[KeyPress::ctrl('P'), KeyPress::ENTER],
         "",
         ("line1", ""),
     );
@@ -249,7 +249,7 @@ fn ctrl_t() {
     /* FIXME
     assert_cursor(
         ("ab", "cd"),
-        &[KeyPress::Meta('2'), KeyPress::Ctrl('T'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::ctrl('T'), KeyPress::ENTER],
         ("acdb", ""),
     );*/
 }
@@ -260,10 +260,10 @@ fn ctrl_x_ctrl_u() {
         EditMode::Emacs,
         ("Hello, ", "world"),
         &[
-            KeyPress::Ctrl('W'),
-            KeyPress::Ctrl('X'),
-            KeyPress::Ctrl('U'),
-            KeyPress::Enter,
+            KeyPress::ctrl('W'),
+            KeyPress::ctrl('X'),
+            KeyPress::ctrl('U'),
+            KeyPress::ENTER,
         ],
         ("Hello, ", "world"),
     );
@@ -274,19 +274,19 @@ fn meta_b() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[KeyPress::Meta('B'), KeyPress::Enter],
+        &[KeyPress::meta('B'), KeyPress::ENTER],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[KeyPress::Meta('2'), KeyPress::Meta('B'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::meta('B'), KeyPress::ENTER],
         ("", "Hello, world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[KeyPress::Meta('-'), KeyPress::Meta('B'), KeyPress::Enter],
+        &[KeyPress::meta('-'), KeyPress::meta('B'), KeyPress::ENTER],
         ("Hello", ", world!"),
     );
 }
@@ -296,19 +296,19 @@ fn meta_f() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[KeyPress::Meta('F'), KeyPress::Enter],
+        &[KeyPress::meta('F'), KeyPress::ENTER],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('F'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::meta('F'), KeyPress::ENTER],
         ("Hello, world", "!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[KeyPress::Meta('-'), KeyPress::Meta('F'), KeyPress::Enter],
+        &[KeyPress::meta('-'), KeyPress::meta('F'), KeyPress::ENTER],
         ("Hello, ", "world!"),
     );
 }
@@ -318,19 +318,19 @@ fn meta_c() {
     assert_cursor(
         EditMode::Emacs,
         ("hi", ""),
-        &[KeyPress::Meta('C'), KeyPress::Enter],
+        &[KeyPress::meta('C'), KeyPress::ENTER],
         ("hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "hi"),
-        &[KeyPress::Meta('C'), KeyPress::Enter],
+        &[KeyPress::meta('C'), KeyPress::ENTER],
         ("Hi", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "hi test"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('C'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::meta('C'), KeyPress::ENTER],
         ("Hi Test", ""),
     );*/
 }
@@ -340,19 +340,19 @@ fn meta_l() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Meta('L'), KeyPress::Enter],
+        &[KeyPress::meta('L'), KeyPress::ENTER],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "HI"),
-        &[KeyPress::Meta('L'), KeyPress::Enter],
+        &[KeyPress::meta('L'), KeyPress::ENTER],
         ("hi", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "HI TEST"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('L'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::meta('L'), KeyPress::ENTER],
         ("hi test", ""),
     );*/
 }
@@ -362,19 +362,19 @@ fn meta_u() {
     assert_cursor(
         EditMode::Emacs,
         ("hi", ""),
-        &[KeyPress::Meta('U'), KeyPress::Enter],
+        &[KeyPress::meta('U'), KeyPress::ENTER],
         ("hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "hi"),
-        &[KeyPress::Meta('U'), KeyPress::Enter],
+        &[KeyPress::meta('U'), KeyPress::ENTER],
         ("HI", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "hi test"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('U'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::meta('U'), KeyPress::ENTER],
         ("HI TEST", ""),
     );*/
 }
@@ -384,13 +384,13 @@ fn meta_d() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[KeyPress::Meta('D'), KeyPress::Enter],
+        &[KeyPress::meta('D'), KeyPress::ENTER],
         ("Hello", "!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('D'), KeyPress::Enter],
+        &[KeyPress::meta('2'), KeyPress::meta('D'), KeyPress::ENTER],
         ("Hello", ""),
     );
 }
@@ -400,13 +400,13 @@ fn meta_t() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[KeyPress::Meta('T'), KeyPress::Enter],
+        &[KeyPress::meta('T'), KeyPress::ENTER],
         ("world, Hello", "!"),
     );
     /* FIXME
     assert_cursor(
         ("One Two", " Three Four"),
-        &[KeyPress::Meta('T'), KeyPress::Enter],
+        &[KeyPress::meta('T'), KeyPress::ENTER],
         ("One Four Three Two", ""),
     );*/
 }
@@ -417,12 +417,12 @@ fn meta_y() {
         EditMode::Emacs,
         ("Hello, world", "!"),
         &[
-            KeyPress::Ctrl('W'),
-            KeyPress::Left,
-            KeyPress::Ctrl('W'),
-            KeyPress::Ctrl('Y'),
-            KeyPress::Meta('Y'),
-            KeyPress::Enter,
+            KeyPress::ctrl('W'),
+            KeyPress::LEFT,
+            KeyPress::ctrl('W'),
+            KeyPress::ctrl('Y'),
+            KeyPress::meta('Y'),
+            KeyPress::ENTER,
         ],
         ("world", " !"),
     );
@@ -433,7 +433,7 @@ fn meta_backspace() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, wor", "ld!"),
-        &[KeyPress::Meta('\x08'), KeyPress::Enter],
+        &[KeyPress::meta('\x08'), KeyPress::ENTER],
         ("Hello, ", "ld!"),
     );
 }
@@ -443,7 +443,7 @@ fn meta_digit() {
     assert_cursor(
         EditMode::Emacs,
         ("", ""),
-        &[KeyPress::Meta('3'), KeyPress::Char('h'), KeyPress::Enter],
+        &[KeyPress::meta('3'), KeyPress::normal('h'), KeyPress::ENTER],
         ("hhh", ""),
     );
 }

--- a/src/test/history.rs
+++ b/src/test/history.rs
@@ -9,14 +9,14 @@ fn down_key() {
         assert_history(
             *mode,
             &["line1"],
-            &[KeyPress::Down, KeyPress::Enter],
+            &[KeyPress::DOWN, KeyPress::ENTER],
             "",
             ("", ""),
         );
         assert_history(
             *mode,
             &["line1", "line2"],
-            &[KeyPress::Up, KeyPress::Up, KeyPress::Down, KeyPress::Enter],
+            &[KeyPress::UP, KeyPress::UP, KeyPress::DOWN, KeyPress::ENTER],
             "",
             ("line2", ""),
         );
@@ -24,10 +24,10 @@ fn down_key() {
             *mode,
             &["line1"],
             &[
-                KeyPress::Char('a'),
-                KeyPress::Up,
-                KeyPress::Down, // restore original line
-                KeyPress::Enter,
+                KeyPress::from('a'),
+                KeyPress::UP,
+                KeyPress::DOWN, // restore original line
+                KeyPress::ENTER,
             ],
             "",
             ("a", ""),
@@ -36,9 +36,9 @@ fn down_key() {
             *mode,
             &["line1"],
             &[
-                KeyPress::Char('a'),
-                KeyPress::Down, // noop
-                KeyPress::Enter,
+                KeyPress::from('a'),
+                KeyPress::DOWN, // noop
+                KeyPress::ENTER,
             ],
             "",
             ("a", ""),
@@ -49,18 +49,18 @@ fn down_key() {
 #[test]
 fn up_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_history(*mode, &[], &[KeyPress::Up, KeyPress::Enter], "", ("", ""));
+        assert_history(*mode, &[], &[KeyPress::UP, KeyPress::ENTER], "", ("", ""));
         assert_history(
             *mode,
             &["line1"],
-            &[KeyPress::Up, KeyPress::Enter],
+            &[KeyPress::UP, KeyPress::ENTER],
             "",
             ("line1", ""),
         );
         assert_history(
             *mode,
             &["line1", "line2"],
-            &[KeyPress::Up, KeyPress::Up, KeyPress::Enter],
+            &[KeyPress::UP, KeyPress::UP, KeyPress::ENTER],
             "",
             ("line1", ""),
         );
@@ -73,7 +73,7 @@ fn ctrl_r() {
         assert_history(
             *mode,
             &[],
-            &[KeyPress::Ctrl('R'), KeyPress::Char('o'), KeyPress::Enter],
+            &[KeyPress::ctrl('R'), KeyPress::from('o'), KeyPress::ENTER],
             "",
             ("o", ""),
         );
@@ -81,10 +81,10 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('o'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                KeyPress::ctrl('R'),
+                KeyPress::from('o'),
+                KeyPress::RIGHT, // just to assert cursor pos
+                KeyPress::ENTER,
             ],
             "",
             ("cargo", ""),
@@ -93,10 +93,10 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('u'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                KeyPress::ctrl('R'),
+                KeyPress::from('u'),
+                KeyPress::RIGHT, // just to assert cursor pos
+                KeyPress::ENTER,
             ],
             "",
             ("ru", "stc"),
@@ -105,11 +105,11 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Char('u'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                KeyPress::ctrl('R'),
+                KeyPress::from('r'),
+                KeyPress::from('u'),
+                KeyPress::RIGHT, // just to assert cursor pos
+                KeyPress::ENTER,
             ],
             "",
             ("r", "ustc"),
@@ -118,11 +118,11 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Ctrl('R'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                KeyPress::ctrl('R'),
+                KeyPress::from('r'),
+                KeyPress::ctrl('R'),
+                KeyPress::RIGHT, // just to assert cursor pos
+                KeyPress::ENTER,
             ],
             "",
             ("r", "ustc"),
@@ -131,11 +131,11 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Char('z'), // no match
-                KeyPress::Right,     // just to assert cursor pos
-                KeyPress::Enter,
+                KeyPress::ctrl('R'),
+                KeyPress::from('r'),
+                KeyPress::from('z'), // no match
+                KeyPress::RIGHT,     // just to assert cursor pos
+                KeyPress::ENTER,
             ],
             "",
             ("car", "go"),
@@ -144,11 +144,11 @@ fn ctrl_r() {
             EditMode::Emacs,
             &["rustc", "cargo"],
             &[
-                KeyPress::Char('a'),
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Ctrl('G'), // abort (FIXME: doesn't work with vi mode)
-                KeyPress::Enter,
+                KeyPress::from('a'),
+                KeyPress::ctrl('R'),
+                KeyPress::from('r'),
+                KeyPress::ctrl('G'), // abort (FIXME: doesn't work with vi mode)
+                KeyPress::ENTER,
             ],
             "",
             ("a", ""),
@@ -162,7 +162,7 @@ fn ctrl_r_with_long_prompt() {
         assert_history(
             *mode,
             &["rustc", "cargo"],
-            &[KeyPress::Ctrl('R'), KeyPress::Char('o'), KeyPress::Enter],
+            &[KeyPress::ctrl('R'), KeyPress::from('o'), KeyPress::ENTER],
             ">>>>>>>>>>>>>>>>>>>>>>>>>>> ",
             ("cargo", ""),
         );
@@ -176,12 +176,12 @@ fn ctrl_s() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Ctrl('R'),
-                KeyPress::Ctrl('S'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                KeyPress::ctrl('R'),
+                KeyPress::from('r'),
+                KeyPress::ctrl('R'),
+                KeyPress::ctrl('S'),
+                KeyPress::RIGHT, // just to assert cursor pos
+                KeyPress::ENTER,
             ],
             "",
             ("car", "go"),
@@ -194,14 +194,14 @@ fn meta_lt() {
     assert_history(
         EditMode::Emacs,
         &[""],
-        &[KeyPress::Meta('<'), KeyPress::Enter],
+        &[KeyPress::meta('<'), KeyPress::ENTER],
         "",
         ("", ""),
     );
     assert_history(
         EditMode::Emacs,
         &["rustc", "cargo"],
-        &[KeyPress::Meta('<'), KeyPress::Enter],
+        &[KeyPress::meta('<'), KeyPress::ENTER],
         "",
         ("rustc", ""),
     );
@@ -212,14 +212,14 @@ fn meta_gt() {
     assert_history(
         EditMode::Emacs,
         &[""],
-        &[KeyPress::Meta('>'), KeyPress::Enter],
+        &[KeyPress::meta('>'), KeyPress::ENTER],
         "",
         ("", ""),
     );
     assert_history(
         EditMode::Emacs,
         &["rustc", "cargo"],
-        &[KeyPress::Meta('<'), KeyPress::Meta('>'), KeyPress::Enter],
+        &[KeyPress::meta('<'), KeyPress::meta('>'), KeyPress::ENTER],
         "",
         ("", ""),
     );
@@ -227,10 +227,10 @@ fn meta_gt() {
         EditMode::Emacs,
         &["rustc", "cargo"],
         &[
-            KeyPress::Char('a'),
-            KeyPress::Meta('<'),
-            KeyPress::Meta('>'), // restore original line
-            KeyPress::Enter,
+            KeyPress::from('a'),
+            KeyPress::meta('<'),
+            KeyPress::meta('>'), // restore original line
+            KeyPress::ENTER,
         ],
         "",
         ("a", ""),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -8,7 +8,7 @@ use crate::edit::init_state;
 use crate::highlight::Highlighter;
 use crate::hint::Hinter;
 use crate::keymap::{Cmd, InputState};
-use crate::keys::KeyPress;
+use crate::keys::{Key, KeyPress};
 use crate::tty::Sink;
 use crate::validate::Validator;
 use crate::{Context, Editor, Helper, Result};
@@ -54,7 +54,7 @@ fn complete_line() {
     let mut s = init_state(&mut out, "rus", 3, helper.as_ref(), &history);
     let config = Config::default();
     let mut input_state = InputState::new(&config, Arc::new(RwLock::new(HashMap::new())));
-    let keys = vec![KeyPress::Enter];
+    let keys = vec![KeyPress::ENTER];
     let mut rdr: IntoIter<KeyPress> = keys.into_iter();
     let cmd = super::complete_line(&mut rdr, &mut s, &mut input_state, &Config::default()).unwrap();
     assert_eq!(Some(Cmd::AcceptLine), cmd);
@@ -118,7 +118,7 @@ fn assert_history(
 #[test]
 fn unknown_esc_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[KeyPress::UnknownEscSeq, KeyPress::Enter], "");
+        assert_line(*mode, &[Key::UnknownEscSeq.into(), KeyPress::ENTER], "");
     }
 }
 

--- a/src/test/vi_cmd.rs
+++ b/src/test/vi_cmd.rs
@@ -8,7 +8,7 @@ fn dollar() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hi"),
-        &[KeyPress::Esc, KeyPress::Char('$'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('$'), KeyPress::ENTER],
         ("Hi", ""), // FIXME
     );
 }
@@ -24,11 +24,11 @@ fn semi_colon() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('f'),
-            KeyPress::Char('o'),
-            KeyPress::Char(';'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('f'),
+            KeyPress::from('o'),
+            KeyPress::from(';'),
+            KeyPress::ENTER,
         ],
         ("Hello, w", "orld!"),
     );
@@ -40,11 +40,11 @@ fn comma() {
         EditMode::Vi,
         ("Hello, w", "orld!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('f'),
-            KeyPress::Char('l'),
-            KeyPress::Char(','),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('f'),
+            KeyPress::from('l'),
+            KeyPress::from(','),
+            KeyPress::ENTER,
         ],
         ("Hel", "lo, world!"),
     );
@@ -55,7 +55,7 @@ fn zero() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[KeyPress::Esc, KeyPress::Char('0'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('0'), KeyPress::ENTER],
         ("", "Hi"),
     );
 }
@@ -65,7 +65,7 @@ fn caret() {
     assert_cursor(
         EditMode::Vi,
         (" Hi", ""),
-        &[KeyPress::Esc, KeyPress::Char('^'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('^'), KeyPress::ENTER],
         (" ", "Hi"),
     );
 }
@@ -76,10 +76,10 @@ fn a() {
         EditMode::Vi,
         ("B", "e"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('a'),
-            KeyPress::Char('y'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('a'),
+            KeyPress::from('y'),
+            KeyPress::ENTER,
         ],
         ("By", "e"),
     );
@@ -91,10 +91,10 @@ fn uppercase_a() {
         EditMode::Vi,
         ("", "By"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('A'),
-            KeyPress::Char('e'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('A'),
+            KeyPress::from('e'),
+            KeyPress::ENTER,
         ],
         ("Bye", ""),
     );
@@ -105,17 +105,17 @@ fn b() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[KeyPress::Esc, KeyPress::Char('b'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('b'), KeyPress::ENTER],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('b'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('2'),
+            KeyPress::from('b'),
+            KeyPress::ENTER,
         ],
         ("Hello", ", world!"),
     );
@@ -126,17 +126,17 @@ fn uppercase_b() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[KeyPress::Esc, KeyPress::Char('B'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('B'), KeyPress::ENTER],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('B'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('2'),
+            KeyPress::from('B'),
+            KeyPress::ENTER,
         ],
         ("", "Hello, world!"),
     );
@@ -148,10 +148,10 @@ fn uppercase_c() {
         EditMode::Vi,
         ("Hello, w", "orld!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('C'),
-            KeyPress::Char('i'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('C'),
+            KeyPress::from('i'),
+            KeyPress::ENTER,
         ],
         ("Hello, i", ""),
     );
@@ -159,23 +159,23 @@ fn uppercase_c() {
 
 #[test]
 fn ctrl_k() {
-    for key in &[KeyPress::Char('D'), KeyPress::Ctrl('K')] {
+    for key in &[KeyPress::from('D'), KeyPress::ctrl('K')] {
         assert_cursor(
             EditMode::Vi,
             ("Hi", ""),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             ("H", ""),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             ("", ""),
         );
         assert_cursor(
             EditMode::Vi,
             ("By", "e"),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             ("B", ""),
         );
     }
@@ -186,17 +186,17 @@ fn e() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[KeyPress::Esc, KeyPress::Char('e'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('e'), KeyPress::ENTER],
         ("Hell", "o, world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('e'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('2'),
+            KeyPress::from('e'),
+            KeyPress::ENTER,
         ],
         ("Hello, worl", "d!"),
     );
@@ -207,17 +207,17 @@ fn uppercase_e() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[KeyPress::Esc, KeyPress::Char('E'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('E'), KeyPress::ENTER],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('E'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('2'),
+            KeyPress::from('E'),
+            KeyPress::ENTER,
         ],
         ("Hello, world", "!"),
     );
@@ -229,10 +229,10 @@ fn f() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('f'),
-            KeyPress::Char('r'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('f'),
+            KeyPress::from('r'),
+            KeyPress::ENTER,
         ],
         ("Hello, wo", "rld!"),
     );
@@ -240,11 +240,11 @@ fn f() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('3'),
-            KeyPress::Char('f'),
-            KeyPress::Char('l'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('3'),
+            KeyPress::from('f'),
+            KeyPress::from('l'),
+            KeyPress::ENTER,
         ],
         ("Hello, wor", "ld!"),
     );
@@ -256,10 +256,10 @@ fn uppercase_f() {
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('F'),
-            KeyPress::Char('r'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('F'),
+            KeyPress::from('r'),
+            KeyPress::ENTER,
         ],
         ("Hello, wo", "rld!"),
     );
@@ -267,11 +267,11 @@ fn uppercase_f() {
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('3'),
-            KeyPress::Char('F'),
-            KeyPress::Char('l'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('3'),
+            KeyPress::from('F'),
+            KeyPress::from('l'),
+            KeyPress::ENTER,
         ],
         ("He", "llo, world!"),
     );
@@ -283,10 +283,10 @@ fn i() {
         EditMode::Vi,
         ("Be", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('i'),
-            KeyPress::Char('y'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('i'),
+            KeyPress::from('y'),
+            KeyPress::ENTER,
         ],
         ("By", "e"),
     );
@@ -298,10 +298,10 @@ fn uppercase_i() {
         EditMode::Vi,
         ("Be", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('I'),
-            KeyPress::Char('y'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('I'),
+            KeyPress::from('y'),
+            KeyPress::ENTER,
         ],
         ("y", "Be"),
     );
@@ -313,10 +313,10 @@ fn u() {
         EditMode::Vi,
         ("Hello, ", "world"),
         &[
-            KeyPress::Esc,
-            KeyPress::Ctrl('W'),
-            KeyPress::Char('u'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::ctrl('W'),
+            KeyPress::from('u'),
+            KeyPress::ENTER,
         ],
         ("Hello,", " world"),
     );
@@ -327,17 +327,17 @@ fn w() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[KeyPress::Esc, KeyPress::Char('w'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('w'), KeyPress::ENTER],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('w'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('2'),
+            KeyPress::from('w'),
+            KeyPress::ENTER,
         ],
         ("Hello, ", "world!"),
     );
@@ -348,17 +348,17 @@ fn uppercase_w() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[KeyPress::Esc, KeyPress::Char('W'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('W'), KeyPress::ENTER],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('W'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('2'),
+            KeyPress::from('W'),
+            KeyPress::ENTER,
         ],
         ("Hello, world", "!"),
     );
@@ -369,7 +369,7 @@ fn x() {
     assert_cursor(
         EditMode::Vi,
         ("", "a"),
-        &[KeyPress::Esc, KeyPress::Char('x'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('x'), KeyPress::ENTER],
         ("", ""),
     );
 }
@@ -379,7 +379,7 @@ fn uppercase_x() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[KeyPress::Esc, KeyPress::Char('X'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('X'), KeyPress::ENTER],
         ("", "i"),
     );
 }
@@ -387,20 +387,20 @@ fn uppercase_x() {
 #[test]
 fn h() {
     for key in &[
-        KeyPress::Char('h'),
-        KeyPress::Ctrl('H'),
-        KeyPress::Backspace,
+        KeyPress::from('h'),
+        KeyPress::ctrl('H'),
+        KeyPress::BACKSPACE,
     ] {
         assert_cursor(
             EditMode::Vi,
             ("Bye", ""),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             ("B", "ye"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Bye", ""),
-            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            &[KeyPress::ESC, KeyPress::from('2'), *key, KeyPress::ENTER],
             ("", "Bye"),
         );
     }
@@ -408,17 +408,17 @@ fn h() {
 
 #[test]
 fn l() {
-    for key in &[KeyPress::Char('l'), KeyPress::Char(' ')] {
+    for key in &[KeyPress::from('l'), KeyPress::from(' ')] {
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             ("H", "i"),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            &[KeyPress::ESC, KeyPress::from('2'), *key, KeyPress::ENTER],
             ("Hi", ""),
         );
     }
@@ -426,25 +426,26 @@ fn l() {
 
 #[test]
 fn j() {
-    for key in &[KeyPress::Char('j'), KeyPress::Char('+')] {
+    for key in &[KeyPress::from('j'), KeyPress::from('+')] {
+
         assert_cursor(
             EditMode::Vi,
             ("Hel", "lo,\nworld!"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             ("Hello,\nwo", "rld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "One\nTwo\nThree"),
-            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            &[KeyPress::ESC, KeyPress::from('2'), *key, KeyPress::ENTER],
             ("One\nTwo\n", "Three"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Hel", "lo,\nworld!"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, KeyPress::Char('7'), *key, KeyPress::Enter],
+            &[KeyPress::ESC, KeyPress::from('7'), *key, KeyPress::ENTER],
             ("Hello,\nwo", "rld!"),
         );
     }
@@ -452,32 +453,32 @@ fn j() {
 
 #[test]
 fn k() {
-    for key in &[KeyPress::Char('k'), KeyPress::Char('-')] {
+    for key in &[KeyPress::from('k'), KeyPress::from('-')] {
         assert_cursor(
             EditMode::Vi,
             ("Hello,\nworl", "d!"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             ("Hel", "lo,\nworld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("One\nTwo\nT", "hree"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            &[KeyPress::ESC, KeyPress::from('2'), *key, KeyPress::ENTER],
             ("", "One\nTwo\nThree"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Hello,\nworl", "d!"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, KeyPress::Char('5'), *key, KeyPress::Enter],
+            &[KeyPress::ESC, KeyPress::from('5'), *key, KeyPress::ENTER],
             ("Hel", "lo,\nworld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("first line\nshort\nlong line", ""),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             ("first line\nshort", "\nlong line"),
         );
     }
@@ -485,16 +486,16 @@ fn k() {
 
 #[test]
 fn ctrl_n() {
-    for key in &[KeyPress::Ctrl('N')] {
+    for key in &[KeyPress::ctrl('N')] {
         assert_history(
             EditMode::Vi,
             &["line1", "line2"],
             &[
-                KeyPress::Esc,
-                KeyPress::Ctrl('P'),
-                KeyPress::Ctrl('P'),
+                KeyPress::ESC,
+                KeyPress::ctrl('P'),
+                KeyPress::ctrl('P'),
                 *key,
-                KeyPress::Enter,
+                KeyPress::ENTER,
             ],
             "",
             ("line2", ""),
@@ -504,11 +505,11 @@ fn ctrl_n() {
 
 #[test]
 fn ctrl_p() {
-    for key in &[KeyPress::Ctrl('P')] {
+    for key in &[KeyPress::ctrl('P')] {
         assert_history(
             EditMode::Vi,
             &["line1"],
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[KeyPress::ESC, *key, KeyPress::ENTER],
             "",
             ("line1", ""),
         );
@@ -521,10 +522,10 @@ fn p() {
         EditMode::Vi,
         ("Hello, ", "world"),
         &[
-            KeyPress::Esc,
-            KeyPress::Ctrl('W'),
-            KeyPress::Char('p'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::ctrl('W'),
+            KeyPress::from('p'),
+            KeyPress::ENTER,
         ],
         (" Hello", ",world"),
     );
@@ -536,10 +537,10 @@ fn uppercase_p() {
         EditMode::Vi,
         ("Hello, ", "world"),
         &[
-            KeyPress::Esc,
-            KeyPress::Ctrl('W'),
-            KeyPress::Char('P'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::ctrl('W'),
+            KeyPress::from('P'),
+            KeyPress::ENTER,
         ],
         ("Hello", ", world"),
     );
@@ -551,10 +552,10 @@ fn r() {
         EditMode::Vi,
         ("Hi", ", world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('r'),
-            KeyPress::Char('o'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('r'),
+            KeyPress::from('o'),
+            KeyPress::ENTER,
         ],
         ("H", "o, world!"),
     );
@@ -562,11 +563,11 @@ fn r() {
         EditMode::Vi,
         ("He", "llo, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('4'),
-            KeyPress::Char('r'),
-            KeyPress::Char('i'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('4'),
+            KeyPress::from('r'),
+            KeyPress::from('i'),
+            KeyPress::ENTER,
         ],
         ("Hiii", "i, world!"),
     );
@@ -578,10 +579,10 @@ fn s() {
         EditMode::Vi,
         ("Hi", ", world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('s'),
-            KeyPress::Char('o'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('s'),
+            KeyPress::from('o'),
+            KeyPress::ENTER,
         ],
         ("Ho", ", world!"),
     );
@@ -589,11 +590,11 @@ fn s() {
         EditMode::Vi,
         ("He", "llo, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('4'),
-            KeyPress::Char('s'),
-            KeyPress::Char('i'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('4'),
+            KeyPress::from('s'),
+            KeyPress::from('i'),
+            KeyPress::ENTER,
         ],
         ("Hi", ", world!"),
     );
@@ -604,7 +605,7 @@ fn uppercase_s() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, ", "world"),
-        &[KeyPress::Esc, KeyPress::Char('S'), KeyPress::Enter],
+        &[KeyPress::ESC, KeyPress::from('S'), KeyPress::ENTER],
         ("", ""),
     );
 }
@@ -615,10 +616,10 @@ fn t() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('t'),
-            KeyPress::Char('r'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('t'),
+            KeyPress::from('r'),
+            KeyPress::ENTER,
         ],
         ("Hello, w", "orld!"),
     );
@@ -626,11 +627,11 @@ fn t() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('3'),
-            KeyPress::Char('t'),
-            KeyPress::Char('l'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('3'),
+            KeyPress::from('t'),
+            KeyPress::from('l'),
+            KeyPress::ENTER,
         ],
         ("Hello, wo", "rld!"),
     );
@@ -642,10 +643,10 @@ fn uppercase_t() {
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('T'),
-            KeyPress::Char('r'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('T'),
+            KeyPress::from('r'),
+            KeyPress::ENTER,
         ],
         ("Hello, wor", "ld!"),
     );
@@ -653,11 +654,11 @@ fn uppercase_t() {
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('3'),
-            KeyPress::Char('T'),
-            KeyPress::Char('l'),
-            KeyPress::Enter,
+            KeyPress::ESC,
+            KeyPress::from('3'),
+            KeyPress::from('T'),
+            KeyPress::from('l'),
+            KeyPress::ENTER,
         ],
         ("Hel", "lo, world!"),
     );

--- a/src/test/vi_insert.rs
+++ b/src/test/vi_insert.rs
@@ -8,7 +8,7 @@ fn insert_mode_by_default() {
     assert_cursor(
         EditMode::Vi,
         ("", ""),
-        &[KeyPress::Char('a'), KeyPress::Enter],
+        &[KeyPress::from('a'), KeyPress::ENTER],
         ("a", ""),
     );
 }
@@ -18,7 +18,7 @@ fn ctrl_h() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[KeyPress::Ctrl('H'), KeyPress::Enter],
+        &[KeyPress::ctrl('H'), KeyPress::ENTER],
         ("H", ""),
     );
 }
@@ -28,19 +28,19 @@ fn backspace() {
     assert_cursor(
         EditMode::Vi,
         ("", ""),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[KeyPress::BACKSPACE, KeyPress::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[KeyPress::BACKSPACE, KeyPress::ENTER],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hi"),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[KeyPress::BACKSPACE, KeyPress::ENTER],
         ("", "Hi"),
     );
 }
@@ -50,7 +50,7 @@ fn esc() {
     assert_cursor(
         EditMode::Vi,
         ("", ""),
-        &[KeyPress::Char('a'), KeyPress::Esc, KeyPress::Enter],
+        &[KeyPress::from('a'), KeyPress::ESC, KeyPress::ENTER],
         ("", "a"),
     );
 }

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -49,7 +49,7 @@ impl RawReader for IntoIter<KeyPress> {
     #[cfg(unix)]
     fn next_char(&mut self) -> Result<char> {
         match self.next() {
-            Some(KeyPress::Char(c)) => Ok(c),
+            Some(key_press!(Char(c))) => Ok(c),
             None => Err(ReadlineError::Eof),
             _ => unimplemented!(),
         }


### PR DESCRIPTION
Also refactor the escape seq. parser to be data-driven, making it easy to add support for these.

Fixes #318 , maybe some others. Big breaking change, but I tried to make the changes not as painful as they naively would be. 

I need to test more, it's late, no rush on this review (It's big, but most of the parts were for updating code with the changes), it just bugged me is all.