### PR TITLE
Prevent crash when position can't be set

### DIFF
--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -283,7 +283,11 @@ impl ConsoleRenderer {
     }
 
     fn set_console_cursor_position(&mut self, pos: wincon::COORD) -> Result<()> {
-        check!(wincon::SetConsoleCursorPosition(self.handle, pos));
+        let result = unsafe {wincon::SetConsoleCursorPosition(self.handle, pos)};
+
+        if result == 0 {
+            println!("");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
There are some cases where the cursor can't be set without causing a panic (reported in #359)

This fix may not be the best fix, but it does seem to at least get around the crash by ensuring that if we fail to set the position we need to move to a new line and try again.