### PR TITLE
vi: command mode - fix j, k, - and +

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -90,10 +90,10 @@ pub enum Cmd {
     YankPop,
     /// moves cursor to the line above or switches to prev history entry if
     /// the cursor is already on the first line
-    LineUpOrPreviousHistory,
+    LineUpOrPreviousHistory(RepeatCount),
     /// moves cursor to the line below or switches to next history entry if
     /// the cursor is already on the last line
-    LineDownOrNextHistory,
+    LineDownOrNextHistory(RepeatCount),
     /// accepts the line when cursor is at the end of the text (non including
     /// trailing whitespace), inserts newline character otherwise
     AcceptOrInsertLine,
@@ -705,10 +705,10 @@ impl InputState {
             KeyPress::Ctrl('G') => Cmd::Abort,
             KeyPress::Char('l') | KeyPress::Char(' ') => Cmd::Move(Movement::ForwardChar(n)),
             KeyPress::Ctrl('L') => Cmd::ClearScreen,
-            KeyPress::Char('+') | KeyPress::Char('j') => Cmd::Move(Movement::LineDown(n)),
+            KeyPress::Char('+') | KeyPress::Char('j') => Cmd::LineDownOrNextHistory(n),
             // TODO: move to the start of the line.
             KeyPress::Ctrl('N') => Cmd::NextHistory,
-            KeyPress::Char('-') | KeyPress::Char('k') => Cmd::Move(Movement::LineUp(n)),
+            KeyPress::Char('-') | KeyPress::Char('k') => Cmd::LineUpOrPreviousHistory(n),
             // TODO: move to the start of the line.
             KeyPress::Ctrl('P') => Cmd::PreviousHistory,
             KeyPress::Ctrl('R') => {
@@ -899,8 +899,8 @@ impl InputState {
             }
             KeyPress::Ctrl('J') |
             KeyPress::Enter => Cmd::AcceptLine,
-            KeyPress::Down => Cmd::LineDownOrNextHistory,
-            KeyPress::Up => Cmd::LineUpOrPreviousHistory,
+            KeyPress::Down => Cmd::LineDownOrNextHistory(1),
+            KeyPress::Up => Cmd::LineUpOrPreviousHistory(1),
             KeyPress::Ctrl('R') => Cmd::ReverseSearchHistory,
             KeyPress::Ctrl('S') => Cmd::ForwardSearchHistory, // most terminals override Ctrl+S to suspend execution
             KeyPress::Ctrl('T') => Cmd::TransposeChars,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,13 +537,13 @@ fn readline_edit<H: Helper>(
                 // Fetch the previous command from the history list.
                 s.edit_history_next(true)?
             }
-            Cmd::LineUpOrPreviousHistory => {
-                if !s.edit_move_line_up(1)? {
+            Cmd::LineUpOrPreviousHistory(n) => {
+                if !s.edit_move_line_up(n)? {
                     s.edit_history_next(true)?
                 }
             }
-            Cmd::LineDownOrNextHistory => {
-                if !s.edit_move_line_down(1)? {
+            Cmd::LineDownOrNextHistory(n) => {
+                if !s.edit_move_line_down(n)? {
                     s.edit_history_next(false)?
                 }
             }


### PR DESCRIPTION
Fix `j`, `k`, `-` and `+` to match readme and readline vi behavior