### PR TITLE
Vi: insert mode escape seq fallback to command mode

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -770,6 +770,14 @@ impl InputState {
             KeyPress::Tab => Cmd::Complete,
             // Don't complete hints when the cursor is not at the end of a line
             KeyPress::Right if wrt.has_hint() && wrt.is_cursor_at_end() => Cmd::CompleteHint,
+            KeyPress::Meta(k) => {
+                debug!(target: "rustyline", "Vi fast command mode: {}", k);
+                self.input_mode = InputMode::Command;
+                wrt.done_inserting();
+
+                // TODO: Do k as command key
+                Cmd::Move(Movement::BeginningOfLine)
+            },
             KeyPress::Esc => {
                 // vi-movement-mode/vi-command-mode
                 self.input_mode = InputMode::Command;


### PR DESCRIPTION
Inspired by #416 

In vi insert mode:

If getting an unrecognized escape sequence, assume it is a command input instead. eg `Esc, j`