### PR TITLE
Avoid EINTR in readline by repeating poll-call.

### DIFF
--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -390,8 +390,16 @@ impl PosixRawReader {
     }
 
     fn poll(&mut self, timeout_ms: i32) -> ::nix::Result<i32> {
+        use nix::{Error, errno::Errno};
+
         let mut fds = [poll::PollFd::new(STDIN_FILENO, PollFlags::POLLIN)];
-        poll::poll(&mut fds, timeout_ms)
+        loop {
+            let polled = poll::poll(&mut fds, timeout_ms);
+            match polled {
+                Err(Error::Sys(Errno::EINTR)) => continue,
+                o => return o
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #402 by repeating the call on EINTR.