### PR TITLE
Always use rectangular prompt for multi-line input

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -55,6 +55,10 @@ impl Highlighter for MyHelper {
         }
     }
 
+    fn has_continuation_prompt(&self) -> bool {
+        return true;
+    }
+
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
         Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
     }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -5,6 +5,7 @@ use rustyline::completion::{Completer, FilenameCompleter, Pair};
 use rustyline::config::OutputStreamType;
 use rustyline::error::ReadlineError;
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
+use rustyline::highlight::{PromptInfo};
 use rustyline::hint::{Hinter, HistoryHinter};
 use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyPress};
 use rustyline_derive::{Helper, Validator};
@@ -15,6 +16,7 @@ struct MyHelper {
     highlighter: MatchingBracketHighlighter,
     hinter: HistoryHinter,
     colored_prompt: String,
+    continuation_prompt: String,
 }
 
 impl Completer for MyHelper {
@@ -40,10 +42,14 @@ impl Highlighter for MyHelper {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
         &'s self,
         prompt: &'p str,
-        default: bool,
+        info: PromptInfo<'_>,
     ) -> Cow<'b, str> {
-        if default {
-            Borrowed(&self.colored_prompt)
+        if info.default() {
+            if info.line_no() > 0 {
+                Borrowed(&self.continuation_prompt)
+            } else {
+                Borrowed(&self.colored_prompt)
+            }
         } else {
             Borrowed(prompt)
         }
@@ -76,7 +82,8 @@ fn main() -> rustyline::Result<()> {
         completer: FilenameCompleter::new(),
         highlighter: MatchingBracketHighlighter::new(),
         hinter: HistoryHinter {},
-        colored_prompt: "".to_owned(),
+        colored_prompt: "  0> ".to_owned(),
+        continuation_prompt: "\x1b[1;32m...> \x1b[0m".to_owned(),
     };
     let mut rl = Editor::with_config(config);
     rl.set_helper(Some(h));
@@ -87,7 +94,7 @@ fn main() -> rustyline::Result<()> {
     }
     let mut count = 1;
     loop {
-        let p = format!("{}> ", count);
+        let p = format!("{:>3}> ", count);
         rl.helper_mut().expect("No helper").colored_prompt = format!("\x1b[1;32m{}\x1b[0m", p);
         let readline = rl.readline(&p);
         match readline {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -112,7 +112,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         // calculate the desired position of the cursor
         let cursor = self
             .out
-            .calculate_position(&self.line[..self.line.pos()], self.prompt_size);
+            .calculate_position(&self.line[..self.line.pos()], Position::default());
         if self.layout.cursor == cursor {
             return Ok(());
         }
@@ -123,7 +123,6 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             self.out.move_cursor(self.layout.cursor, cursor)?;
             self.layout.prompt_size = self.prompt_size;
             self.layout.cursor = cursor;
-            debug_assert!(self.layout.prompt_size <= self.layout.cursor);
             debug_assert!(self.layout.cursor <= self.layout.end);
         }
         Ok(())
@@ -153,7 +152,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
 
         // calculate the desired position of the cursor
         let pos = self.line.pos();
-        let cursor = self.out.calculate_position(&self.line[..pos], prompt_size);
+        let cursor = self.out.calculate_position(&self.line[..pos], Position::default());
         // calculate the position of the end of the input line
         let mut end = if pos == self.line.len() {
             cursor
@@ -170,7 +169,6 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             cursor,
             end,
         };
-        debug_assert!(new_layout.prompt_size <= new_layout.cursor);
         debug_assert!(new_layout.cursor <= new_layout.end);
 
         debug!(target: "rustyline", "old layout: {:?}", self.layout);
@@ -338,7 +336,6 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
                     // Avoid a full update of the line in the trivial case.
                     self.layout.cursor.col += width;
                     self.layout.end.col += width;
-                    debug_assert!(self.layout.prompt_size <= self.layout.cursor);
                     debug_assert!(self.layout.cursor <= self.layout.end);
                     let bits = ch.encode_utf8(&mut self.byte_buffer);
                     let bits = bits.as_bytes();

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -5,6 +5,15 @@ use memchr::memchr;
 use std::borrow::Cow::{self, Borrowed, Owned};
 use std::cell::Cell;
 
+pub struct PromptInfo<'a> {
+    pub(crate) default: bool,
+    pub(crate) offset: usize,
+    pub(crate) cursor: Option<usize>,
+    pub(crate) input: &'a str,
+    pub(crate) line: &'a str,
+    pub(crate) line_no: usize,
+}
+
 /// Syntax highlighter with [ANSI color](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters).
 /// Rustyline will try to handle escape sequence for ANSI color on windows
 /// when not supported natively (windows <10).
@@ -26,9 +35,9 @@ pub trait Highlighter {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
         &'s self,
         prompt: &'p str,
-        default: bool,
+        info: PromptInfo<'_>,
     ) -> Cow<'b, str> {
-        let _ = default;
+        let _ = info;
         Borrowed(prompt)
     }
     /// Takes the `hint` and
@@ -69,9 +78,9 @@ impl<'r, H: ?Sized + Highlighter> Highlighter for &'r H {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
         &'s self,
         prompt: &'p str,
-        default: bool,
+        info: PromptInfo<'_>,
     ) -> Cow<'b, str> {
-        (**self).highlight_prompt(prompt, default)
+        (**self).highlight_prompt(prompt, info)
     }
 
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
@@ -228,6 +237,88 @@ fn is_open_bracket(bracket: u8) -> bool {
 }
 fn is_close_bracket(bracket: u8) -> bool {
     memchr(bracket, CLOSES).is_some()
+}
+
+pub(crate) fn split_highlight<'a>(src: &'a str, offset: usize)
+    -> (Cow<'a, str>, Cow<'a, str>)
+{
+    let mut style_buffer = String::with_capacity(32);
+    let mut iter = src.char_indices();
+    let mut non_escape_idx = 0;
+    while let Some((idx, c)) = iter.next() {
+        if c == '\x1b' {
+            match iter.next() {
+                Some((_, '[')) => {}
+                _ => continue, // unknown escape, skip
+            }
+            while let Some((end_idx, c)) = iter.next() {
+                match c {
+                    'm' => {
+                        let slice = &src[idx..end_idx+1];
+                        if slice == "\x1b[0m" {
+                            style_buffer.clear();
+                        } else {
+                            style_buffer.push_str(slice);
+                        }
+                        break;
+                    }
+                    ';' | '0'..='9' => continue,
+                    _ => break,  // unknown escape, skip
+                }
+            }
+            continue;
+        }
+        if non_escape_idx >= offset {
+            if style_buffer.is_empty() {
+                return (src[..idx].into(), src[idx..].into());
+            } else {
+                let mut left = String::with_capacity(idx + 4);
+                left.push_str(&src[..idx]);
+                left.push_str("\x1b[0m");
+                let mut right = String::with_capacity(
+                    src.len() - idx + style_buffer.len());
+                right.push_str(&style_buffer);
+                right.push_str(&src[idx..]);
+                return (left.into(), right.into());
+            }
+        }
+        non_escape_idx += c.len_utf8();
+    }
+    return (src.into(), "".into());
+}
+
+impl PromptInfo<'_> {
+    /// Returns true if this is the default prompt
+    pub fn default(&self) -> bool {
+        self.default
+    }
+    /// Returns the byte offset where prompt is shown in the initial text
+    ///
+    /// This is a position right after the newline of the previous line
+    pub fn line_offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the byte position of the cursor relative to `line_offset` if
+    /// the cursor is in the current line
+    pub fn cursor(&self) -> Option<usize> {
+        self.cursor
+    }
+
+    /// Returns the zero-based line number of the current prompt line
+    pub fn line_no(&self) -> usize {
+        self.line_no
+    }
+
+    /// Returns the line contents shown after the prompt
+    pub fn line(&self) -> &str {
+        self.line
+    }
+
+    /// Returns the whole input (equal to `line` if input is the single line)
+    pub fn input(&self) -> &str {
+        self.input
+    }
 }
 
 #[cfg(test)]

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -40,6 +40,13 @@ pub trait Highlighter {
         let _ = info;
         Borrowed(prompt)
     }
