### PR TITLE
Print an error message while trying to use the dummy implementation.

### DIFF
--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -159,8 +159,14 @@ impl Term for DummyTerminal {
 
     // Init checks:
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn is_unsupported(&self) -> bool {
         false
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn is_unsupported(&self) -> bool {
+        true
     }
 
     fn is_stdin_tty(&self) -> bool {


### PR DESCRIPTION
It was quite confusing that rustyline did not work under WASI with no error message.