### PR TITLE
Fixed error detection in move_cursor_at_leftmost

### DIFF
--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -9,6 +9,7 @@ use log::{debug, warn};
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE, WORD};
+use winapi::shared::winerror;
 use winapi::um::winnt::{CHAR, HANDLE};
 use winapi::um::{consoleapi, handleapi, processenv, winbase, wincon, winuser};
 
@@ -513,7 +514,7 @@ impl Renderer for ConsoleRenderer {
         info.dwCursorPosition.Y += 1;
         let res = self.set_console_cursor_position(info.dwCursorPosition);
         if let Err(error::ReadlineError::Io(ref e)) = res {
-            if e.kind() == ErrorKind::Other && e.raw_os_error() == Some(87) {
+            if e.raw_os_error() == Some(winerror::ERROR_INVALID_PARAMETER as i32) {
                 warn!(target: "rustyline", "invalid cursor position: ({:?}, {:?}) in ({:?}, {:?})", info.dwCursorPosition.X, info.dwCursorPosition.Y, info.dwSize.X, info.dwSize.Y);
                 println!();
                 return Ok(());


### PR DESCRIPTION
Code 87 emits an `ErrorKind::InvalidInput`, not `ErrorKind::Other`. Fixed the detection here by removing the `ErrorKind` detection entirely and using a winapi named constant. Fixes #433. See https://github.com/rust-lang/rust/blob/master/library/std/src/sys/windows/mod.rs#L64 for details.