### PR TITLE
Add `Cmd::Yield` for complex custom bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4"
 unicode-width = "0.1"
 unicode-segmentation = "1.0"
 memchr = "2.0"
+matches = "0.1.8"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17"

--- a/examples/yield_binding.rs
+++ b/examples/yield_binding.rs
@@ -1,0 +1,159 @@
+use std::sync::Arc;
+use std::borrow::Cow::{self, Borrowed, Owned};
+use std::mem;
+
+use rustyline::completion::{Completer, FilenameCompleter, Pair};
+use rustyline::config::OutputStreamType;
+use rustyline::error::ReadlineError;
+use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
+use rustyline::highlight::{PromptInfo};
+use rustyline::hint::{Hinter, HistoryHinter};
+use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyPress};
+use rustyline_derive::{Helper, Validator};
+
+#[derive(Helper, Validator)]
+struct MyHelper {
+    completer: FilenameCompleter,
+    highlighter: MatchingBracketHighlighter,
+    hinter: HistoryHinter,
+    colored_prompt: String,
+    continuation_prompt: String,
+}
+
+#[derive(Debug)]
+struct ViMode;
+
+#[derive(Debug)]
+struct EmacsMode;
+
+impl Completer for MyHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        ctx: &Context<'_>,
+    ) -> Result<(usize, Vec<Pair>), ReadlineError> {
+        self.completer.complete(line, pos, ctx)
+    }
+}
+
+impl Hinter for MyHelper {
+    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
+        self.hinter.hint(line, pos, ctx)
+    }
+}
+
+impl Highlighter for MyHelper {
+    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
+        &'s self,
+        prompt: &'p str,
+        info: PromptInfo<'_>,
+    ) -> Cow<'b, str> {
+        if info.default() {
+            if info.line_no() > 0 {
+                Borrowed(&self.continuation_prompt)
+            } else {
+                Borrowed(&self.colored_prompt)
+            }
+        } else {
+            Borrowed(prompt)
+        }
+    }
+
+    fn has_continuation_prompt(&self) -> bool {
+        return true;
+    }
+
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
+    }
+
+    fn highlight<'l>(&self, line: &'l str, pos: usize) -> Cow<'l, str> {
+        self.highlighter.highlight(line, pos)
+    }
+
+    fn highlight_char(&self, line: &str, pos: usize) -> bool {
+        self.highlighter.highlight_char(line, pos)
+    }
+}
+
+// To debug rustyline:
+// RUST_LOG=rustyline=debug cargo run --example example 2> debug.log
+fn main() -> rustyline::Result<()> {
+    env_logger::init();
+    let mut config = Config::builder()
+        .history_ignore_space(true)
+        .completion_type(CompletionType::List)
+        .edit_mode(EditMode::Emacs)
+        .output_stream(OutputStreamType::Stdout);
+    let mut initial = String::new();
+    let mut initial_cursor = 0;
+    println!("Use F2 fo vi mode, F3 for emacs mode");
+    'outer: loop {
+        let h = MyHelper {
+            completer: FilenameCompleter::new(),
+            highlighter: MatchingBracketHighlighter::new(),
+            hinter: HistoryHinter {},
+            colored_prompt: "  0> ".to_owned(),
+            continuation_prompt: "\x1b[1;32m...> \x1b[0m".to_owned(),
+        };
+        let mut rl = Editor::with_config(config.clone().build());
+        rl.set_helper(Some(h));
+        rl.bind_sequence(KeyPress::F(2), Cmd::Yield(Arc::new(ViMode)));
+        rl.bind_sequence(KeyPress::F(3), Cmd::Yield(Arc::new(EmacsMode)));
+        if rl.load_history("history.txt").is_err() {
+            println!("No previous history.");
+        }
+        let mut count = 1;
+        loop {
+            let p = format!("{:>3}> ", count);
+            rl.helper_mut().expect("No helper").colored_prompt = format!("\x1b[1;32m{}\x1b[0m", p);
+            let cur_ini = mem::replace(&mut initial, String::new());
+            let cur_cursor = mem::replace(&mut initial_cursor, 0);
+            let readline = rl.readline_with_initial(&p,
+                (&cur_ini[..cur_cursor], &cur_ini[cur_cursor..]));
+            let mut stop = false;
+            match readline {
+                Ok(line) => {
+                    rl.add_history_entry(line.as_str());
+                    println!("Line: {}", line);
+                    count += 1;
+                    continue;
+                }
+                Err(ReadlineError::Interrupted) => {
+                    println!("CTRL-C");
+                    stop = true;
+                }
+                Err(ReadlineError::Yielded { input, cursor, value }) => {
+                    if value.is::<ViMode>() {
+                        println!("Switching to vi mode");
+                        config = config.edit_mode(EditMode::Vi);
+                    }
+                    if value.is::<EmacsMode>() {
+                        println!("Switching to emacs mode");
+                        config = config.edit_mode(EditMode::Emacs);
+                    }
+                    initial = input;
+                    initial_cursor = cursor;
+                }
+                Err(ReadlineError::Eof) => {
+                    println!("CTRL-D");
+                    stop = true;
+                }
+                Err(err) => {
+                    println!("Error: {:?}", err);
+                    stop = true;
+                }
+            }
+            rl.save_history("history.txt")?;
+            if stop {
+                break 'outer;
+            } else {
+                break;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,12 @@
 //! Contains error type for handling I/O and Errno errors
+use std::any::Any;
 #[cfg(windows)]
 use std::char;
 use std::error;
 use std::fmt;
 use std::io;
+use std::sync::Arc;
+
 
 /// The error type for Rustyline errors that can arise from
 /// I/O related errors or Errno when using the nix-rust library
@@ -17,6 +20,15 @@ pub enum ReadlineError {
     Eof,
     /// Ctrl-C
     Interrupted,
+    /// Key bindinding yielded the special value
+    Yielded {
+        /// Current input buffer
+        input: String,
+        /// Cursor position as the offset inside the buffer
+        cursor: usize,
+        /// The value yielded by the keybinding
+        value: Arc<dyn Any+Send+Sync>,
+    },
     /// Chars Error
     #[cfg(unix)]
     Utf8Error,
@@ -35,6 +47,7 @@ impl fmt::Display for ReadlineError {
             ReadlineError::Io(ref err) => err.fmt(f),
             ReadlineError::Eof => write!(f, "EOF"),
             ReadlineError::Interrupted => write!(f, "Interrupted"),
+            ReadlineError::Yielded { .. } => write!(f, "Yielded"),
             #[cfg(unix)]
             ReadlineError::Utf8Error => write!(f, "invalid utf-8: corrupt contents"),
             #[cfg(unix)]

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,4 +1,5 @@
 //! Bindings from keys to command for Emacs and Vi modes
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -15,7 +16,7 @@ pub type RepeatCount = usize;
 
 /// Commands
 // #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum Cmd {
     /// abort
     Abort, // Miscellaneous Command
@@ -97,6 +98,9 @@ pub enum Cmd {
     /// accepts the line when cursor is at the end of the text (non including
     /// trailing whitespace), inserts newline character otherwise
     AcceptOrInsertLine,
+    /// yields a special value along with the current buffer and cursor
+    /// position to the readline caller
+    Yield(Arc<dyn Any+Send+Sync>),
 }
 
 impl Cmd {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use log::debug;
 use unicode_width::UnicodeWidthStr;
+use matches::matches;
 
 use crate::tty::{RawMode, Renderer, Term, Terminal};
 
@@ -154,7 +155,7 @@ fn complete_line<H: Helper>(
         // we can't complete any further, wait for second tab
         let mut cmd = s.next_cmd(input_state, rdr, true)?;
         // if any character other than tab, pass it to the main loop
-        if cmd != Cmd::Complete {
+        if !matches!(cmd, Cmd::Complete) {
             return Ok(Some(cmd));
         }
         // move cursor to EOL to avoid overwriting the command line
@@ -166,11 +167,12 @@ fn complete_line<H: Helper>(
             let msg = format!("\nDisplay all {} possibilities? (y or n)", candidates.len());
             s.out.write_and_flush(msg.as_bytes())?;
             s.layout.end.row += 1;
-            while cmd != Cmd::SelfInsert(1, 'y')
-                && cmd != Cmd::SelfInsert(1, 'Y')
-                && cmd != Cmd::SelfInsert(1, 'n')
-                && cmd != Cmd::SelfInsert(1, 'N')
-                && cmd != Cmd::Kill(Movement::BackwardChar(1))
+            while !matches!(cmd,
+                | Cmd::SelfInsert(1, 'y')
+                | Cmd::SelfInsert(1, 'Y')
+                | Cmd::SelfInsert(1, 'n')
+                | Cmd::SelfInsert(1, 'N')
+                | Cmd::Kill(Movement::BackwardChar(1)))
             {
                 cmd = s.next_cmd(input_state, rdr, false)?;
             }
@@ -272,16 +274,17 @@ fn page_completions<C: Candidate, H: Helper>(
         if row == pause_row {
             s.out.write_and_flush(b"\n--More--")?;
             let mut cmd = Cmd::Noop;
-            while cmd != Cmd::SelfInsert(1, 'y')
-                && cmd != Cmd::SelfInsert(1, 'Y')
-                && cmd != Cmd::SelfInsert(1, 'n')
-                && cmd != Cmd::SelfInsert(1, 'N')
-                && cmd != Cmd::SelfInsert(1, 'q')
-                && cmd != Cmd::SelfInsert(1, 'Q')
-                && cmd != Cmd::SelfInsert(1, ' ')
-                && cmd != Cmd::Kill(Movement::BackwardChar(1))
-                && cmd != Cmd::AcceptLine
-                && cmd != Cmd::AcceptOrInsertLine
+            while !matches!(cmd,
+                | Cmd::SelfInsert(1, 'y')
+                | Cmd::SelfInsert(1, 'Y')
+                | Cmd::SelfInsert(1, 'n')
+                | Cmd::SelfInsert(1, 'N')
+                | Cmd::SelfInsert(1, 'q')
+                | Cmd::SelfInsert(1, 'Q')
+                | Cmd::SelfInsert(1, ' ')
+                | Cmd::Kill(Movement::BackwardChar(1))
+                | Cmd::AcceptLine
+                | Cmd::AcceptOrInsertLine)
             {
                 cmd = s.next_cmd(input_state, rdr, false)?;
             }
@@ -450,7 +453,7 @@ fn readline_edit<H: Helper>(
         }
 
         // autocomplete
-        if cmd == Cmd::Complete && s.helper.is_some() {
+        if matches!(cmd, Cmd::Complete) && s.helper.is_some() {
             let next = complete_line(&mut rdr, &mut s, &mut input_state, &editor.config)?;
             if let Some(next) = next {
                 cmd = next;
@@ -459,7 +462,7 @@ fn readline_edit<H: Helper>(
             }
         }
 
-        if Cmd::CompleteHint == cmd {
+        if matches!(cmd, Cmd::CompleteHint) {
             complete_hint_line(&mut s)?;
             continue;
         }
@@ -472,7 +475,7 @@ fn readline_edit<H: Helper>(
             continue;
         }
 
-        if cmd == Cmd::ReverseSearchHistory {
+        if matches!(cmd, Cmd::ReverseSearchHistory) {
             // Search history backward
             let next =
                 reverse_incremental_search(&mut rdr, &mut s, &mut input_state, &editor.history)?;
@@ -584,7 +587,7 @@ fn readline_edit<H: Helper>(
                     s.refresh_line_with_msg(None)?;
                 }
                 // Only accept value if cursor is at the end of the buffer
-                if s.validate()? && (cmd == Cmd::AcceptLine || s.line.is_end_of_input()) {
+                if s.validate()? && (matches!(cmd, Cmd::AcceptLine) || s.line.is_end_of_input()) {
                     break;
                 } else {
                     s.edit_insert('\n', 1)?;
@@ -647,6 +650,13 @@ fn readline_edit<H: Helper>(
             }
             Cmd::Interrupt => {
                 return Err(error::ReadlineError::Interrupted);
+            }
+            Cmd::Yield(value) => {
+                return Err(error::ReadlineError::Yielded {
+                    input: s.line.to_string(),
+                    cursor: s.line.pos(),
+                    value: value.clone(),
+                });
             }
             #[cfg(unix)]
             Cmd::Suspend => {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -57,7 +57,7 @@ fn complete_line() {
     let keys = vec![KeyPress::Enter];
     let mut rdr: IntoIter<KeyPress> = keys.into_iter();
     let cmd = super::complete_line(&mut rdr, &mut s, &mut input_state, &Config::default()).unwrap();
-    assert_eq!(Some(Cmd::AcceptLine), cmd);
+    assert_matches!(cmd, Some(Cmd::AcceptLine));
     assert_eq!("rust", s.line.as_str());
     assert_eq!(4, s.line.pos());
 }


### PR DESCRIPTION
This partially replaces #293, i.e. some custom bindings can be implemented like this, although using `Yield`-style bindings is more complex so they are mostly unrelated.

The idea behind the `Yield` building is that we return from the `readline` function with a special error value which holds user's value (`Arc<dyn Any>`) along with current input. This may be used by user's REPL loop for many complex to implement but useful things like:
1. Changing prompt
2. Changing mode of operation
3. Changing Vi / Emacs mode like I've put in the `yield_binding` example as part of this PR

What do you think?