### PR TITLE
Flexible AcceptLine, fix bug in multi-line accept

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -20,6 +20,8 @@ pub enum Cmd {
     /// abort
     Abort, // Miscellaneous Command
     /// accept-line
+    ///
+    /// See also AcceptOrInsertLine
     AcceptLine,
     /// beginning-of-history
     BeginningOfHistory,
@@ -99,9 +101,23 @@ pub enum Cmd {
     /// moves cursor to the line below or switches to next history entry if
     /// the cursor is already on the last line
     LineDownOrNextHistory(RepeatCount),
-    /// accepts the line when cursor is at the end of the text (non including
-    /// trailing whitespace), inserts newline character otherwise
-    AcceptOrInsertLine,
+    /// Inserts a newline
+    Newline,
+    /// Either accepts or inserts a newline
+    ///
+    /// Always inserts newline if input is non-valid. Can also insert newline
+    /// if cursor is in the middle of the text
+    ///
+    /// If you support multi-line input:
+    /// * Use `accept_in_the_middle: true` for mostly single-line cases,
+    ///   for example command-line.
+    /// * Use `accept_in_the_middle: false` for mostly multi-line cases,
+    ///   for example SQL or JSON input.
+    AcceptOrInsertLine {
+        /// Whether this commands accepts input if the cursor not at the end
+        /// of the current input
+        accept_in_the_middle: bool
+    },
 }
 
 impl Cmd {
@@ -913,7 +929,9 @@ impl InputState {
                 }
             }
             KeyPress::Ctrl('J') |
-            KeyPress::Enter => Cmd::AcceptLine,
+            KeyPress::Enter => {
+                Cmd::AcceptOrInsertLine { accept_in_the_middle: true }
+            }
             KeyPress::Down => Cmd::LineDownOrNextHistory(1),
             KeyPress::Up => Cmd::LineUpOrPreviousHistory(1),
             KeyPress::Ctrl('R') => Cmd::ReverseSearchHistory,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,13 +511,14 @@ fn readline_edit<H: Helper>(
                 s.edit_overwrite_char(c)?;
             }
             Cmd::EndOfFile => {
+                if s.has_hint() || !s.is_default_prompt() {
+                    // Force a refresh without hints to leave the previous
+                    // line as the user typed it after a newline.
+                    s.refresh_line_with_msg(None)?;
+                }
                 if !input_state.is_emacs_mode() && !s.line.is_empty() {
                     break;
                 } else if s.line.is_empty() {
-                    // Move to end, in case cursor was in the middle of the
-                    // line, so that next thing application prints goes after
-                    // the input
-                    s.edit_move_buffer_end()?;
                     return Err(error::ReadlineError::Eof);
                 } else {
                     s.edit_delete(1)?

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -56,7 +56,7 @@ fn complete_line() {
     let keys = vec![KeyPress::Enter];
     let mut rdr: IntoIter<KeyPress> = keys.into_iter();
     let cmd = super::complete_line(&mut rdr, &mut s, &mut input_state, &Config::default()).unwrap();
-    assert_eq!(Some(Cmd::AcceptLine), cmd);
+    assert_eq!(Some(Cmd::AcceptOrInsertLine { accept_in_the_middle: true }), cmd);
     assert_eq!("rust", s.line.as_str());
     assert_eq!(4, s.line.pos());
 }


### PR DESCRIPTION
1. This commit allows keybinding for forcing accept line (even if
  validator fails). This is useful if you have a separate keybinding
  for accepting, such as `Alt-Enter`. It makes sense to show an error
  to user rather than insert an unexpected newline.
2. Forcing `Newline` is also accepted
3. `AcceptLine` meaning is changed (now it forces accept),
   but default `Enter` keybinding is not
4. `AcceptOrInsertLine` now has a flag that modifies it's behavior in
  the middle of the line (at the end it always submits, when validator
  returned false it's always a newline)
5. Fixed bug with exiting readline (both on success and error) when
  cursor is not on the last line

I'm not sure that current command-names are the best possible, so let me know if we can do better. The primary motivator was (1) from above.

This conflicts with #342. I'll rebase other one when either of them is merged.