### PR TITLE
Fix incorrect cfg-if dependency declaration.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 members = ["rustyline-derive"]
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "0.1.6"
 dirs = { version = "2.0", optional = true }
 libc = "0.2"
 log = "0.4"


### PR DESCRIPTION
There is an incorrect dependency declaration for `cfg-if` in `Cargo.toml`. See discussion here:

https://users.rust-lang.org/t/library-compiles-and-runs-tests-but-fails-compilation-when-used-as-a-dependency/38463/2

This PR just adjusts the `cfg-if` dependency to be `0.1.6` rather than `0.1`.