### PR TITLE
Bugfixes/consistency improvements for multiline stuff

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -451,6 +451,24 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         }
     }
 
+    /// Move cursor to the start of the buffer.
+    pub fn edit_move_buffer_start(&mut self) -> Result<()> {
+        if self.line.move_buffer_start() {
+            self.move_cursor()
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Move cursor to the end of the buffer.
+    pub fn edit_move_buffer_end(&mut self) -> Result<()> {
+        if self.line.move_buffer_end() {
+            self.move_cursor()
+        } else {
+            Ok(())
+        }
+    }
+
     pub fn edit_kill(&mut self, mvt: &Movement) -> Result<()> {
         if self.line.kill(mvt) {
             self.refresh_line()

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -255,6 +255,11 @@ pub enum Movement {
     LineUp(RepeatCount),
     /// move to the same column on the next line
     LineDown(RepeatCount),
+    WholeBuffer, // not really a movement
+    /// beginning-of-buffer
+    BeginningOfBuffer,
+    /// end-of-buffer
+    EndOfBuffer,
 }
 
 impl Movement {
@@ -278,6 +283,9 @@ impl Movement {
             Movement::ForwardChar(previous) => Movement::ForwardChar(repeat_count(previous, new)),
             Movement::LineUp(previous) => Movement::LineUp(repeat_count(previous, new)),
             Movement::LineDown(previous) => Movement::LineDown(repeat_count(previous, new)),
+            Movement::WholeBuffer => Movement::WholeBuffer,
+            Movement::BeginningOfBuffer => Movement::BeginningOfBuffer,
+            Movement::EndOfBuffer => Movement::EndOfBuffer,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -620,6 +620,14 @@ fn readline_edit<H: Helper>(
             Cmd::Move(Movement::LineDown(n)) => {
                 s.edit_move_line_down(n)?;
             }
+            Cmd::Move(Movement::BeginningOfBuffer) => {
+                // Move to the start of the buffer.
+                s.edit_move_buffer_start()?
+            }
+            Cmd::Move(Movement::EndOfBuffer) => {
+                // Move to the end of the buffer.
+                s.edit_move_buffer_end()?
+            }
             Cmd::DowncaseWord => {
                 // lowercase word after point
                 s.edit_word(WordAction::LOWERCASE)?

--- a/src/test/emacs.rs
+++ b/src/test/emacs.rs
@@ -11,6 +11,12 @@ fn ctrl_a() {
         &[KeyPress::Ctrl('A'), KeyPress::Enter],
         ("", "Hi"),
     );
+    assert_cursor(
+        EditMode::Emacs,
+        ("test test\n123", "foo"),
+        &[KeyPress::Ctrl('A'), KeyPress::Enter],
+        ("test test\n", "123foo"),
+    );
 }
 
 #[test]
@@ -20,6 +26,12 @@ fn ctrl_e() {
         ("", "Hi"),
         &[KeyPress::Ctrl('E'), KeyPress::Enter],
         ("Hi", ""),
+    );
+    assert_cursor(
+        EditMode::Emacs,
+        ("foo", "test test\n123"),
+        &[KeyPress::Ctrl('E'), KeyPress::Enter],
+        ("footest test", "\n123"),
     );
 }
 
@@ -146,8 +158,66 @@ fn ctrl_k() {
         &[KeyPress::Ctrl('K'), KeyPress::Enter],
         ("B", ""),
     );
+    assert_cursor(
+        EditMode::Emacs,
+        ("Hi", "foo\nbar"),
+        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        ("Hi", "\nbar"),
+    );
+    assert_cursor(
+        EditMode::Emacs,
+        ("Hi", "\nbar"),
+        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        ("Hi", "bar"),
+    );
+    assert_cursor(
+        EditMode::Emacs,
+        ("Hi", "bar"),
+        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        ("Hi", ""),
+    );
 }
 
+
+#[test]
+fn ctrl_u() {
+    assert_cursor(
+        EditMode::Emacs,
+        ("", "Hi"),
+        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        ("", "Hi"),
+    );
+    assert_cursor(
+        EditMode::Emacs,
+        ("Hi", ""),
+        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        ("", ""),
+    );
+    assert_cursor(
+        EditMode::Emacs,
+        ("B", "ye"),
+        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        ("", "ye"),
+    );
+    assert_cursor(
+        EditMode::Emacs,
+        ("foo\nbar", "Hi"),
+        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        ("foo\n", "Hi"),
+    );
+    assert_cursor(
+        EditMode::Emacs,
+        ("foo\n", "Hi"),
+        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        ("foo", "Hi"),
+    );
+    assert_cursor(
+        EditMode::Emacs,
+        ("foo", "Hi"),
+        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        ("", "Hi"),
+    );
+}
 #[test]
 fn ctrl_n() {
     assert_history(


### PR DESCRIPTION
- Movement::{BeginningOfLine,EndOfLine,etc} now actually go to beginning/end of the line.
- Movement::BeginningOfBuffer, etc was added to get the original functionality back.
- Fix some off-by-one bugs in the line movement code.
- Make it easier to test the multiline functionality by adding a matching bracket validator, and using it in the examples.