+
+    /// Returns `true` if prompt is rectangular rather than being present only
+    /// on the first line of input
+    fn has_continuation_prompt(&self) -> bool {
+        false
+    }
+
     /// Takes the `hint` and
     /// returns the highlighted version (with ANSI color).
     fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -26,8 +26,8 @@ pub struct Layout {
     /// Prompt Unicode/visible width and height
     pub prompt_size: Position,
     pub default_prompt: bool,
-    /// Cursor position (relative to the start of the prompt)
+    /// Cursor position (relative to the end of the prompt)
     pub cursor: Position,
-    /// Number of rows used so far (from start of prompt to end of input)
+    /// Number of rows used so far (from end of prompt to end of input)
     pub end: Position,
 }

--- a/src/test/highlight.rs
+++ b/src/test/highlight.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::highlight::split_highlight;
 
 #[test]

--- a/src/test/highlight.rs
+++ b/src/test/highlight.rs
@@ -1,0 +1,24 @@
+use std::borrow::Cow;
+
+use crate::highlight::split_highlight;
+
+#[test]
+fn split_bold() {
+    let (a, b) = split_highlight("\x1b[1mword1 word2\x1b[0m", 5);
+    assert_eq!(a, "\x1b[1mword1\x1b[0m");
+    assert_eq!(b, "\x1b[1m word2\x1b[0m");
+}
+
+#[test]
+fn split_at_the_reset() {
+    let (a, b) = split_highlight("\x1b[1mword1\x1b[0m word2", 5);
+    assert_eq!(a, "\x1b[1mword1\x1b[0m");
+    assert_eq!(b, " word2");
+}
+
+#[test]
+fn split_nowhere() {
+    let (a, b) = split_highlight("\x1b[1mword1\x1b[0m word2", 6);
+    assert_eq!(a, "\x1b[1mword1\x1b[0m ");
+    assert_eq!(b, "word2");
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -18,6 +18,7 @@ mod emacs;
 mod history;
 mod vi_cmd;
 mod vi_insert;
+mod highlight;
 
 fn init_editor(mode: EditMode, keys: &[KeyPress]) -> Editor<()> {
     let config = Config::builder().edit_mode(mode).build();

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -1,6 +1,6 @@
 //! This module implements and describes common TTY methods & traits
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
-use crate::highlight::Highlighter;
+use crate::highlight::{Highlighter, PromptInfo, split_highlight};
 use crate::keys::KeyPress;
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
@@ -154,6 +154,89 @@ pub trait Term {
     fn create_reader(&self, config: &Config) -> Result<Self::Reader>;
     /// Create a writer
     fn create_writer(&self) -> Self::Writer;
+}
+
+fn add_prompt_and_highlight(
+    buffer: &mut String, highlighter: Option<&dyn Highlighter>,
+    line: &LineBuffer, prompt: &str, default_prompt: bool, layout: &Layout,
+    cursor: &mut Position)
+{
+    if let Some(highlighter) = highlighter {
+        if highlighter.has_continuation_prompt() {
+            if &line[..] == "" {
+                // line.lines() is an empty iterator for empty line so
+                // we need to treat it as a special case
+                let prompt = highlighter.highlight_prompt(prompt, PromptInfo {
+                    default: default_prompt,
+                    offset: 0,
+                    cursor: Some(0),
+                    input: "",
+                    line: "",
+                    line_no: 0,
+                });
+                buffer.push_str(&prompt);
+            } else {
+                let highlighted = highlighter.highlight(line, line.pos());
+                let lines = line.split('\n');
+                let mut highlighted_left = highlighted.to_string();
+                let mut offset = 0;
+                for (line_no, orig) in lines.enumerate() {
+                    let (hl, tail) = split_highlight(&highlighted_left,
+                        orig.len()+1);
+                    let prompt = highlighter.highlight_prompt(prompt, PromptInfo {
+                        default: default_prompt,
+                        offset,
+                        cursor: if line.pos() > offset && line.pos() < orig.len() {
+                            Some(line.pos() - offset)
+                        } else {
+                            None
+                        },
+                        input: line,
+                        line: orig,
+                        line_no,
+                    });
+                    buffer.push_str(&prompt);
+                    buffer.push_str(&hl);
+                    highlighted_left = tail.to_string();
+                    offset += orig.len() + 1;
+                }
+            }
+            cursor.col += layout.prompt_size.col;
+        } else {
+            // display the prompt
+            buffer
+                .push_str(&highlighter.highlight_prompt(prompt, PromptInfo {
+                    default: default_prompt,
+                    offset: 0,
+                    cursor: Some(line.pos()),
+                    input: line,
+                    line: line,
+                    line_no: 0,
+                }));
+            // display the input line
+            buffer
+                .push_str(&highlighter.highlight(line, line.pos()));
+            // we have to generate our own newline on line wrap
+            if layout.end.col == 0 && layout.end.row > 0 && !buffer.ends_with('\n') {
+                buffer.push_str("\n");
+            }
+            if cursor.row == 0 {
+                cursor.col += layout.prompt_size.col;
+            }
+        }
+    } else {
+        // display the prompt
+        buffer.push_str(prompt);
+        // display the input line
+        buffer.push_str(line);
+        // we have to generate our own newline on line wrap
+        if layout.end.col == 0 && layout.end.row > 0 && !buffer.ends_with('\n') {
+            buffer.push_str("\n");
+        }
+        if cursor.row == 0 {
+            cursor.col += layout.prompt_size.col;
+        }
+    }
 }
 
 cfg_if::cfg_if! {

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -578,13 +578,12 @@ impl Renderer for PosixRenderer {
                 self.buffer.push_str(&prompt);
             } else {
                 let highlighted = highlighter.highlight(line, line.pos());
-                let orig_lines = line.split('\n');
-                let hl_lines = highlighted.split('\n');
+                let lines = line.split('\n');
                 let mut highlighted_left = highlighted.to_string();
                 let mut offset = 0;
-                for (line_no, (orig, hl)) in orig_lines.zip(hl_lines).enumerate() {
+                for (line_no, orig) in lines.enumerate() {
                     let (hl, tail) = split_highlight(&highlighted_left,
-                        hl.len()+1);
+                        orig.len()+1);
                     let prompt = highlighter.highlight_prompt(prompt, PromptInfo {
                         default: default_prompt,
                         offset,

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -347,13 +347,12 @@ impl Renderer for ConsoleRenderer {
                 self.buffer.push_str(&prompt);
             } else {
                 let highlighted = highlighter.highlight(line, line.pos());
-                let orig_lines = line.split('\n');
-                let hl_lines = highlighted.split('\n');
+                let lines = line.split('\n');
                 let mut highlighted_left = highlighted.to_string();
                 let mut offset = 0;
-                for (line_no, (orig, hl)) in orig_lines.zip(hl_lines).enumerate() {
+                for (line_no, orig) in lines.enumerate() {
                     let (hl, tail) = split_highlight(&highlighted_left,
-                        hl.len()+1);
+                        orig.len()+1);
                     let prompt = highlighter.highlight_prompt(prompt, PromptInfo {
                         default: default_prompt,
                         offset,

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -12,11 +12,12 @@ use winapi::um::{consoleapi, handleapi, processenv, winbase, wincon, winuser};
 use super::{RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error;
-use crate::highlight::{Highlighter, PromptInfo, split_highlight};
+use crate::highlight::Highlighter;
 use crate::keys::{self, KeyPress};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
+use crate::tty::add_prompt_and_highlight;
 
 const STDIN_FILENO: DWORD = winbase::STD_INPUT_HANDLE;
 const STDOUT_FILENO: DWORD = winbase::STD_OUTPUT_HANDLE;
@@ -326,64 +327,15 @@ impl Renderer for ConsoleRenderer {
         highlighter: Option<&dyn Highlighter>,
     ) -> Result<()> {
         let default_prompt = new_layout.default_prompt;
-        let cursor = new_layout.cursor;
+        let mut cursor = new_layout.cursor;
         let end_pos = new_layout.end;
         let current_row = old_layout.cursor.row;
         let old_rows = old_layout.end.row;
 
         self.buffer.clear();
-        if let Some(highlighter) = highlighter {
-            if &line[..] == "" {
-                // line.lines() is an empty iterator for empty line so
-                // we need to treat it as a special case
-                let prompt = highlighter.highlight_prompt(prompt, PromptInfo {
-                    default: default_prompt,
-                    offset: 0,
-                    cursor: Some(0),
-                    input: "",
-                    line: "",
-                    line_no: 0,
-                });
-                self.buffer.push_str(&prompt);
-            } else {
-                let highlighted = highlighter.highlight(line, line.pos());
-                let lines = line.split('\n');
-                let mut highlighted_left = highlighted.to_string();
-                let mut offset = 0;
-                for (line_no, orig) in lines.enumerate() {
-                    let (hl, tail) = split_highlight(&highlighted_left,
-                        orig.len()+1);
-                    let prompt = highlighter.highlight_prompt(prompt, PromptInfo {
-                        default: default_prompt,
-                        offset,
-                        cursor: if line.pos() > offset && line.pos() < orig.len() {
-                            Some(line.pos() - offset)
-                        } else {
-                            None
-                        },
-                        input: line,
-                        line: orig,
-                        line_no,
-                    });
-                    self.buffer.push_str(&prompt);
-                    self.buffer.push_str(&hl);
-                    highlighted_left = tail.to_string();
-                    offset += orig.len() + 1;
-                }
-            }
-        } else {
-            let mut lines = line.split("\n");
-            self.buffer.push_str(prompt);
-            if let Some(line) = lines.next() {
-                self.buffer.push_str(line);
-            }
-            let next_prompt = format!("{:1$}", "", new_layout.prompt_size.col);
-            for line in lines {
-                self.buffer.push('\n');
-                self.buffer.push_str(&next_prompt);
-                self.buffer.push_str(line);
-            }
-        }
+        add_prompt_and_highlight(&mut self.buffer, highlighter,
+            line, prompt, default_prompt, &new_layout, &mut cursor);
+
         // append hint
         if let Some(hint) = hint {
             if let Some(highlighter) = highlighter {


### PR DESCRIPTION
This commit changes multi-line input support in the following way:
* If there is no highlighter, the prompt is used in the first line and
  next lines are prepended by amount of spaces equal to the first line
  prompt
* If highlighter is used, the original prompt is passed for every line
  to the highlighter, and highlighter is free to change color or
  characters of the prompt as long as its length is the same (usual
  contract for the highlighter)

Internally this changes `layout` object to contain cursor position
without prompt size (this should make it easier to allow non-rectangular
prompts in future).

This mostly fixes #311

I've only implemented this thing for unix terminal. I'll take a look on windows support if this general approach is fine.