### PR TITLE
More sane behavior if terminal size is zero

### DIFF
--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -63,9 +63,9 @@ fn get_win_size<T: AsRawFd + ?Sized>(fileno: &T) -> (usize, usize) {
                     size.ws_col as usize
                 };
                 let rows = if size.ws_row == 0 {
-                    0
-                } else {
                     usize::max_value()
+                } else {
+                    size.ws_row as usize
                 };
                 (cols, rows)
             }


### PR DESCRIPTION
In linux pseudo-terminals are created with dimensions of zero. If host application didn't initialize the correct size before start we treat zero size as 80 columns and
inifinite rows.

See https://github.com/containers/libpod/issues/351 and https://github.com/philippkeller/rexpect/pull/17 for examples of such issues.