### PR TITLE
Updated history to escape history entries differently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4"
 unicode-width = "0.1"
 unicode-segmentation = "1.0"
 memchr = "2.0"
+snailquote = "0.3.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.17"

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -342,7 +342,6 @@ fn filename_complete(
         return Ok(entries);
     }
 
-    if cfg!(unix) {}
     // if any of the below IO operations have errors, just ignore them
     if let Ok(read_dir) = dir.read_dir() {
         for entry in read_dir {

--- a/src/history.rs
+++ b/src/history.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use super::Result;
 use crate::config::{Config, HistoryDuplicates};
+use snailquote::{escape, unescape};
 
 /// Search direction
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,7 +142,8 @@ impl History {
         wtr.write_all(Self::FILE_VERSION_V2.as_bytes())?;
         for entry in &self.entries {
             wtr.write_all(b"\n")?;
-            wtr.write_all(entry.replace('\\', "\\\\").replace('\n', "\\n").as_bytes())?;
+            let esc = escape(entry);
+            wtr.write_all(&esc.as_bytes())?;
         }
         wtr.write_all(b"\n")?;
         // https://github.com/rust-lang/rust/issues/32677#issuecomment-204833485
@@ -170,7 +172,11 @@ impl History {
         }
         for line in lines {
             let line = if v2 {
-                line?.replace("\\n", "\n").replace("\\\\", "\\")
+                let li = match unescape(&line.unwrap()) {
+                    Ok(s) => s,
+                    _ => "".to_string()
+                };
+                li
             } else {
                 line?
             };


### PR DESCRIPTION
@gwenn How's this for a fix for #409?

I used the  `snailquote` escaping/unescaping crate found [here](https://docs.rs/snailquote/0.3.0/snailquote/)

I tested it with nushell and it seemed to work, once I straightened out my history.txt file