### PR TITLE
Split KeyPress into separate Key and Modifier types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "actively-developed" }
 members = ["rustyline-derive"]
 
 [dependencies]
+bitflags = "1.2"
 cfg-if = "0.1.6"
 dirs-next = { version = "1.0", optional = true }
 fs2 = "0.4"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -6,7 +6,9 @@ use rustyline::error::ReadlineError;
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
 use rustyline::hint::{Hinter, HistoryHinter};
 use rustyline::validate::{self, MatchingBracketValidator, Validator};
-use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyCode as K, Modifiers as M};
+use rustyline::{
+    Cmd, CompletionType, Config, Context, EditMode, Editor, KeyCode as K, Modifiers as M,
+};
 use rustyline_derive::Helper;
 
 #[derive(Helper)]

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -6,9 +6,7 @@ use rustyline::error::ReadlineError;
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
 use rustyline::hint::{Hinter, HistoryHinter};
 use rustyline::validate::{self, MatchingBracketValidator, Validator};
-use rustyline::{
-    Cmd, CompletionType, Config, Context, EditMode, Editor, KeyCode as K, Modifiers as M,
-};
+use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyEvent};
 use rustyline_derive::Helper;
 
 #[derive(Helper)]
@@ -99,8 +97,8 @@ fn main() -> rustyline::Result<()> {
     };
     let mut rl = Editor::with_config(config);
     rl.set_helper(Some(h));
-    rl.bind_sequence((K::Char('N'), M::ALT), Cmd::HistorySearchForward);
-    rl.bind_sequence((K::Char('P'), M::ALT), Cmd::HistorySearchBackward);
+    rl.bind_sequence(KeyEvent::alt('N'), Cmd::HistorySearchForward);
+    rl.bind_sequence(KeyEvent::alt('P'), Cmd::HistorySearchBackward);
     if rl.load_history("history.txt").is_err() {
         println!("No previous history.");
     }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -6,7 +6,7 @@ use rustyline::error::ReadlineError;
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
 use rustyline::hint::{Hinter, HistoryHinter};
 use rustyline::validate::{self, MatchingBracketValidator, Validator};
-use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyPress};
+use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyCode as K, Modifiers as M};
 use rustyline_derive::Helper;
 
 #[derive(Helper)]
@@ -97,8 +97,8 @@ fn main() -> rustyline::Result<()> {
     };
     let mut rl = Editor::with_config(config);
     rl.set_helper(Some(h));
-    rl.bind_sequence(KeyPress::Meta('N'), Cmd::HistorySearchForward);
-    rl.bind_sequence(KeyPress::Meta('P'), Cmd::HistorySearchBackward);
+    rl.bind_sequence((K::Char('N'), M::ALT), Cmd::HistorySearchForward);
+    rl.bind_sequence((K::Char('P'), M::ALT), Cmd::HistorySearchBackward);
     if rl.load_history("history.txt").is_err() {
         println!("No previous history.");
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -484,7 +484,7 @@ impl InputState {
                     Cmd::Move(Movement::BackwardChar(n))
                 }
             }
-            E(K::Char('G'), M::CTRL) | E::ESC | E(K::Char('\x07'), M::ALT) => Cmd::Abort,
+            E(K::Char('G'), M::CTRL) | E::ESC | E(K::Char('G'), M::CTRL_ALT) => Cmd::Abort,
             E(K::Char('H'), M::CTRL) | E::BACKSPACE => {
                 if positive {
                     Cmd::Kill(Movement::BackwardChar(n))

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -7,7 +7,7 @@ use log::debug;
 use super::Result;
 use crate::config::Config;
 use crate::config::EditMode;
-use crate::keys::{KeyEvent, KeyCode as K, Modifiers as M};
+use crate::keys::{KeyCode as K, KeyEvent, Modifiers as M};
 use crate::tty::{RawReader, Term, Terminal};
 
 /// The number of times one command should be repeated.
@@ -639,7 +639,7 @@ impl InputState {
                 wrt.doing_insert();
                 Cmd::Move(Movement::EndOfLine)
             }
-            (K::Char('b'), M::NONE) => Cmd::Move(Movement::BackwardWord(n, Word::Vi)), // vi-prev-word
+            (K::Char('b'), M::NONE) => Cmd::Move(Movement::BackwardWord(n, Word::Vi)), /* vi-prev-word */
             (K::Char('B'), M::NONE) => Cmd::Move(Movement::BackwardWord(n, Word::Big)),
             (K::Char('c'), M::NONE) => {
                 self.input_mode = InputMode::Insert;
@@ -658,7 +658,9 @@ impl InputState {
             },
             (K::Char('D'), M::NONE) | (K::Char('K'), M::CTRL) => Cmd::Kill(Movement::EndOfLine),
             (K::Char('e'), M::NONE) => Cmd::Move(Movement::ForwardWord(n, At::BeforeEnd, Word::Vi)),
-            (K::Char('E'), M::NONE) => Cmd::Move(Movement::ForwardWord(n, At::BeforeEnd, Word::Big)),
+            (K::Char('E'), M::NONE) => {
+                Cmd::Move(Movement::ForwardWord(n, At::BeforeEnd, Word::Big))
+            }
             (K::Char('i'), M::NONE) => {
                 // vi-insertion-mode
                 self.input_mode = InputMode::Insert;
@@ -730,7 +732,9 @@ impl InputState {
                 Cmd::Move(Movement::BackwardChar(n))
             }
             (K::Char('G'), M::CTRL) => Cmd::Abort,
-            (K::Char('l'), M::NONE) | (K::Char(' '), M::NONE) => Cmd::Move(Movement::ForwardChar(n)),
+            (K::Char('l'), M::NONE) | (K::Char(' '), M::NONE) => {
+                Cmd::Move(Movement::ForwardChar(n))
+            }
             (K::Char('L'), M::CTRL) => Cmd::ClearScreen,
             (K::Char('+'), M::NONE) | (K::Char('j'), M::NONE) => Cmd::LineDownOrNextHistory(n),
             // TODO: move to the start of the line.
@@ -781,7 +785,9 @@ impl InputState {
                     Cmd::SelfInsert(1, c)
                 }
             }
-            (K::Char('H'), M::CTRL) | (K::Backspace, M::NONE) => Cmd::Kill(Movement::BackwardChar(1)),
+            (K::Char('H'), M::CTRL) | (K::Backspace, M::NONE) => {
+                Cmd::Kill(Movement::BackwardChar(1))
+            }
             (K::BackTab, M::NONE) => Cmd::CompleteBackward,
             (K::Tab, M::NONE) => Cmd::Complete,
             // Don't complete hints when the cursor is not at the end of a line

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -520,7 +520,7 @@ impl InputState {
                     _ => Cmd::Unknown,
                 }
             }
-            E(K::Char('\x08'), M::ALT) | E(K::Char('\x7f'), M::ALT) => {
+            E(K::Backspace, M::ALT) => {
                 if positive {
                     Cmd::Kill(Movement::BackwardWord(n, Word::Emacs))
                 } else {
@@ -553,6 +553,7 @@ impl InputState {
             }
             E(K::Char('L'), M::ALT) | E(K::Char('l'), M::ALT) => Cmd::DowncaseWord,
             E(K::Char('T'), M::ALT) | E(K::Char('t'), M::ALT) => Cmd::TransposeWords(n),
+            // TODO ESC-R (r): Undo all changes made to this line.
             E(K::Char('U'), M::ALT) | E(K::Char('u'), M::ALT) => Cmd::UpcaseWord,
             E(K::Char('Y'), M::ALT) | E(K::Char('y'), M::ALT) => Cmd::YankPop,
             _ => self.common(rdr, key, n, positive)?,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -95,58 +95,60 @@ bitflags::bitflags! {
 
 #[cfg(any(windows, unix))]
 pub fn char_to_key_press(c: char, mut mods: Modifiers) -> KeyEvent {
+    use {KeyCode as K, Modifiers as M};
+
     if !c.is_control() {
         if !mods.is_empty() {
-            mods.remove(Modifiers::SHIFT); // TODO Validate: no SHIFT even if
-                                           // `c` is uppercase
+            mods.remove(M::SHIFT); // TODO Validate: no SHIFT even if
+                                   // `c` is uppercase
         }
-        return (KeyCode::Char(c), mods);
+        return (K::Char(c), mods);
     }
     #[allow(clippy::match_same_arms)]
     match c {
-        '\x00' => (KeyCode::Char(' '), mods | Modifiers::CTRL),
-        '\x01' => (KeyCode::Char('A'), mods | Modifiers::CTRL),
-        '\x02' => (KeyCode::Char('B'), mods | Modifiers::CTRL),
-        '\x03' => (KeyCode::Char('C'), mods | Modifiers::CTRL),
-        '\x04' => (KeyCode::Char('D'), mods | Modifiers::CTRL),
-        '\x05' => (KeyCode::Char('E'), mods | Modifiers::CTRL),
-        '\x06' => (KeyCode::Char('F'), mods | Modifiers::CTRL),
-        '\x07' => (KeyCode::Char('G'), mods | Modifiers::CTRL),
-        '\x08' => (KeyCode::Backspace, mods), // '\b'
+        '\x00' => (K::Char(' '), mods | M::CTRL),
+        '\x01' => (K::Char('A'), mods | M::CTRL),
+        '\x02' => (K::Char('B'), mods | M::CTRL),
+        '\x03' => (K::Char('C'), mods | M::CTRL),
+        '\x04' => (K::Char('D'), mods | M::CTRL),
+        '\x05' => (K::Char('E'), mods | M::CTRL),
+        '\x06' => (K::Char('F'), mods | M::CTRL),
+        '\x07' => (K::Char('G'), mods | M::CTRL),
+        '\x08' => (K::Backspace, mods), // '\b'
         '\x09' => {
             // '\t'
-            if mods.contains(Modifiers::SHIFT) {
-                mods.remove(Modifiers::SHIFT);
-                (KeyCode::BackTab, mods)
+            if mods.contains(M::SHIFT) {
+                mods.remove(M::SHIFT);
+                (K::BackTab, mods)
             } else {
-                (KeyCode::Tab, mods)
+                (K::Tab, mods)
             }
         }
-        '\x0a' => (KeyCode::Char('J'), mods | Modifiers::CTRL), // '\n' (10)
-        '\x0b' => (KeyCode::Char('K'), mods | Modifiers::CTRL),
-        '\x0c' => (KeyCode::Char('L'), mods | Modifiers::CTRL),
-        '\x0d' => (KeyCode::Enter, mods), // '\r' (13)
-        '\x0e' => (KeyCode::Char('N'), mods | Modifiers::CTRL),
-        '\x0f' => (KeyCode::Char('O'), mods | Modifiers::CTRL),
-        '\x10' => (KeyCode::Char('P'), mods | Modifiers::CTRL),
-        '\x11' => (KeyCode::Char('Q'), mods | Modifiers::CTRL),
-        '\x12' => (KeyCode::Char('R'), mods | Modifiers::CTRL),
-        '\x13' => (KeyCode::Char('S'), mods | Modifiers::CTRL),
-        '\x14' => (KeyCode::Char('T'), mods | Modifiers::CTRL),
-        '\x15' => (KeyCode::Char('U'), mods | Modifiers::CTRL),
-        '\x16' => (KeyCode::Char('V'), mods | Modifiers::CTRL),
-        '\x17' => (KeyCode::Char('W'), mods | Modifiers::CTRL),
-        '\x18' => (KeyCode::Char('X'), mods | Modifiers::CTRL),
-        '\x19' => (KeyCode::Char('Y'), mods | Modifiers::CTRL),
-        '\x1a' => (KeyCode::Char('Z'), mods | Modifiers::CTRL),
-        '\x1b' => (KeyCode::Esc, mods), // Ctrl-[
-        '\x1c' => (KeyCode::Char('\\'), mods | Modifiers::CTRL),
-        '\x1d' => (KeyCode::Char(']'), mods | Modifiers::CTRL),
-        '\x1e' => (KeyCode::Char('^'), mods | Modifiers::CTRL),
-        '\x1f' => (KeyCode::Char('_'), mods | Modifiers::CTRL),
-        '\x7f' => (KeyCode::Backspace, mods), // Rubout
-        '\u{9b}' => (KeyCode::Esc, mods | Modifiers::SHIFT),
-        _ => (KeyCode::Null, mods),
+        '\x0a' => (K::Char('J'), mods | M::CTRL), // '\n' (10)
+        '\x0b' => (K::Char('K'), mods | M::CTRL),
+        '\x0c' => (K::Char('L'), mods | M::CTRL),
+        '\x0d' => (K::Enter, mods), // '\r' (13)
+        '\x0e' => (K::Char('N'), mods | M::CTRL),
+        '\x0f' => (K::Char('O'), mods | M::CTRL),
+        '\x10' => (K::Char('P'), mods | M::CTRL),
+        '\x11' => (K::Char('Q'), mods | M::CTRL),
+        '\x12' => (K::Char('R'), mods | M::CTRL),
+        '\x13' => (K::Char('S'), mods | M::CTRL),
+        '\x14' => (K::Char('T'), mods | M::CTRL),
+        '\x15' => (K::Char('U'), mods | M::CTRL),
+        '\x16' => (K::Char('V'), mods | M::CTRL),
+        '\x17' => (K::Char('W'), mods | M::CTRL),
+        '\x18' => (K::Char('X'), mods | M::CTRL),
+        '\x19' => (K::Char('Y'), mods | M::CTRL),
+        '\x1a' => (K::Char('Z'), mods | M::CTRL),
+        '\x1b' => (K::Esc, mods), // Ctrl-[
+        '\x1c' => (K::Char('\\'), mods | M::CTRL),
+        '\x1d' => (K::Char(']'), mods | M::CTRL),
+        '\x1e' => (K::Char('^'), mods | M::CTRL),
+        '\x1f' => (K::Char('_'), mods | M::CTRL),
+        '\x7f' => (K::Backspace, mods), // Rubout
+        '\u{9b}' => (K::Esc, mods | M::SHIFT),
+        _ => (K::Null, mods),
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -78,7 +78,8 @@ bitflags::bitflags! {
 pub fn char_to_key_press(c: char, mut mods: Modifiers) -> KeyEvent {
     if !c.is_control() {
         if !mods.is_empty() {
-            mods.remove(Modifiers::SHIFT); // TODO Validate: no SHIFT even if `c` is uppercase
+            mods.remove(Modifiers::SHIFT); // TODO Validate: no SHIFT even if
+                                           // `c` is uppercase
         }
         return (KeyCode::Char(c), mods);
     }
@@ -93,14 +94,15 @@ pub fn char_to_key_press(c: char, mut mods: Modifiers) -> KeyEvent {
         '\x06' => (KeyCode::Char('F'), mods | Modifiers::CTRL),
         '\x07' => (KeyCode::Char('G'), mods | Modifiers::CTRL),
         '\x08' => (KeyCode::Backspace, mods), // '\b'
-        '\x09' => { // '\t'
+        '\x09' => {
+            // '\t'
             if mods.contains(Modifiers::SHIFT) {
                 mods.remove(Modifiers::SHIFT);
                 (KeyCode::BackTab, mods)
             } else {
                 (KeyCode::Tab, mods)
             }
-        },
+        }
         '\x0a' => (KeyCode::Char('J'), mods | Modifiers::CTRL), // '\n' (10)
         '\x0b' => (KeyCode::Char('K'), mods | Modifiers::CTRL),
         '\x0c' => (KeyCode::Char('L'), mods | Modifiers::CTRL),
@@ -135,6 +137,9 @@ mod tests {
 
     #[test]
     fn char_to_key() {
-        assert_eq!((KeyCode::Esc, Modifiers::NONE), char_to_key_press('\x1b', Modifiers::NONE));
+        assert_eq!(
+            (KeyCode::Esc, Modifiers::NONE),
+            char_to_key_press('\x1b', Modifiers::NONE)
+        );
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -75,47 +75,60 @@ bitflags::bitflags! {
 }
 
 #[cfg(any(windows, unix))]
-pub fn char_to_key_press(c: char) -> KeyEvent {
+pub fn char_to_key_press(c: char, mut mods: Modifiers) -> KeyEvent {
     if !c.is_control() {
-        return (KeyCode::Char(c), Modifiers::NONE); // no SHIFT even if `c` is uppercase
+        if !mods.is_empty() {
+            if c.is_ascii_uppercase() { // no SHIFT even if `c` is uppercase
+                mods.remove(Modifiers::SHIFT);
+            // } else if c.is_ascii_lowercase() && mods.contains(Modifiers::SHIFT) { TODO possible ?
+            }
+        }
+        return (KeyCode::Char(c), mods);
     }
     #[allow(clippy::match_same_arms)]
     match c {
-        '\x00' => (KeyCode::Char(' '), Modifiers::CTRL),
-        '\x01' => (KeyCode::Char('A'), Modifiers::CTRL),
-        '\x02' => (KeyCode::Char('B'), Modifiers::CTRL),
-        '\x03' => (KeyCode::Char('C'), Modifiers::CTRL),
-        '\x04' => (KeyCode::Char('D'), Modifiers::CTRL),
-        '\x05' => (KeyCode::Char('E'), Modifiers::CTRL),
-        '\x06' => (KeyCode::Char('F'), Modifiers::CTRL),
-        '\x07' => (KeyCode::Char('G'), Modifiers::CTRL),
-        '\x08' => (KeyCode::Backspace, Modifiers::NONE), // '\b'
-        '\x09' => (KeyCode::Tab, Modifiers::NONE),       // '\t'
-        '\x0a' => (KeyCode::Char('J'), Modifiers::CTRL), // '\n' (10)
-        '\x0b' => (KeyCode::Char('K'), Modifiers::CTRL),
-        '\x0c' => (KeyCode::Char('L'), Modifiers::CTRL),
-        '\x0d' => (KeyCode::Enter, Modifiers::NONE), // '\r' (13)
-        '\x0e' => (KeyCode::Char('N'), Modifiers::CTRL),
-        '\x0f' => (KeyCode::Char('O'), Modifiers::CTRL),
-        '\x10' => (KeyCode::Char('P'), Modifiers::CTRL),
-        '\x11' => (KeyCode::Char('Q'), Modifiers::CTRL),
-        '\x12' => (KeyCode::Char('R'), Modifiers::CTRL),
-        '\x13' => (KeyCode::Char('S'), Modifiers::CTRL),
-        '\x14' => (KeyCode::Char('T'), Modifiers::CTRL),
-        '\x15' => (KeyCode::Char('U'), Modifiers::CTRL),
-        '\x16' => (KeyCode::Char('V'), Modifiers::CTRL),
-        '\x17' => (KeyCode::Char('W'), Modifiers::CTRL),
-        '\x18' => (KeyCode::Char('X'), Modifiers::CTRL),
-        '\x19' => (KeyCode::Char('Y'), Modifiers::CTRL),
-        '\x1a' => (KeyCode::Char('Z'), Modifiers::CTRL),
-        '\x1b' => (KeyCode::Esc, Modifiers::NONE), // Ctrl-[
-        '\x1c' => (KeyCode::Char('\\'), Modifiers::CTRL),
-        '\x1d' => (KeyCode::Char(']'), Modifiers::CTRL),
-        '\x1e' => (KeyCode::Char('^'), Modifiers::CTRL),
-        '\x1f' => (KeyCode::Char('_'), Modifiers::CTRL),
-        '\x7f' => (KeyCode::Backspace, Modifiers::NONE), // Rubout
-        '\u{9b}' => (KeyCode::Esc, Modifiers::SHIFT),
-        _ => (KeyCode::Null, Modifiers::NONE),
+        '\x00' => (KeyCode::Char(' '), mods | Modifiers::CTRL),
+        '\x01' => (KeyCode::Char('A'), mods | Modifiers::CTRL),
+        '\x02' => (KeyCode::Char('B'), mods | Modifiers::CTRL),
+        '\x03' => (KeyCode::Char('C'), mods | Modifiers::CTRL),
+        '\x04' => (KeyCode::Char('D'), mods | Modifiers::CTRL),
+        '\x05' => (KeyCode::Char('E'), mods | Modifiers::CTRL),
+        '\x06' => (KeyCode::Char('F'), mods | Modifiers::CTRL),
+        '\x07' => (KeyCode::Char('G'), mods | Modifiers::CTRL),
+        '\x08' => (KeyCode::Backspace, mods), // '\b'
+        '\x09' => { // '\t'
+            if mods.contains(Modifiers::SHIFT) {
+                mods.remove(Modifiers::SHIFT);
+                (KeyCode::BackTab, mods)
+            } else {
+                (KeyCode::Tab, mods)
+            }
+        },
+        '\x0a' => (KeyCode::Char('J'), mods | Modifiers::CTRL), // '\n' (10)
+        '\x0b' => (KeyCode::Char('K'), mods | Modifiers::CTRL),
+        '\x0c' => (KeyCode::Char('L'), mods | Modifiers::CTRL),
+        '\x0d' => (KeyCode::Enter, mods), // '\r' (13)
+        '\x0e' => (KeyCode::Char('N'), mods | Modifiers::CTRL),
+        '\x0f' => (KeyCode::Char('O'), mods | Modifiers::CTRL),
+        '\x10' => (KeyCode::Char('P'), mods | Modifiers::CTRL),
+        '\x11' => (KeyCode::Char('Q'), mods | Modifiers::CTRL),
+        '\x12' => (KeyCode::Char('R'), mods | Modifiers::CTRL),
+        '\x13' => (KeyCode::Char('S'), mods | Modifiers::CTRL),
+        '\x14' => (KeyCode::Char('T'), mods | Modifiers::CTRL),
+        '\x15' => (KeyCode::Char('U'), mods | Modifiers::CTRL),
+        '\x16' => (KeyCode::Char('V'), mods | Modifiers::CTRL),
+        '\x17' => (KeyCode::Char('W'), mods | Modifiers::CTRL),
+        '\x18' => (KeyCode::Char('X'), mods | Modifiers::CTRL),
+        '\x19' => (KeyCode::Char('Y'), mods | Modifiers::CTRL),
+        '\x1a' => (KeyCode::Char('Z'), mods | Modifiers::CTRL),
+        '\x1b' => (KeyCode::Esc, mods), // Ctrl-[
+        '\x1c' => (KeyCode::Char('\\'), mods | Modifiers::CTRL),
+        '\x1d' => (KeyCode::Char(']'), mods | Modifiers::CTRL),
+        '\x1e' => (KeyCode::Char('^'), mods | Modifiers::CTRL),
+        '\x1f' => (KeyCode::Char('_'), mods | Modifiers::CTRL),
+        '\x7f' => (KeyCode::Backspace, mods), // Rubout
+        '\u{9b}' => (KeyCode::Esc, mods | Modifiers::SHIFT),
+        _ => (KeyCode::Null, mods),
     }
 }
 
@@ -125,6 +138,6 @@ mod tests {
 
     #[test]
     fn char_to_key() {
-        assert_eq!((KeyCode::Esc, Modifiers::NONE), char_to_key_press('\x1b'));
+        assert_eq!((KeyCode::Esc, Modifiers::NONE), char_to_key_press('\x1b', Modifiers::NONE));
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -78,10 +78,7 @@ bitflags::bitflags! {
 pub fn char_to_key_press(c: char, mut mods: Modifiers) -> KeyEvent {
     if !c.is_control() {
         if !mods.is_empty() {
-            if c.is_ascii_uppercase() { // no SHIFT even if `c` is uppercase
-                mods.remove(Modifiers::SHIFT);
-            // } else if c.is_ascii_lowercase() && mods.contains(Modifiers::SHIFT) { TODO possible ?
-            }
+            mods.remove(Modifiers::SHIFT); // TODO Validate: no SHIFT even if `c` is uppercase
         }
         return (KeyCode::Char(c), mods);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -897,7 +897,7 @@ impl<H: Helper> Editor<H> {
     /// Bind a sequence to a command.
     pub fn bind_sequence(&mut self, key_seq: KeyEvent, cmd: Cmd) -> Option<Cmd> {
         if let Ok(mut bindings) = self.custom_bindings.write() {
-            bindings.insert(key_seq, cmd)
+            bindings.insert(keys::normalize(key_seq), cmd)
         } else {
             None
         }
@@ -906,7 +906,7 @@ impl<H: Helper> Editor<H> {
     /// Remove a binding for the given sequence.
     pub fn unbind_sequence(&mut self, key_seq: KeyEvent) -> Option<Cmd> {
         if let Ok(mut bindings) = self.custom_bindings.write() {
-            bindings.remove(&key_seq)
+            bindings.remove(&keys::normalize(key_seq))
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -897,7 +897,7 @@ impl<H: Helper> Editor<H> {
     /// Bind a sequence to a command.
     pub fn bind_sequence(&mut self, key_seq: KeyEvent, cmd: Cmd) -> Option<Cmd> {
         if let Ok(mut bindings) = self.custom_bindings.write() {
-            bindings.insert(keys::normalize(key_seq), cmd)
+            bindings.insert(KeyEvent::normalize(key_seq), cmd)
         } else {
             None
         }
@@ -906,7 +906,7 @@ impl<H: Helper> Editor<H> {
     /// Remove a binding for the given sequence.
     pub fn unbind_sequence(&mut self, key_seq: KeyEvent) -> Option<Cmd> {
         if let Ok(mut bindings) = self.custom_bindings.write() {
-            bindings.remove(&keys::normalize(key_seq))
+            bindings.remove(&KeyEvent::normalize(key_seq))
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use crate::hint::Hinter;
 use crate::history::{Direction, History};
 pub use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
 use crate::keymap::{InputState, Refresher};
-pub use crate::keys::KeyPress;
+pub use crate::keys::{KeyEvent, KeyCode, Modifiers};
 use crate::kill_ring::{KillRing, Mode};
 use crate::line_buffer::WordAction;
 use crate::validate::Validator;
@@ -776,7 +776,7 @@ pub struct Editor<H: Helper> {
     helper: Option<H>,
     kill_ring: Arc<Mutex<KillRing>>,
     config: Config,
-    custom_bindings: Arc<RwLock<HashMap<KeyPress, Cmd>>>,
+    custom_bindings: Arc<RwLock<HashMap<KeyEvent, Cmd>>>,
 }
 
 #[allow(clippy::new_without_default)]
@@ -895,7 +895,7 @@ impl<H: Helper> Editor<H> {
     }
 
     /// Bind a sequence to a command.
-    pub fn bind_sequence(&mut self, key_seq: KeyPress, cmd: Cmd) -> Option<Cmd> {
+    pub fn bind_sequence(&mut self, key_seq: KeyEvent, cmd: Cmd) -> Option<Cmd> {
         if let Ok(mut bindings) = self.custom_bindings.write() {
             bindings.insert(key_seq, cmd)
         } else {
@@ -904,7 +904,7 @@ impl<H: Helper> Editor<H> {
     }
 
     /// Remove a binding for the given sequence.
-    pub fn unbind_sequence(&mut self, key_seq: KeyPress) -> Option<Cmd> {
+    pub fn unbind_sequence(&mut self, key_seq: KeyEvent) -> Option<Cmd> {
         if let Ok(mut bindings) = self.custom_bindings.write() {
             bindings.remove(&key_seq)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use crate::hint::Hinter;
 use crate::history::{Direction, History};
 pub use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
 use crate::keymap::{InputState, Refresher};
-pub use crate::keys::{KeyEvent, KeyCode, Modifiers};
+pub use crate::keys::{KeyCode, KeyEvent, Modifiers};
 use crate::kill_ring::{KillRing, Mode};
 use crate::line_buffer::WordAction;
 use crate::validate::Validator;

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -34,7 +34,12 @@ fn home_key() {
 #[test]
 fn end_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_cursor(*mode, ("", ""), &[(K::End, M::NONE), (K::Enter, M::NONE)], ("", ""));
+        assert_cursor(
+            *mode,
+            ("", ""),
+            &[(K::End, M::NONE), (K::Enter, M::NONE)],
+            ("", ""),
+        );
         assert_cursor(
             *mode,
             ("H", "i"),
@@ -144,12 +149,31 @@ fn enter_key() {
             assert_line(*mode, &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "");
             assert_line(
                 *mode,
-                &[(K::Char('a'), M::NONE), (K::Esc, M::NONE), (K::Enter, M::NONE)],
+                &[
+                    (K::Char('a'), M::NONE),
+                    (K::Esc, M::NONE),
+                    (K::Enter, M::NONE),
+                ],
                 "a",
             );
-            assert_line_with_initial(*mode, ("Hi", ""), &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "Hi");
-            assert_line_with_initial(*mode, ("", "Hi"), &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "Hi");
-            assert_line_with_initial(*mode, ("H", "i"), &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "Hi");
+            assert_line_with_initial(
+                *mode,
+                ("Hi", ""),
+                &[(K::Esc, M::NONE), (K::Enter, M::NONE)],
+                "Hi",
+            );
+            assert_line_with_initial(
+                *mode,
+                ("", "Hi"),
+                &[(K::Esc, M::NONE), (K::Enter, M::NONE)],
+                "Hi",
+            );
+            assert_line_with_initial(
+                *mode,
+                ("H", "i"),
+                &[(K::Esc, M::NONE), (K::Enter, M::NONE)],
+                "Hi",
+            );
         }
     }
 }
@@ -158,13 +182,21 @@ fn enter_key() {
 fn newline_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
         assert_line(*mode, &[(K::Char('J'), M::CTRL)], "");
-        assert_line(*mode, &[(K::Char('a'), M::NONE), (K::Char('J'), M::CTRL)], "a");
+        assert_line(
+            *mode,
+            &[(K::Char('a'), M::NONE), (K::Char('J'), M::CTRL)],
+            "a",
+        );
         if *mode == EditMode::Vi {
             // vi command mode
             assert_line(*mode, &[(K::Esc, M::NONE), (K::Char('J'), M::CTRL)], "");
             assert_line(
                 *mode,
-                &[(K::Char('a'), M::NONE), (K::Esc, M::NONE), (K::Char('J'), M::CTRL)],
+                &[
+                    (K::Char('a'), M::NONE),
+                    (K::Esc, M::NONE),
+                    (K::Char('J'), M::CTRL),
+                ],
                 "a",
             );
         }
@@ -180,7 +212,11 @@ fn eof_key() {
     }
     assert_line(
         EditMode::Emacs,
-        &[(K::Char('a'), M::NONE), (K::Char('D'), M::CTRL), (K::Enter, M::NONE)],
+        &[
+            (K::Char('a'), M::NONE),
+            (K::Char('D'), M::CTRL),
+            (K::Enter, M::NONE),
+        ],
         "a",
     );
     assert_line(
@@ -190,7 +226,11 @@ fn eof_key() {
     );
     assert_line(
         EditMode::Vi,
-        &[(K::Char('a'), M::NONE), (K::Esc, M::NONE), (K::Char('D'), M::CTRL)],
+        &[
+            (K::Char('a'), M::NONE),
+            (K::Esc, M::NONE),
+            (K::Char('D'), M::CTRL),
+        ],
         "a",
     );
     assert_line_with_initial(
@@ -274,7 +314,11 @@ fn ctrl_t() {
             assert_cursor(
                 *mode,
                 ("ab", ""),
-                &[(K::Esc, M::NONE), (K::Char('T'), M::CTRL), (K::Enter, M::NONE)],
+                &[
+                    (K::Esc, M::NONE),
+                    (K::Char('T'), M::CTRL),
+                    (K::Enter, M::NONE),
+                ],
                 ("ba", ""),
             );
         }
@@ -301,7 +345,11 @@ fn ctrl_u() {
             assert_cursor(
                 *mode,
                 ("start of line ", "end"),
-                &[(K::Esc, M::NONE), (K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
+                &[
+                    (K::Esc, M::NONE),
+                    (K::Char('U'), M::CTRL),
+                    (K::Enter, M::NONE),
+                ],
                 ("", " end"),
             );
         }
@@ -315,7 +363,11 @@ fn ctrl_v() {
         assert_cursor(
             *mode,
             ("", ""),
-            &[(K::Char('V'), M::CTRL), (K::Char('\t'), M::NONE), (K::Enter, M::NONE)],
+            &[
+                (K::Char('V'), M::CTRL),
+                (K::Char('\t'), M::NONE),
+                (K::Enter, M::NONE),
+            ],
             ("\t", ""),
         );
         if *mode == EditMode::Vi {
@@ -355,7 +407,11 @@ fn ctrl_w() {
             assert_cursor(
                 *mode,
                 ("Hello, world.", ""),
-                &[(K::Esc, M::NONE), (K::Char('W'), M::CTRL), (K::Enter, M::NONE)],
+                &[
+                    (K::Esc, M::NONE),
+                    (K::Char('W'), M::CTRL),
+                    (K::Enter, M::NONE),
+                ],
                 ("Hello, ", "."),
             );
         }
@@ -368,7 +424,11 @@ fn ctrl_y() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[(K::Char('W'), M::CTRL), (K::Char('Y'), M::CTRL), (K::Enter, M::NONE)],
+            &[
+                (K::Char('W'), M::CTRL),
+                (K::Char('Y'), M::CTRL),
+                (K::Enter, M::NONE),
+            ],
             ("Hello, ", "world"),
         );
     }
@@ -380,7 +440,11 @@ fn ctrl__() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[(K::Char('W'), M::CTRL), (K::Char('_'), M::CTRL), (K::Enter, M::NONE)],
+            &[
+                (K::Char('W'), M::CTRL),
+                (K::Char('_'), M::CTRL),
+                (K::Enter, M::NONE),
+            ],
             ("Hello, ", "world"),
         );
         if *mode == EditMode::Vi {

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -2,21 +2,16 @@
 use super::{assert_cursor, assert_line, assert_line_with_initial, init_editor};
 use crate::config::EditMode;
 use crate::error::ReadlineError;
-use crate::keys::{KeyCode as K, Modifiers as M};
+use crate::keys::{KeyCode as K, KeyEvent as E, Modifiers as M};
 
 #[test]
 fn home_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_cursor(
-            *mode,
-            ("", ""),
-            &[(K::Home, M::NONE), (K::Enter, M::NONE)],
-            ("", ""),
-        );
+        assert_cursor(*mode, ("", ""), &[E(K::Home, M::NONE), E::ENTER], ("", ""));
         assert_cursor(
             *mode,
             ("Hi", ""),
-            &[(K::Home, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Home, M::NONE), E::ENTER],
             ("", "Hi"),
         );
         if *mode == EditMode::Vi {
@@ -24,7 +19,7 @@ fn home_key() {
             assert_cursor(
                 *mode,
                 ("Hi", ""),
-                &[(K::Esc, M::NONE), (K::Home, M::NONE), (K::Enter, M::NONE)],
+                &[E::ESC, E(K::Home, M::NONE), E::ENTER],
                 ("", "Hi"),
             );
         }
@@ -34,22 +29,17 @@ fn home_key() {
 #[test]
 fn end_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_cursor(
-            *mode,
-            ("", ""),
-            &[(K::End, M::NONE), (K::Enter, M::NONE)],
-            ("", ""),
-        );
+        assert_cursor(*mode, ("", ""), &[E(K::End, M::NONE), E::ENTER], ("", ""));
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[(K::End, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::End, M::NONE), E::ENTER],
             ("Hi", ""),
         );
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[(K::End, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::End, M::NONE), E::ENTER],
             ("Hi", ""),
         );
         if *mode == EditMode::Vi {
@@ -57,7 +47,7 @@ fn end_key() {
             assert_cursor(
                 *mode,
                 ("", "Hi"),
-                &[(K::Esc, M::NONE), (K::End, M::NONE), (K::Enter, M::NONE)],
+                &[E::ESC, E(K::End, M::NONE), E::ENTER],
                 ("Hi", ""),
             );
         }
@@ -70,19 +60,19 @@ fn left_key() {
         assert_cursor(
             *mode,
             ("Hi", ""),
-            &[(K::Left, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Left, M::NONE), E::ENTER],
             ("H", "i"),
         );
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[(K::Left, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Left, M::NONE), E::ENTER],
             ("", "Hi"),
         );
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[(K::Left, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Left, M::NONE), E::ENTER],
             ("", "Hi"),
         );
         if *mode == EditMode::Vi {
@@ -90,7 +80,7 @@ fn left_key() {
             assert_cursor(
                 *mode,
                 ("Bye", ""),
-                &[(K::Esc, M::NONE), (K::Left, M::NONE), (K::Enter, M::NONE)],
+                &[E::ESC, E(K::Left, M::NONE), E::ENTER],
                 ("B", "ye"),
             );
         }
@@ -100,28 +90,23 @@ fn left_key() {
 #[test]
 fn right_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_cursor(
-            *mode,
-            ("", ""),
-            &[(K::Right, M::NONE), (K::Enter, M::NONE)],
-            ("", ""),
-        );
+        assert_cursor(*mode, ("", ""), &[E(K::Right, M::NONE), E::ENTER], ("", ""));
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[(K::Right, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Right, M::NONE), E::ENTER],
             ("H", "i"),
         );
         assert_cursor(
             *mode,
             ("B", "ye"),
-            &[(K::Right, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Right, M::NONE), E::ENTER],
             ("By", "e"),
         );
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[(K::Right, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Right, M::NONE), E::ENTER],
             ("Hi", ""),
         );
         if *mode == EditMode::Vi {
@@ -129,7 +114,7 @@ fn right_key() {
             assert_cursor(
                 *mode,
                 ("", "Hi"),
-                &[(K::Esc, M::NONE), (K::Right, M::NONE), (K::Enter, M::NONE)],
+                &[E::ESC, E(K::Right, M::NONE), E::ENTER],
                 ("H", "i"),
             );
         }
@@ -139,41 +124,18 @@ fn right_key() {
 #[test]
 fn enter_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[(K::Enter, M::NONE)], "");
-        assert_line(*mode, &[(K::Char('a'), M::NONE), (K::Enter, M::NONE)], "a");
-        assert_line_with_initial(*mode, ("Hi", ""), &[(K::Enter, M::NONE)], "Hi");
-        assert_line_with_initial(*mode, ("", "Hi"), &[(K::Enter, M::NONE)], "Hi");
-        assert_line_with_initial(*mode, ("H", "i"), &[(K::Enter, M::NONE)], "Hi");
+        assert_line(*mode, &[E::ENTER], "");
+        assert_line(*mode, &[E::from('a'), E::ENTER], "a");
+        assert_line_with_initial(*mode, ("Hi", ""), &[E::ENTER], "Hi");
+        assert_line_with_initial(*mode, ("", "Hi"), &[E::ENTER], "Hi");
+        assert_line_with_initial(*mode, ("H", "i"), &[E::ENTER], "Hi");
         if *mode == EditMode::Vi {
             // vi command mode
-            assert_line(*mode, &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "");
-            assert_line(
-                *mode,
-                &[
-                    (K::Char('a'), M::NONE),
-                    (K::Esc, M::NONE),
-                    (K::Enter, M::NONE),
-                ],
-                "a",
-            );
-            assert_line_with_initial(
-                *mode,
-                ("Hi", ""),
-                &[(K::Esc, M::NONE), (K::Enter, M::NONE)],
-                "Hi",
-            );
-            assert_line_with_initial(
-                *mode,
-                ("", "Hi"),
-                &[(K::Esc, M::NONE), (K::Enter, M::NONE)],
-                "Hi",
-            );
-            assert_line_with_initial(
-                *mode,
-                ("H", "i"),
-                &[(K::Esc, M::NONE), (K::Enter, M::NONE)],
-                "Hi",
-            );
+            assert_line(*mode, &[E::ESC, E::ENTER], "");
+            assert_line(*mode, &[E::from('a'), E::ESC, E::ENTER], "a");
+            assert_line_with_initial(*mode, ("Hi", ""), &[E::ESC, E::ENTER], "Hi");
+            assert_line_with_initial(*mode, ("", "Hi"), &[E::ESC, E::ENTER], "Hi");
+            assert_line_with_initial(*mode, ("H", "i"), &[E::ESC, E::ENTER], "Hi");
         }
     }
 }
@@ -181,24 +143,12 @@ fn enter_key() {
 #[test]
 fn newline_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[(K::Char('J'), M::CTRL)], "");
-        assert_line(
-            *mode,
-            &[(K::Char('a'), M::NONE), (K::Char('J'), M::CTRL)],
-            "a",
-        );
+        assert_line(*mode, &[E::ctrl('J')], "");
+        assert_line(*mode, &[E::from('a'), E::ctrl('J')], "a");
         if *mode == EditMode::Vi {
             // vi command mode
-            assert_line(*mode, &[(K::Esc, M::NONE), (K::Char('J'), M::CTRL)], "");
-            assert_line(
-                *mode,
-                &[
-                    (K::Char('a'), M::NONE),
-                    (K::Esc, M::NONE),
-                    (K::Char('J'), M::CTRL),
-                ],
-                "a",
-            );
+            assert_line(*mode, &[E::ESC, E::ctrl('J')], "");
+            assert_line(*mode, &[E::from('a'), E::ESC, E::ctrl('J')], "a");
         }
     }
 }
@@ -206,61 +156,35 @@ fn newline_key() {
 #[test]
 fn eof_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        let mut editor = init_editor(*mode, &[(K::Char('D'), M::CTRL)]);
+        let mut editor = init_editor(*mode, &[E::ctrl('D')]);
         let err = editor.readline(">>");
         assert_matches!(err, Err(ReadlineError::Eof));
     }
     assert_line(
         EditMode::Emacs,
-        &[
-            (K::Char('a'), M::NONE),
-            (K::Char('D'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::from('a'), E::ctrl('D'), E::ENTER],
         "a",
     );
-    assert_line(
-        EditMode::Vi,
-        &[(K::Char('a'), M::NONE), (K::Char('D'), M::CTRL)],
-        "a",
-    );
-    assert_line(
-        EditMode::Vi,
-        &[
-            (K::Char('a'), M::NONE),
-            (K::Esc, M::NONE),
-            (K::Char('D'), M::CTRL),
-        ],
-        "a",
-    );
-    assert_line_with_initial(
-        EditMode::Emacs,
-        ("", "Hi"),
-        &[(K::Char('D'), M::CTRL), (K::Enter, M::NONE)],
-        "i",
-    );
-    assert_line_with_initial(EditMode::Vi, ("", "Hi"), &[(K::Char('D'), M::CTRL)], "Hi");
-    assert_line_with_initial(
-        EditMode::Vi,
-        ("", "Hi"),
-        &[(K::Esc, M::NONE), (K::Char('D'), M::CTRL)],
-        "Hi",
-    );
+    assert_line(EditMode::Vi, &[E::from('a'), E::ctrl('D')], "a");
+    assert_line(EditMode::Vi, &[E::from('a'), E::ESC, E::ctrl('D')], "a");
+    assert_line_with_initial(EditMode::Emacs, ("", "Hi"), &[E::ctrl('D'), E::ENTER], "i");
+    assert_line_with_initial(EditMode::Vi, ("", "Hi"), &[E::ctrl('D')], "Hi");
+    assert_line_with_initial(EditMode::Vi, ("", "Hi"), &[E::ESC, E::ctrl('D')], "Hi");
 }
 
 #[test]
 fn interrupt_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        let mut editor = init_editor(*mode, &[(K::Char('C'), M::CTRL)]);
+        let mut editor = init_editor(*mode, &[E::ctrl('C')]);
         let err = editor.readline(">>");
         assert_matches!(err, Err(ReadlineError::Interrupted));
 
-        let mut editor = init_editor(*mode, &[(K::Char('C'), M::CTRL)]);
+        let mut editor = init_editor(*mode, &[E::ctrl('C')]);
         let err = editor.readline_with_initial(">>", ("Hi", ""));
         assert_matches!(err, Err(ReadlineError::Interrupted));
         if *mode == EditMode::Vi {
             // vi command mode
-            let mut editor = init_editor(*mode, &[(K::Esc, M::NONE), (K::Char('C'), M::CTRL)]);
+            let mut editor = init_editor(*mode, &[E::ESC, E::ctrl('C')]);
             let err = editor.readline_with_initial(">>", ("Hi", ""));
             assert_matches!(err, Err(ReadlineError::Interrupted));
         }
@@ -273,13 +197,13 @@ fn delete_key() {
         assert_cursor(
             *mode,
             ("a", ""),
-            &[(K::Delete, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Delete, M::NONE), E::ENTER],
             ("a", ""),
         );
         assert_cursor(
             *mode,
             ("", "a"),
-            &[(K::Delete, M::NONE), (K::Enter, M::NONE)],
+            &[E(K::Delete, M::NONE), E::ENTER],
             ("", ""),
         );
         if *mode == EditMode::Vi {
@@ -287,7 +211,7 @@ fn delete_key() {
             assert_cursor(
                 *mode,
                 ("", "a"),
-                &[(K::Esc, M::NONE), (K::Delete, M::NONE), (K::Enter, M::NONE)],
+                &[E::ESC, E(K::Delete, M::NONE), E::ENTER],
                 ("", ""),
             );
         }
@@ -297,28 +221,14 @@ fn delete_key() {
 #[test]
 fn ctrl_t() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_cursor(
-            *mode,
-            ("a", "b"),
-            &[(K::Char('T'), M::CTRL), (K::Enter, M::NONE)],
-            ("ba", ""),
-        );
-        assert_cursor(
-            *mode,
-            ("ab", "cd"),
-            &[(K::Char('T'), M::CTRL), (K::Enter, M::NONE)],
-            ("acb", "d"),
-        );
+        assert_cursor(*mode, ("a", "b"), &[E::ctrl('T'), E::ENTER], ("ba", ""));
+        assert_cursor(*mode, ("ab", "cd"), &[E::ctrl('T'), E::ENTER], ("acb", "d"));
         if *mode == EditMode::Vi {
             // vi command mode
             assert_cursor(
                 *mode,
                 ("ab", ""),
-                &[
-                    (K::Esc, M::NONE),
-                    (K::Char('T'), M::CTRL),
-                    (K::Enter, M::NONE),
-                ],
+                &[E::ESC, E::ctrl('T'), E::ENTER],
                 ("ba", ""),
             );
         }
@@ -331,25 +241,16 @@ fn ctrl_u() {
         assert_cursor(
             *mode,
             ("start of line ", "end"),
-            &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
+            &[E::ctrl('U'), E::ENTER],
             ("", "end"),
         );
-        assert_cursor(
-            *mode,
-            ("", "end"),
-            &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
-            ("", "end"),
-        );
+        assert_cursor(*mode, ("", "end"), &[E::ctrl('U'), E::ENTER], ("", "end"));
         if *mode == EditMode::Vi {
             // vi command mode
             assert_cursor(
                 *mode,
                 ("start of line ", "end"),
-                &[
-                    (K::Esc, M::NONE),
-                    (K::Char('U'), M::CTRL),
-                    (K::Enter, M::NONE),
-                ],
+                &[E::ESC, E::ctrl('U'), E::ENTER],
                 ("", " end"),
             );
         }
@@ -363,11 +264,7 @@ fn ctrl_v() {
         assert_cursor(
             *mode,
             ("", ""),
-            &[
-                (K::Char('V'), M::CTRL),
-                (K::Char('\t'), M::NONE),
-                (K::Enter, M::NONE),
-            ],
+            &[E::ctrl('V'), E(K::Char('\t'), M::NONE), E::ENTER],
             ("\t", ""),
         );
         if *mode == EditMode::Vi {
@@ -375,12 +272,7 @@ fn ctrl_v() {
             assert_cursor(
                 *mode,
                 ("", ""),
-                &[
-                    (K::Esc, M::NONE),
-                    (K::Char('V'), M::CTRL),
-                    (K::Char('\t'), M::NONE),
-                    (K::Enter, M::NONE),
-                ],
+                &[E::ESC, E::ctrl('V'), E(K::Char('\t'), M::NONE), E::ENTER],
                 ("\t", ""),
             );
         }
@@ -393,13 +285,13 @@ fn ctrl_w() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[(K::Char('W'), M::CTRL), (K::Enter, M::NONE)],
+            &[E::ctrl('W'), E::ENTER],
             ("", "world"),
         );
         assert_cursor(
             *mode,
             ("Hello, world.", ""),
-            &[(K::Char('W'), M::CTRL), (K::Enter, M::NONE)],
+            &[E::ctrl('W'), E::ENTER],
             ("Hello, ", ""),
         );
         if *mode == EditMode::Vi {
@@ -407,11 +299,7 @@ fn ctrl_w() {
             assert_cursor(
                 *mode,
                 ("Hello, world.", ""),
-                &[
-                    (K::Esc, M::NONE),
-                    (K::Char('W'), M::CTRL),
-                    (K::Enter, M::NONE),
-                ],
+                &[E::ESC, E::ctrl('W'), E::ENTER],
                 ("Hello, ", "."),
             );
         }
@@ -424,11 +312,7 @@ fn ctrl_y() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[
-                (K::Char('W'), M::CTRL),
-                (K::Char('Y'), M::CTRL),
-                (K::Enter, M::NONE),
-            ],
+            &[E::ctrl('W'), E::ctrl('Y'), E::ENTER],
             ("Hello, ", "world"),
         );
     }
@@ -440,11 +324,7 @@ fn ctrl__() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[
-                (K::Char('W'), M::CTRL),
-                (K::Char('_'), M::CTRL),
-                (K::Enter, M::NONE),
-            ],
+            &[E::ctrl('W'), E::ctrl('_'), E::ENTER],
             ("Hello, ", "world"),
         );
         if *mode == EditMode::Vi {
@@ -452,12 +332,7 @@ fn ctrl__() {
             assert_cursor(
                 *mode,
                 ("Hello, ", "world"),
-                &[
-                    (K::Esc, M::NONE),
-                    (K::Char('W'), M::CTRL),
-                    (K::Char('_'), M::CTRL),
-                    (K::Enter, M::NONE),
-                ],
+                &[E::ESC, E::ctrl('W'), E::ctrl('_'), E::ENTER],
                 ("Hello,", " world"),
             );
         }

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -2,7 +2,7 @@
 use super::{assert_cursor, assert_line, assert_line_with_initial, init_editor};
 use crate::config::EditMode;
 use crate::error::ReadlineError;
-use crate::keys::KeyPress;
+use crate::keys::{KeyCode as K, Modifiers as M};
 
 #[test]
 fn home_key() {
@@ -10,13 +10,13 @@ fn home_key() {
         assert_cursor(
             *mode,
             ("", ""),
-            &[KeyPress::Home, KeyPress::Enter],
+            &[(K::Home, M::NONE), (K::Enter, M::NONE)],
             ("", ""),
         );
         assert_cursor(
             *mode,
             ("Hi", ""),
-            &[KeyPress::Home, KeyPress::Enter],
+            &[(K::Home, M::NONE), (K::Enter, M::NONE)],
             ("", "Hi"),
         );
         if *mode == EditMode::Vi {
@@ -24,7 +24,7 @@ fn home_key() {
             assert_cursor(
                 *mode,
                 ("Hi", ""),
-                &[KeyPress::Esc, KeyPress::Home, KeyPress::Enter],
+                &[(K::Esc, M::NONE), (K::Home, M::NONE), (K::Enter, M::NONE)],
                 ("", "Hi"),
             );
         }
@@ -34,17 +34,17 @@ fn home_key() {
 #[test]
 fn end_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_cursor(*mode, ("", ""), &[KeyPress::End, KeyPress::Enter], ("", ""));
+        assert_cursor(*mode, ("", ""), &[(K::End, M::NONE), (K::Enter, M::NONE)], ("", ""));
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[KeyPress::End, KeyPress::Enter],
+            &[(K::End, M::NONE), (K::Enter, M::NONE)],
             ("Hi", ""),
         );
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[KeyPress::End, KeyPress::Enter],
+            &[(K::End, M::NONE), (K::Enter, M::NONE)],
             ("Hi", ""),
         );
         if *mode == EditMode::Vi {
@@ -52,7 +52,7 @@ fn end_key() {
             assert_cursor(
                 *mode,
                 ("", "Hi"),
-                &[KeyPress::Esc, KeyPress::End, KeyPress::Enter],
+                &[(K::Esc, M::NONE), (K::End, M::NONE), (K::Enter, M::NONE)],
                 ("Hi", ""),
             );
         }
@@ -65,19 +65,19 @@ fn left_key() {
         assert_cursor(
             *mode,
             ("Hi", ""),
-            &[KeyPress::Left, KeyPress::Enter],
+            &[(K::Left, M::NONE), (K::Enter, M::NONE)],
             ("H", "i"),
         );
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[KeyPress::Left, KeyPress::Enter],
+            &[(K::Left, M::NONE), (K::Enter, M::NONE)],
             ("", "Hi"),
         );
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[KeyPress::Left, KeyPress::Enter],
+            &[(K::Left, M::NONE), (K::Enter, M::NONE)],
             ("", "Hi"),
         );
         if *mode == EditMode::Vi {
@@ -85,7 +85,7 @@ fn left_key() {
             assert_cursor(
                 *mode,
                 ("Bye", ""),
-                &[KeyPress::Esc, KeyPress::Left, KeyPress::Enter],
+                &[(K::Esc, M::NONE), (K::Left, M::NONE), (K::Enter, M::NONE)],
                 ("B", "ye"),
             );
         }
@@ -98,25 +98,25 @@ fn right_key() {
         assert_cursor(
             *mode,
             ("", ""),
-            &[KeyPress::Right, KeyPress::Enter],
+            &[(K::Right, M::NONE), (K::Enter, M::NONE)],
             ("", ""),
         );
         assert_cursor(
             *mode,
             ("", "Hi"),
-            &[KeyPress::Right, KeyPress::Enter],
+            &[(K::Right, M::NONE), (K::Enter, M::NONE)],
             ("H", "i"),
         );
         assert_cursor(
             *mode,
             ("B", "ye"),
-            &[KeyPress::Right, KeyPress::Enter],
+            &[(K::Right, M::NONE), (K::Enter, M::NONE)],
             ("By", "e"),
         );
         assert_cursor(
             *mode,
             ("H", "i"),
-            &[KeyPress::Right, KeyPress::Enter],
+            &[(K::Right, M::NONE), (K::Enter, M::NONE)],
             ("Hi", ""),
         );
         if *mode == EditMode::Vi {
@@ -124,7 +124,7 @@ fn right_key() {
             assert_cursor(
                 *mode,
                 ("", "Hi"),
-                &[KeyPress::Esc, KeyPress::Right, KeyPress::Enter],
+                &[(K::Esc, M::NONE), (K::Right, M::NONE), (K::Enter, M::NONE)],
                 ("H", "i"),
             );
         }
@@ -134,22 +134,22 @@ fn right_key() {
 #[test]
 fn enter_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[KeyPress::Enter], "");
-        assert_line(*mode, &[KeyPress::Char('a'), KeyPress::Enter], "a");
-        assert_line_with_initial(*mode, ("Hi", ""), &[KeyPress::Enter], "Hi");
-        assert_line_with_initial(*mode, ("", "Hi"), &[KeyPress::Enter], "Hi");
-        assert_line_with_initial(*mode, ("H", "i"), &[KeyPress::Enter], "Hi");
+        assert_line(*mode, &[(K::Enter, M::NONE)], "");
+        assert_line(*mode, &[(K::Char('a'), M::NONE), (K::Enter, M::NONE)], "a");
+        assert_line_with_initial(*mode, ("Hi", ""), &[(K::Enter, M::NONE)], "Hi");
+        assert_line_with_initial(*mode, ("", "Hi"), &[(K::Enter, M::NONE)], "Hi");
+        assert_line_with_initial(*mode, ("H", "i"), &[(K::Enter, M::NONE)], "Hi");
         if *mode == EditMode::Vi {
             // vi command mode
-            assert_line(*mode, &[KeyPress::Esc, KeyPress::Enter], "");
+            assert_line(*mode, &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "");
             assert_line(
                 *mode,
-                &[KeyPress::Char('a'), KeyPress::Esc, KeyPress::Enter],
+                &[(K::Char('a'), M::NONE), (K::Esc, M::NONE), (K::Enter, M::NONE)],
                 "a",
             );
-            assert_line_with_initial(*mode, ("Hi", ""), &[KeyPress::Esc, KeyPress::Enter], "Hi");
-            assert_line_with_initial(*mode, ("", "Hi"), &[KeyPress::Esc, KeyPress::Enter], "Hi");
-            assert_line_with_initial(*mode, ("H", "i"), &[KeyPress::Esc, KeyPress::Enter], "Hi");
+            assert_line_with_initial(*mode, ("Hi", ""), &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "Hi");
+            assert_line_with_initial(*mode, ("", "Hi"), &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "Hi");
+            assert_line_with_initial(*mode, ("H", "i"), &[(K::Esc, M::NONE), (K::Enter, M::NONE)], "Hi");
         }
     }
 }
@@ -157,14 +157,14 @@ fn enter_key() {
 #[test]
 fn newline_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[KeyPress::Ctrl('J')], "");
-        assert_line(*mode, &[KeyPress::Char('a'), KeyPress::Ctrl('J')], "a");
+        assert_line(*mode, &[(K::Char('J'), M::CTRL)], "");
+        assert_line(*mode, &[(K::Char('a'), M::NONE), (K::Char('J'), M::CTRL)], "a");
         if *mode == EditMode::Vi {
             // vi command mode
-            assert_line(*mode, &[KeyPress::Esc, KeyPress::Ctrl('J')], "");
+            assert_line(*mode, &[(K::Esc, M::NONE), (K::Char('J'), M::CTRL)], "");
             assert_line(
                 *mode,
-                &[KeyPress::Char('a'), KeyPress::Esc, KeyPress::Ctrl('J')],
+                &[(K::Char('a'), M::NONE), (K::Esc, M::NONE), (K::Char('J'), M::CTRL)],
                 "a",
             );
         }
@@ -174,36 +174,36 @@ fn newline_key() {
 #[test]
 fn eof_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        let mut editor = init_editor(*mode, &[KeyPress::Ctrl('D')]);
+        let mut editor = init_editor(*mode, &[(K::Char('D'), M::CTRL)]);
         let err = editor.readline(">>");
         assert_matches!(err, Err(ReadlineError::Eof));
     }
     assert_line(
         EditMode::Emacs,
-        &[KeyPress::Char('a'), KeyPress::Ctrl('D'), KeyPress::Enter],
+        &[(K::Char('a'), M::NONE), (K::Char('D'), M::CTRL), (K::Enter, M::NONE)],
         "a",
     );
     assert_line(
         EditMode::Vi,
-        &[KeyPress::Char('a'), KeyPress::Ctrl('D')],
+        &[(K::Char('a'), M::NONE), (K::Char('D'), M::CTRL)],
         "a",
     );
     assert_line(
         EditMode::Vi,
-        &[KeyPress::Char('a'), KeyPress::Esc, KeyPress::Ctrl('D')],
+        &[(K::Char('a'), M::NONE), (K::Esc, M::NONE), (K::Char('D'), M::CTRL)],
         "a",
     );
     assert_line_with_initial(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('D'), KeyPress::Enter],
+        &[(K::Char('D'), M::CTRL), (K::Enter, M::NONE)],
         "i",
     );
-    assert_line_with_initial(EditMode::Vi, ("", "Hi"), &[KeyPress::Ctrl('D')], "Hi");
+    assert_line_with_initial(EditMode::Vi, ("", "Hi"), &[(K::Char('D'), M::CTRL)], "Hi");
     assert_line_with_initial(
         EditMode::Vi,
         ("", "Hi"),
-        &[KeyPress::Esc, KeyPress::Ctrl('D')],
+        &[(K::Esc, M::NONE), (K::Char('D'), M::CTRL)],
         "Hi",
     );
 }
@@ -211,16 +211,16 @@ fn eof_key() {
 #[test]
 fn interrupt_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        let mut editor = init_editor(*mode, &[KeyPress::Ctrl('C')]);
+        let mut editor = init_editor(*mode, &[(K::Char('C'), M::CTRL)]);
         let err = editor.readline(">>");
         assert_matches!(err, Err(ReadlineError::Interrupted));
 
-        let mut editor = init_editor(*mode, &[KeyPress::Ctrl('C')]);
+        let mut editor = init_editor(*mode, &[(K::Char('C'), M::CTRL)]);
         let err = editor.readline_with_initial(">>", ("Hi", ""));
         assert_matches!(err, Err(ReadlineError::Interrupted));
         if *mode == EditMode::Vi {
             // vi command mode
-            let mut editor = init_editor(*mode, &[KeyPress::Esc, KeyPress::Ctrl('C')]);
+            let mut editor = init_editor(*mode, &[(K::Esc, M::NONE), (K::Char('C'), M::CTRL)]);
             let err = editor.readline_with_initial(">>", ("Hi", ""));
             assert_matches!(err, Err(ReadlineError::Interrupted));
         }
@@ -233,13 +233,13 @@ fn delete_key() {
         assert_cursor(
             *mode,
             ("a", ""),
-            &[KeyPress::Delete, KeyPress::Enter],
+            &[(K::Delete, M::NONE), (K::Enter, M::NONE)],
             ("a", ""),
         );
         assert_cursor(
             *mode,
             ("", "a"),
-            &[KeyPress::Delete, KeyPress::Enter],
+            &[(K::Delete, M::NONE), (K::Enter, M::NONE)],
             ("", ""),
         );
         if *mode == EditMode::Vi {
@@ -247,7 +247,7 @@ fn delete_key() {
             assert_cursor(
                 *mode,
                 ("", "a"),
-                &[KeyPress::Esc, KeyPress::Delete, KeyPress::Enter],
+                &[(K::Esc, M::NONE), (K::Delete, M::NONE), (K::Enter, M::NONE)],
                 ("", ""),
             );
         }
@@ -260,13 +260,13 @@ fn ctrl_t() {
         assert_cursor(
             *mode,
             ("a", "b"),
-            &[KeyPress::Ctrl('T'), KeyPress::Enter],
+            &[(K::Char('T'), M::CTRL), (K::Enter, M::NONE)],
             ("ba", ""),
         );
         assert_cursor(
             *mode,
             ("ab", "cd"),
-            &[KeyPress::Ctrl('T'), KeyPress::Enter],
+            &[(K::Char('T'), M::CTRL), (K::Enter, M::NONE)],
             ("acb", "d"),
         );
         if *mode == EditMode::Vi {
@@ -274,7 +274,7 @@ fn ctrl_t() {
             assert_cursor(
                 *mode,
                 ("ab", ""),
-                &[KeyPress::Esc, KeyPress::Ctrl('T'), KeyPress::Enter],
+                &[(K::Esc, M::NONE), (K::Char('T'), M::CTRL), (K::Enter, M::NONE)],
                 ("ba", ""),
             );
         }
@@ -287,13 +287,13 @@ fn ctrl_u() {
         assert_cursor(
             *mode,
             ("start of line ", "end"),
-            &[KeyPress::Ctrl('U'), KeyPress::Enter],
+            &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
             ("", "end"),
         );
         assert_cursor(
             *mode,
             ("", "end"),
-            &[KeyPress::Ctrl('U'), KeyPress::Enter],
+            &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
             ("", "end"),
         );
         if *mode == EditMode::Vi {
@@ -301,7 +301,7 @@ fn ctrl_u() {
             assert_cursor(
                 *mode,
                 ("start of line ", "end"),
-                &[KeyPress::Esc, KeyPress::Ctrl('U'), KeyPress::Enter],
+                &[(K::Esc, M::NONE), (K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
                 ("", " end"),
             );
         }
@@ -315,7 +315,7 @@ fn ctrl_v() {
         assert_cursor(
             *mode,
             ("", ""),
-            &[KeyPress::Ctrl('V'), KeyPress::Char('\t'), KeyPress::Enter],
+            &[(K::Char('V'), M::CTRL), (K::Char('\t'), M::NONE), (K::Enter, M::NONE)],
             ("\t", ""),
         );
         if *mode == EditMode::Vi {
@@ -324,10 +324,10 @@ fn ctrl_v() {
                 *mode,
                 ("", ""),
                 &[
-                    KeyPress::Esc,
-                    KeyPress::Ctrl('V'),
-                    KeyPress::Char('\t'),
-                    KeyPress::Enter,
+                    (K::Esc, M::NONE),
+                    (K::Char('V'), M::CTRL),
+                    (K::Char('\t'), M::NONE),
+                    (K::Enter, M::NONE),
                 ],
                 ("\t", ""),
             );
@@ -341,13 +341,13 @@ fn ctrl_w() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[KeyPress::Ctrl('W'), KeyPress::Enter],
+            &[(K::Char('W'), M::CTRL), (K::Enter, M::NONE)],
             ("", "world"),
         );
         assert_cursor(
             *mode,
             ("Hello, world.", ""),
-            &[KeyPress::Ctrl('W'), KeyPress::Enter],
+            &[(K::Char('W'), M::CTRL), (K::Enter, M::NONE)],
             ("Hello, ", ""),
         );
         if *mode == EditMode::Vi {
@@ -355,7 +355,7 @@ fn ctrl_w() {
             assert_cursor(
                 *mode,
                 ("Hello, world.", ""),
-                &[KeyPress::Esc, KeyPress::Ctrl('W'), KeyPress::Enter],
+                &[(K::Esc, M::NONE), (K::Char('W'), M::CTRL), (K::Enter, M::NONE)],
                 ("Hello, ", "."),
             );
         }
@@ -368,7 +368,7 @@ fn ctrl_y() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[KeyPress::Ctrl('W'), KeyPress::Ctrl('Y'), KeyPress::Enter],
+            &[(K::Char('W'), M::CTRL), (K::Char('Y'), M::CTRL), (K::Enter, M::NONE)],
             ("Hello, ", "world"),
         );
     }
@@ -380,7 +380,7 @@ fn ctrl__() {
         assert_cursor(
             *mode,
             ("Hello, ", "world"),
-            &[KeyPress::Ctrl('W'), KeyPress::Ctrl('_'), KeyPress::Enter],
+            &[(K::Char('W'), M::CTRL), (K::Char('_'), M::CTRL), (K::Enter, M::NONE)],
             ("Hello, ", "world"),
         );
         if *mode == EditMode::Vi {
@@ -389,10 +389,10 @@ fn ctrl__() {
                 *mode,
                 ("Hello, ", "world"),
                 &[
-                    KeyPress::Esc,
-                    KeyPress::Ctrl('W'),
-                    KeyPress::Ctrl('_'),
-                    KeyPress::Enter,
+                    (K::Esc, M::NONE),
+                    (K::Char('W'), M::CTRL),
+                    (K::Char('_'), M::CTRL),
+                    (K::Enter, M::NONE),
                 ],
                 ("Hello,", " world"),
             );

--- a/src/test/emacs.rs
+++ b/src/test/emacs.rs
@@ -1,20 +1,20 @@
 //! Emacs specific key bindings
 use super::{assert_cursor, assert_history};
 use crate::config::EditMode;
-use crate::keys::KeyPress;
+use crate::keys::{KeyCode as K, Modifiers as M};
 
 #[test]
 fn ctrl_a() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('A'), KeyPress::Enter],
+        &[(K::Char('A'), M::CTRL), (K::Enter, M::NONE)],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("test test\n123", "foo"),
-        &[KeyPress::Ctrl('A'), KeyPress::Enter],
+        &[(K::Char('A'), M::CTRL), (K::Enter, M::NONE)],
         ("test test\n", "123foo"),
     );
 }
@@ -24,13 +24,13 @@ fn ctrl_e() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('E'), KeyPress::Enter],
+        &[(K::Char('E'), M::CTRL), (K::Enter, M::NONE)],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo", "test test\n123"),
-        &[KeyPress::Ctrl('E'), KeyPress::Enter],
+        &[(K::Char('E'), M::CTRL), (K::Enter, M::NONE)],
         ("footest test", "\n123"),
     );
 }
@@ -40,23 +40,23 @@ fn ctrl_b() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('B'), KeyPress::Enter],
+        &[(K::Char('B'), M::CTRL), (K::Enter, M::NONE)],
         ("H", "i"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Meta('2'), KeyPress::Ctrl('B'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('B'), M::CTRL), (K::Enter, M::NONE)],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
         &[
-            KeyPress::Meta('-'),
-            KeyPress::Meta('2'),
-            KeyPress::Ctrl('B'),
-            KeyPress::Enter,
+            (K::Char('-'), M::ALT),
+            (K::Char('2'), M::ALT),
+            (K::Char('B'), M::CTRL),
+            (K::Enter, M::NONE),
         ],
         ("Hi", ""),
     );
@@ -67,23 +67,23 @@ fn ctrl_f() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('F'), KeyPress::Enter],
+        &[(K::Char('F'), M::CTRL), (K::Enter, M::NONE)],
         ("H", "i"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Meta('2'), KeyPress::Ctrl('F'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('F'), M::CTRL), (K::Enter, M::NONE)],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
         &[
-            KeyPress::Meta('-'),
-            KeyPress::Meta('2'),
-            KeyPress::Ctrl('F'),
-            KeyPress::Enter,
+            (K::Char('-'), M::ALT),
+            (K::Char('2'), M::ALT),
+            (K::Char('F'), M::CTRL),
+            (K::Enter, M::NONE),
         ],
         ("", "Hi"),
     );
@@ -94,23 +94,23 @@ fn ctrl_h() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('H'), KeyPress::Enter],
+        &[(K::Char('H'), M::CTRL), (K::Enter, M::NONE)],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Meta('2'), KeyPress::Ctrl('H'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('H'), M::CTRL), (K::Enter, M::NONE)],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
         &[
-            KeyPress::Meta('-'),
-            KeyPress::Meta('2'),
-            KeyPress::Ctrl('H'),
-            KeyPress::Enter,
+            (K::Char('-'), M::ALT),
+            (K::Char('2'), M::ALT),
+            (K::Char('H'), M::CTRL),
+            (K::Enter, M::NONE),
         ],
         ("", ""),
     );
@@ -121,19 +121,19 @@ fn backspace() {
     assert_cursor(
         EditMode::Emacs,
         ("", ""),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
         ("", "Hi"),
     );
 }
@@ -143,37 +143,37 @@ fn ctrl_k() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("B", "ye"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
         ("B", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "foo\nbar"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
         ("Hi", "\nbar"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "\nbar"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
         ("Hi", "bar"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "bar"),
-        &[KeyPress::Ctrl('K'), KeyPress::Enter],
+        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
         ("Hi", ""),
     );
 }
@@ -183,37 +183,37 @@ fn ctrl_u() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("B", "ye"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
         ("", "ye"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo\nbar", "Hi"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
         ("foo\n", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo\n", "Hi"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
         ("foo", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo", "Hi"),
-        &[KeyPress::Ctrl('U'), KeyPress::Enter],
+        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
         ("", "Hi"),
     );
 }
@@ -223,10 +223,10 @@ fn ctrl_n() {
         EditMode::Emacs,
         &["line1", "line2"],
         &[
-            KeyPress::Ctrl('P'),
-            KeyPress::Ctrl('P'),
-            KeyPress::Ctrl('N'),
-            KeyPress::Enter,
+            (K::Char('P'), M::CTRL),
+            (K::Char('P'), M::CTRL),
+            (K::Char('N'), M::CTRL),
+            (K::Enter, M::NONE),
         ],
         "",
         ("line2", ""),
@@ -238,7 +238,7 @@ fn ctrl_p() {
     assert_history(
         EditMode::Emacs,
         &["line1"],
-        &[KeyPress::Ctrl('P'), KeyPress::Enter],
+        &[(K::Char('P'), M::CTRL), (K::Enter, M::NONE)],
         "",
         ("line1", ""),
     );
@@ -249,7 +249,7 @@ fn ctrl_t() {
     /* FIXME
     assert_cursor(
         ("ab", "cd"),
-        &[KeyPress::Meta('2'), KeyPress::Ctrl('T'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('T'), M::CTRL), (K::Enter, M::NONE)],
         ("acdb", ""),
     );*/
 }
@@ -260,10 +260,10 @@ fn ctrl_x_ctrl_u() {
         EditMode::Emacs,
         ("Hello, ", "world"),
         &[
-            KeyPress::Ctrl('W'),
-            KeyPress::Ctrl('X'),
-            KeyPress::Ctrl('U'),
-            KeyPress::Enter,
+            (K::Char('W'), M::CTRL),
+            (K::Char('X'), M::CTRL),
+            (K::Char('U'), M::CTRL),
+            (K::Enter, M::NONE),
         ],
         ("Hello, ", "world"),
     );
@@ -274,19 +274,19 @@ fn meta_b() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[KeyPress::Meta('B'), KeyPress::Enter],
+        &[(K::Char('B'), M::ALT), (K::Enter, M::NONE)],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[KeyPress::Meta('2'), KeyPress::Meta('B'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('B'), M::ALT), (K::Enter, M::NONE)],
         ("", "Hello, world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[KeyPress::Meta('-'), KeyPress::Meta('B'), KeyPress::Enter],
+        &[(K::Char('-'), M::ALT), (K::Char('B'), M::ALT), (K::Enter, M::NONE)],
         ("Hello", ", world!"),
     );
 }
@@ -296,19 +296,19 @@ fn meta_f() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[KeyPress::Meta('F'), KeyPress::Enter],
+        &[(K::Char('F'), M::ALT), (K::Enter, M::NONE)],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('F'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('F'), M::ALT), (K::Enter, M::NONE)],
         ("Hello, world", "!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[KeyPress::Meta('-'), KeyPress::Meta('F'), KeyPress::Enter],
+        &[(K::Char('-'), M::ALT), (K::Char('F'), M::ALT), (K::Enter, M::NONE)],
         ("Hello, ", "world!"),
     );
 }
@@ -318,19 +318,19 @@ fn meta_c() {
     assert_cursor(
         EditMode::Emacs,
         ("hi", ""),
-        &[KeyPress::Meta('C'), KeyPress::Enter],
+        &[(K::Char('C'), M::ALT), (K::Enter, M::NONE)],
         ("hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "hi"),
-        &[KeyPress::Meta('C'), KeyPress::Enter],
+        &[(K::Char('C'), M::ALT), (K::Enter, M::NONE)],
         ("Hi", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "hi test"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('C'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('C'), M::ALT), (K::Enter, M::NONE)],
         ("Hi Test", ""),
     );*/
 }
@@ -340,19 +340,19 @@ fn meta_l() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[KeyPress::Meta('L'), KeyPress::Enter],
+        &[(K::Char('L'), M::ALT), (K::Enter, M::NONE)],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "HI"),
-        &[KeyPress::Meta('L'), KeyPress::Enter],
+        &[(K::Char('L'), M::ALT), (K::Enter, M::NONE)],
         ("hi", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "HI TEST"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('L'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('L'), M::ALT), (K::Enter, M::NONE)],
         ("hi test", ""),
     );*/
 }
@@ -362,19 +362,19 @@ fn meta_u() {
     assert_cursor(
         EditMode::Emacs,
         ("hi", ""),
-        &[KeyPress::Meta('U'), KeyPress::Enter],
+        &[(K::Char('U'), M::ALT), (K::Enter, M::NONE)],
         ("hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "hi"),
-        &[KeyPress::Meta('U'), KeyPress::Enter],
+        &[(K::Char('U'), M::ALT), (K::Enter, M::NONE)],
         ("HI", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "hi test"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('U'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('U'), M::ALT), (K::Enter, M::NONE)],
         ("HI TEST", ""),
     );*/
 }
@@ -384,13 +384,13 @@ fn meta_d() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[KeyPress::Meta('D'), KeyPress::Enter],
+        &[(K::Char('D'), M::ALT), (K::Enter, M::NONE)],
         ("Hello", "!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[KeyPress::Meta('2'), KeyPress::Meta('D'), KeyPress::Enter],
+        &[(K::Char('2'), M::ALT), (K::Char('D'), M::ALT), (K::Enter, M::NONE)],
         ("Hello", ""),
     );
 }
@@ -400,13 +400,13 @@ fn meta_t() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[KeyPress::Meta('T'), KeyPress::Enter],
+        &[(K::Char('T'), M::ALT), (K::Enter, M::NONE)],
         ("world, Hello", "!"),
     );
     /* FIXME
     assert_cursor(
         ("One Two", " Three Four"),
-        &[KeyPress::Meta('T'), KeyPress::Enter],
+        &[(K::Char('T'), M::ALT), (K::Enter, M::NONE)],
         ("One Four Three Two", ""),
     );*/
 }
@@ -417,12 +417,12 @@ fn meta_y() {
         EditMode::Emacs,
         ("Hello, world", "!"),
         &[
-            KeyPress::Ctrl('W'),
-            KeyPress::Left,
-            KeyPress::Ctrl('W'),
-            KeyPress::Ctrl('Y'),
-            KeyPress::Meta('Y'),
-            KeyPress::Enter,
+            (K::Char('W'), M::CTRL),
+            (K::Left, M::NONE),
+            (K::Char('W'), M::CTRL),
+            (K::Char('Y'), M::CTRL),
+            (K::Char('Y'), M::ALT),
+            (K::Enter, M::NONE),
         ],
         ("world", " !"),
     );
@@ -433,7 +433,7 @@ fn meta_backspace() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, wor", "ld!"),
-        &[KeyPress::Meta('\x08'), KeyPress::Enter],
+        &[(K::Char('\x08'), M::ALT), (K::Enter, M::NONE)],
         ("Hello, ", "ld!"),
     );
 }
@@ -443,7 +443,7 @@ fn meta_digit() {
     assert_cursor(
         EditMode::Emacs,
         ("", ""),
-        &[KeyPress::Meta('3'), KeyPress::Char('h'), KeyPress::Enter],
+        &[(K::Char('3'), M::ALT), (K::Char('h'), M::NONE), (K::Enter, M::NONE)],
         ("hhh", ""),
     );
 }

--- a/src/test/emacs.rs
+++ b/src/test/emacs.rs
@@ -408,7 +408,7 @@ fn meta_backspace() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, wor", "ld!"),
-        &[E(K::Char('\x08'), M::ALT), E::ENTER],
+        &[E(K::Backspace, M::ALT), E::ENTER],
         ("Hello, ", "ld!"),
     );
 }

--- a/src/test/emacs.rs
+++ b/src/test/emacs.rs
@@ -46,7 +46,11 @@ fn ctrl_b() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Char('2'), M::ALT), (K::Char('B'), M::CTRL), (K::Enter, M::NONE)],
+        &[
+            (K::Char('2'), M::ALT),
+            (K::Char('B'), M::CTRL),
+            (K::Enter, M::NONE),
+        ],
         ("", "Hi"),
     );
     assert_cursor(
@@ -73,7 +77,11 @@ fn ctrl_f() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[(K::Char('2'), M::ALT), (K::Char('F'), M::CTRL), (K::Enter, M::NONE)],
+        &[
+            (K::Char('2'), M::ALT),
+            (K::Char('F'), M::CTRL),
+            (K::Enter, M::NONE),
+        ],
         ("Hi", ""),
     );
     assert_cursor(
@@ -100,7 +108,11 @@ fn ctrl_h() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Char('2'), M::ALT), (K::Char('H'), M::CTRL), (K::Enter, M::NONE)],
+        &[
+            (K::Char('2'), M::ALT),
+            (K::Char('H'), M::CTRL),
+            (K::Enter, M::NONE),
+        ],
         ("", ""),
     );
     assert_cursor(
@@ -280,13 +292,21 @@ fn meta_b() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[(K::Char('2'), M::ALT), (K::Char('B'), M::ALT), (K::Enter, M::NONE)],
+        &[
+            (K::Char('2'), M::ALT),
+            (K::Char('B'), M::ALT),
+            (K::Enter, M::NONE),
+        ],
         ("", "Hello, world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[(K::Char('-'), M::ALT), (K::Char('B'), M::ALT), (K::Enter, M::NONE)],
+        &[
+            (K::Char('-'), M::ALT),
+            (K::Char('B'), M::ALT),
+            (K::Enter, M::NONE),
+        ],
         ("Hello", ", world!"),
     );
 }
@@ -302,13 +322,21 @@ fn meta_f() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[(K::Char('2'), M::ALT), (K::Char('F'), M::ALT), (K::Enter, M::NONE)],
+        &[
+            (K::Char('2'), M::ALT),
+            (K::Char('F'), M::ALT),
+            (K::Enter, M::NONE),
+        ],
         ("Hello, world", "!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[(K::Char('-'), M::ALT), (K::Char('F'), M::ALT), (K::Enter, M::NONE)],
+        &[
+            (K::Char('-'), M::ALT),
+            (K::Char('F'), M::ALT),
+            (K::Enter, M::NONE),
+        ],
         ("Hello, ", "world!"),
     );
 }
@@ -390,7 +418,11 @@ fn meta_d() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[(K::Char('2'), M::ALT), (K::Char('D'), M::ALT), (K::Enter, M::NONE)],
+        &[
+            (K::Char('2'), M::ALT),
+            (K::Char('D'), M::ALT),
+            (K::Enter, M::NONE),
+        ],
         ("Hello", ""),
     );
 }
@@ -443,7 +475,11 @@ fn meta_digit() {
     assert_cursor(
         EditMode::Emacs,
         ("", ""),
-        &[(K::Char('3'), M::ALT), (K::Char('h'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Char('3'), M::ALT),
+            (K::Char('h'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("hhh", ""),
     );
 }

--- a/src/test/emacs.rs
+++ b/src/test/emacs.rs
@@ -1,20 +1,20 @@
 //! Emacs specific key bindings
 use super::{assert_cursor, assert_history};
 use crate::config::EditMode;
-use crate::keys::{KeyCode as K, Modifiers as M};
+use crate::keys::{KeyCode as K, KeyEvent as E, Modifiers as M};
 
 #[test]
 fn ctrl_a() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Char('A'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('A'), E::ENTER],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("test test\n123", "foo"),
-        &[(K::Char('A'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('A'), E::ENTER],
         ("test test\n", "123foo"),
     );
 }
@@ -24,13 +24,13 @@ fn ctrl_e() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[(K::Char('E'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('E'), E::ENTER],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo", "test test\n123"),
-        &[(K::Char('E'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('E'), E::ENTER],
         ("footest test", "\n123"),
     );
 }
@@ -40,28 +40,19 @@ fn ctrl_b() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Char('B'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('B'), E::ENTER],
         ("H", "i"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[
-            (K::Char('2'), M::ALT),
-            (K::Char('B'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('2'), E::ctrl('B'), E::ENTER],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[
-            (K::Char('-'), M::ALT),
-            (K::Char('2'), M::ALT),
-            (K::Char('B'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('-'), E::alt('2'), E::ctrl('B'), E::ENTER],
         ("Hi", ""),
     );
 }
@@ -71,28 +62,19 @@ fn ctrl_f() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[(K::Char('F'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('F'), E::ENTER],
         ("H", "i"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[
-            (K::Char('2'), M::ALT),
-            (K::Char('F'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('2'), E::ctrl('F'), E::ENTER],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[
-            (K::Char('-'), M::ALT),
-            (K::Char('2'), M::ALT),
-            (K::Char('F'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('-'), E::alt('2'), E::ctrl('F'), E::ENTER],
         ("", "Hi"),
     );
 }
@@ -102,28 +84,19 @@ fn ctrl_h() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Char('H'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('H'), E::ENTER],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[
-            (K::Char('2'), M::ALT),
-            (K::Char('H'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('2'), E::ctrl('H'), E::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[
-            (K::Char('-'), M::ALT),
-            (K::Char('2'), M::ALT),
-            (K::Char('H'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('-'), E::alt('2'), E::ctrl('H'), E::ENTER],
         ("", ""),
     );
 }
@@ -133,19 +106,19 @@ fn backspace() {
     assert_cursor(
         EditMode::Emacs,
         ("", ""),
-        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
+        &[E::BACKSPACE, E::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
+        &[E::BACKSPACE, E::ENTER],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
+        &[E::BACKSPACE, E::ENTER],
         ("", "Hi"),
     );
 }
@@ -155,37 +128,37 @@ fn ctrl_k() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('K'), E::ENTER],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('K'), E::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("B", "ye"),
-        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('K'), E::ENTER],
         ("B", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "foo\nbar"),
-        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('K'), E::ENTER],
         ("Hi", "\nbar"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "\nbar"),
-        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('K'), E::ENTER],
         ("Hi", "bar"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", "bar"),
-        &[(K::Char('K'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('K'), E::ENTER],
         ("Hi", ""),
     );
 }
@@ -195,37 +168,37 @@ fn ctrl_u() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hi"),
-        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('U'), E::ENTER],
         ("", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('U'), E::ENTER],
         ("", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("B", "ye"),
-        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('U'), E::ENTER],
         ("", "ye"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo\nbar", "Hi"),
-        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('U'), E::ENTER],
         ("foo\n", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo\n", "Hi"),
-        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('U'), E::ENTER],
         ("foo", "Hi"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("foo", "Hi"),
-        &[(K::Char('U'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('U'), E::ENTER],
         ("", "Hi"),
     );
 }
@@ -234,12 +207,7 @@ fn ctrl_n() {
     assert_history(
         EditMode::Emacs,
         &["line1", "line2"],
-        &[
-            (K::Char('P'), M::CTRL),
-            (K::Char('P'), M::CTRL),
-            (K::Char('N'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ctrl('P'), E::ctrl('P'), E::ctrl('N'), E::ENTER],
         "",
         ("line2", ""),
     );
@@ -250,7 +218,7 @@ fn ctrl_p() {
     assert_history(
         EditMode::Emacs,
         &["line1"],
-        &[(K::Char('P'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('P'), E::ENTER],
         "",
         ("line1", ""),
     );
@@ -261,7 +229,7 @@ fn ctrl_t() {
     /* FIXME
     assert_cursor(
         ("ab", "cd"),
-        &[(K::Char('2'), M::ALT), (K::Char('T'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::alt('2'), E::ctrl('T'), E::ENTER],
         ("acdb", ""),
     );*/
 }
@@ -271,12 +239,7 @@ fn ctrl_x_ctrl_u() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, ", "world"),
-        &[
-            (K::Char('W'), M::CTRL),
-            (K::Char('X'), M::CTRL),
-            (K::Char('U'), M::CTRL),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ctrl('W'), E::ctrl('X'), E::ctrl('U'), E::ENTER],
         ("Hello, ", "world"),
     );
 }
@@ -286,27 +249,19 @@ fn meta_b() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[(K::Char('B'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('B'), E::ENTER],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[
-            (K::Char('2'), M::ALT),
-            (K::Char('B'), M::ALT),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('2'), E::alt('B'), E::ENTER],
         ("", "Hello, world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[
-            (K::Char('-'), M::ALT),
-            (K::Char('B'), M::ALT),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('-'), E::alt('B'), E::ENTER],
         ("Hello", ", world!"),
     );
 }
@@ -316,27 +271,19 @@ fn meta_f() {
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[(K::Char('F'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('F'), E::ENTER],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "Hello, world!"),
-        &[
-            (K::Char('2'), M::ALT),
-            (K::Char('F'), M::ALT),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('2'), E::alt('F'), E::ENTER],
         ("Hello, world", "!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello, world!", ""),
-        &[
-            (K::Char('-'), M::ALT),
-            (K::Char('F'), M::ALT),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('-'), E::alt('F'), E::ENTER],
         ("Hello, ", "world!"),
     );
 }
@@ -346,19 +293,19 @@ fn meta_c() {
     assert_cursor(
         EditMode::Emacs,
         ("hi", ""),
-        &[(K::Char('C'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('C'), E::ENTER],
         ("hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "hi"),
-        &[(K::Char('C'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('C'), E::ENTER],
         ("Hi", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "hi test"),
-        &[(K::Char('2'), M::ALT), (K::Char('C'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('2'), E::alt('C'), E::ENTER],
         ("Hi Test", ""),
     );*/
 }
@@ -368,19 +315,19 @@ fn meta_l() {
     assert_cursor(
         EditMode::Emacs,
         ("Hi", ""),
-        &[(K::Char('L'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('L'), E::ENTER],
         ("Hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "HI"),
-        &[(K::Char('L'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('L'), E::ENTER],
         ("hi", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "HI TEST"),
-        &[(K::Char('2'), M::ALT), (K::Char('L'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('2'), E::alt('L'), E::ENTER],
         ("hi test", ""),
     );*/
 }
@@ -390,19 +337,19 @@ fn meta_u() {
     assert_cursor(
         EditMode::Emacs,
         ("hi", ""),
-        &[(K::Char('U'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('U'), E::ENTER],
         ("hi", ""),
     );
     assert_cursor(
         EditMode::Emacs,
         ("", "hi"),
-        &[(K::Char('U'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('U'), E::ENTER],
         ("HI", ""),
     );
     /* FIXME
     assert_cursor(
         ("", "hi test"),
-        &[(K::Char('2'), M::ALT), (K::Char('U'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('2'), E::alt('U'), E::ENTER],
         ("HI TEST", ""),
     );*/
 }
@@ -412,17 +359,13 @@ fn meta_d() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[(K::Char('D'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('D'), E::ENTER],
         ("Hello", "!"),
     );
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[
-            (K::Char('2'), M::ALT),
-            (K::Char('D'), M::ALT),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('2'), E::alt('D'), E::ENTER],
         ("Hello", ""),
     );
 }
@@ -432,13 +375,13 @@ fn meta_t() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello", ", world!"),
-        &[(K::Char('T'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('T'), E::ENTER],
         ("world, Hello", "!"),
     );
     /* FIXME
     assert_cursor(
         ("One Two", " Three Four"),
-        &[(K::Char('T'), M::ALT), (K::Enter, M::NONE)],
+        &[E::alt('T'), E::ENTER],
         ("One Four Three Two", ""),
     );*/
 }
@@ -449,12 +392,12 @@ fn meta_y() {
         EditMode::Emacs,
         ("Hello, world", "!"),
         &[
-            (K::Char('W'), M::CTRL),
-            (K::Left, M::NONE),
-            (K::Char('W'), M::CTRL),
-            (K::Char('Y'), M::CTRL),
-            (K::Char('Y'), M::ALT),
-            (K::Enter, M::NONE),
+            E::ctrl('W'),
+            E(K::Left, M::NONE),
+            E::ctrl('W'),
+            E::ctrl('Y'),
+            E::alt('Y'),
+            E::ENTER,
         ],
         ("world", " !"),
     );
@@ -465,7 +408,7 @@ fn meta_backspace() {
     assert_cursor(
         EditMode::Emacs,
         ("Hello, wor", "ld!"),
-        &[(K::Char('\x08'), M::ALT), (K::Enter, M::NONE)],
+        &[E(K::Char('\x08'), M::ALT), E::ENTER],
         ("Hello, ", "ld!"),
     );
 }
@@ -475,11 +418,7 @@ fn meta_digit() {
     assert_cursor(
         EditMode::Emacs,
         ("", ""),
-        &[
-            (K::Char('3'), M::ALT),
-            (K::Char('h'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::alt('3'), E::from('h'), E::ENTER],
         ("hhh", ""),
     );
 }

--- a/src/test/history.rs
+++ b/src/test/history.rs
@@ -1,7 +1,7 @@
 //! History related commands tests
 use super::assert_history;
 use crate::config::EditMode;
-use crate::keys::KeyPress;
+use crate::keys::{KeyCode as K, Modifiers as M};
 
 #[test]
 fn down_key() {
@@ -9,14 +9,14 @@ fn down_key() {
         assert_history(
             *mode,
             &["line1"],
-            &[KeyPress::Down, KeyPress::Enter],
+            &[(K::Down, M::NONE), (K::Enter, M::NONE)],
             "",
             ("", ""),
         );
         assert_history(
             *mode,
             &["line1", "line2"],
-            &[KeyPress::Up, KeyPress::Up, KeyPress::Down, KeyPress::Enter],
+            &[(K::Up, M::NONE), (K::Up, M::NONE), (K::Down, M::NONE), (K::Enter, M::NONE)],
             "",
             ("line2", ""),
         );
@@ -24,10 +24,10 @@ fn down_key() {
             *mode,
             &["line1"],
             &[
-                KeyPress::Char('a'),
-                KeyPress::Up,
-                KeyPress::Down, // restore original line
-                KeyPress::Enter,
+                (K::Char('a'), M::NONE),
+                (K::Up, M::NONE),
+                (K::Down, M::NONE), // restore original line
+                (K::Enter, M::NONE),
             ],
             "",
             ("a", ""),
@@ -36,9 +36,9 @@ fn down_key() {
             *mode,
             &["line1"],
             &[
-                KeyPress::Char('a'),
-                KeyPress::Down, // noop
-                KeyPress::Enter,
+                (K::Char('a'), M::NONE),
+                (K::Down, M::NONE), // noop
+                (K::Enter, M::NONE),
             ],
             "",
             ("a", ""),
@@ -49,18 +49,18 @@ fn down_key() {
 #[test]
 fn up_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_history(*mode, &[], &[KeyPress::Up, KeyPress::Enter], "", ("", ""));
+        assert_history(*mode, &[], &[(K::Up, M::NONE), (K::Enter, M::NONE)], "", ("", ""));
         assert_history(
             *mode,
             &["line1"],
-            &[KeyPress::Up, KeyPress::Enter],
+            &[(K::Up, M::NONE), (K::Enter, M::NONE)],
             "",
             ("line1", ""),
         );
         assert_history(
             *mode,
             &["line1", "line2"],
-            &[KeyPress::Up, KeyPress::Up, KeyPress::Enter],
+            &[(K::Up, M::NONE), (K::Up, M::NONE), (K::Enter, M::NONE)],
             "",
             ("line1", ""),
         );
@@ -73,7 +73,7 @@ fn ctrl_r() {
         assert_history(
             *mode,
             &[],
-            &[KeyPress::Ctrl('R'), KeyPress::Char('o'), KeyPress::Enter],
+            &[(K::Char('R'), M::CTRL), (K::Char('o'), M::NONE), (K::Enter, M::NONE)],
             "",
             ("o", ""),
         );
@@ -81,10 +81,10 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('o'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                (K::Char('R'), M::CTRL),
+                (K::Char('o'), M::NONE),
+                (K::Right, M::NONE), // just to assert cursor pos
+                (K::Enter, M::NONE),
             ],
             "",
             ("cargo", ""),
@@ -93,10 +93,10 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('u'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                (K::Char('R'), M::CTRL),
+                (K::Char('u'), M::NONE),
+                (K::Right, M::NONE), // just to assert cursor pos
+                (K::Enter, M::NONE),
             ],
             "",
             ("ru", "stc"),
@@ -105,11 +105,11 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Char('u'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                (K::Char('R'), M::CTRL),
+                (K::Char('r'), M::NONE),
+                (K::Char('u'), M::NONE),
+                (K::Right, M::NONE), // just to assert cursor pos
+                (K::Enter, M::NONE),
             ],
             "",
             ("r", "ustc"),
@@ -118,11 +118,11 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Ctrl('R'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                (K::Char('R'), M::CTRL),
+                (K::Char('r'), M::NONE),
+                (K::Char('R'), M::CTRL),
+                (K::Right, M::NONE), // just to assert cursor pos
+                (K::Enter, M::NONE),
             ],
             "",
             ("r", "ustc"),
@@ -131,11 +131,11 @@ fn ctrl_r() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Char('z'), // no match
-                KeyPress::Right,     // just to assert cursor pos
-                KeyPress::Enter,
+                (K::Char('R'), M::CTRL),
+                (K::Char('r'), M::NONE),
+                (K::Char('z'), M::NONE), // no match
+                (K::Right, M::NONE),     // just to assert cursor pos
+                (K::Enter, M::NONE),
             ],
             "",
             ("car", "go"),
@@ -144,11 +144,11 @@ fn ctrl_r() {
             EditMode::Emacs,
             &["rustc", "cargo"],
             &[
-                KeyPress::Char('a'),
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Ctrl('G'), // abort (FIXME: doesn't work with vi mode)
-                KeyPress::Enter,
+                (K::Char('a'), M::NONE),
+                (K::Char('R'), M::CTRL),
+                (K::Char('r'), M::NONE),
+                (K::Char('G'), M::CTRL), // abort (FIXME: doesn't work with vi mode)
+                (K::Enter, M::NONE),
             ],
             "",
             ("a", ""),
@@ -162,7 +162,7 @@ fn ctrl_r_with_long_prompt() {
         assert_history(
             *mode,
             &["rustc", "cargo"],
-            &[KeyPress::Ctrl('R'), KeyPress::Char('o'), KeyPress::Enter],
+            &[(K::Char('R'), M::CTRL), (K::Char('o'), M::NONE), (K::Enter, M::NONE)],
             ">>>>>>>>>>>>>>>>>>>>>>>>>>> ",
             ("cargo", ""),
         );
@@ -176,12 +176,12 @@ fn ctrl_s() {
             *mode,
             &["rustc", "cargo"],
             &[
-                KeyPress::Ctrl('R'),
-                KeyPress::Char('r'),
-                KeyPress::Ctrl('R'),
-                KeyPress::Ctrl('S'),
-                KeyPress::Right, // just to assert cursor pos
-                KeyPress::Enter,
+                (K::Char('R'), M::CTRL),
+                (K::Char('r'), M::NONE),
+                (K::Char('R'), M::CTRL),
+                (K::Char('S'), M::CTRL),
+                (K::Right, M::NONE), // just to assert cursor pos
+                (K::Enter, M::NONE),
             ],
             "",
             ("car", "go"),
@@ -194,14 +194,14 @@ fn meta_lt() {
     assert_history(
         EditMode::Emacs,
         &[""],
-        &[KeyPress::Meta('<'), KeyPress::Enter],
+        &[(K::Char('<'), M::ALT), (K::Enter, M::NONE)],
         "",
         ("", ""),
     );
     assert_history(
         EditMode::Emacs,
         &["rustc", "cargo"],
-        &[KeyPress::Meta('<'), KeyPress::Enter],
+        &[(K::Char('<'), M::ALT), (K::Enter, M::NONE)],
         "",
         ("rustc", ""),
     );
@@ -212,14 +212,14 @@ fn meta_gt() {
     assert_history(
         EditMode::Emacs,
         &[""],
-        &[KeyPress::Meta('>'), KeyPress::Enter],
+        &[(K::Char('>'), M::ALT), (K::Enter, M::NONE)],
         "",
         ("", ""),
     );
     assert_history(
         EditMode::Emacs,
         &["rustc", "cargo"],
-        &[KeyPress::Meta('<'), KeyPress::Meta('>'), KeyPress::Enter],
+        &[(K::Char('<'), M::ALT), (K::Char('>'), M::ALT), (K::Enter, M::NONE)],
         "",
         ("", ""),
     );
@@ -227,10 +227,10 @@ fn meta_gt() {
         EditMode::Emacs,
         &["rustc", "cargo"],
         &[
-            KeyPress::Char('a'),
-            KeyPress::Meta('<'),
-            KeyPress::Meta('>'), // restore original line
-            KeyPress::Enter,
+            (K::Char('a'), M::NONE),
+            (K::Char('<'), M::ALT),
+            (K::Char('>'), M::ALT), // restore original line
+            (K::Enter, M::NONE),
         ],
         "",
         ("a", ""),

--- a/src/test/history.rs
+++ b/src/test/history.rs
@@ -16,7 +16,12 @@ fn down_key() {
         assert_history(
             *mode,
             &["line1", "line2"],
-            &[(K::Up, M::NONE), (K::Up, M::NONE), (K::Down, M::NONE), (K::Enter, M::NONE)],
+            &[
+                (K::Up, M::NONE),
+                (K::Up, M::NONE),
+                (K::Down, M::NONE),
+                (K::Enter, M::NONE),
+            ],
             "",
             ("line2", ""),
         );
@@ -49,7 +54,13 @@ fn down_key() {
 #[test]
 fn up_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_history(*mode, &[], &[(K::Up, M::NONE), (K::Enter, M::NONE)], "", ("", ""));
+        assert_history(
+            *mode,
+            &[],
+            &[(K::Up, M::NONE), (K::Enter, M::NONE)],
+            "",
+            ("", ""),
+        );
         assert_history(
             *mode,
             &["line1"],
@@ -73,7 +84,11 @@ fn ctrl_r() {
         assert_history(
             *mode,
             &[],
-            &[(K::Char('R'), M::CTRL), (K::Char('o'), M::NONE), (K::Enter, M::NONE)],
+            &[
+                (K::Char('R'), M::CTRL),
+                (K::Char('o'), M::NONE),
+                (K::Enter, M::NONE),
+            ],
             "",
             ("o", ""),
         );
@@ -162,7 +177,11 @@ fn ctrl_r_with_long_prompt() {
         assert_history(
             *mode,
             &["rustc", "cargo"],
-            &[(K::Char('R'), M::CTRL), (K::Char('o'), M::NONE), (K::Enter, M::NONE)],
+            &[
+                (K::Char('R'), M::CTRL),
+                (K::Char('o'), M::NONE),
+                (K::Enter, M::NONE),
+            ],
             ">>>>>>>>>>>>>>>>>>>>>>>>>>> ",
             ("cargo", ""),
         );
@@ -219,7 +238,11 @@ fn meta_gt() {
     assert_history(
         EditMode::Emacs,
         &["rustc", "cargo"],
-        &[(K::Char('<'), M::ALT), (K::Char('>'), M::ALT), (K::Enter, M::NONE)],
+        &[
+            (K::Char('<'), M::ALT),
+            (K::Char('>'), M::ALT),
+            (K::Enter, M::NONE),
+        ],
         "",
         ("", ""),
     );

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -8,7 +8,7 @@ use crate::edit::init_state;
 use crate::highlight::Highlighter;
 use crate::hint::Hinter;
 use crate::keymap::{Cmd, InputState};
-use crate::keys::{KeyEvent, KeyCode as K, Modifiers as M};
+use crate::keys::{KeyCode as K, KeyEvent, Modifiers as M};
 use crate::tty::Sink;
 use crate::validate::Validator;
 use crate::{Context, Editor, Helper, Result};
@@ -123,7 +123,11 @@ fn assert_history(
 #[test]
 fn unknown_esc_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[(K::UnknownEscSeq, M::NONE), (K::Enter, M::NONE)], "");
+        assert_line(
+            *mode,
+            &[(K::UnknownEscSeq, M::NONE), (K::Enter, M::NONE)],
+            "",
+        );
     }
 }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -8,7 +8,7 @@ use crate::edit::init_state;
 use crate::highlight::Highlighter;
 use crate::hint::Hinter;
 use crate::keymap::{Cmd, InputState};
-use crate::keys::{KeyCode as K, KeyEvent, Modifiers as M};
+use crate::keys::{KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
 use crate::tty::Sink;
 use crate::validate::Validator;
 use crate::{Context, Editor, Helper, Result};
@@ -59,7 +59,7 @@ fn complete_line() {
     let mut s = init_state(&mut out, "rus", 3, helper.as_ref(), &history);
     let config = Config::default();
     let mut input_state = InputState::new(&config, Arc::new(RwLock::new(HashMap::new())));
-    let keys = vec![(K::Enter, M::NONE)];
+    let keys = vec![E::ENTER];
     let mut rdr: IntoIter<KeyEvent> = keys.into_iter();
     let cmd = super::complete_line(&mut rdr, &mut s, &mut input_state, &Config::default()).unwrap();
     assert_eq!(Some(Cmd::AcceptLine), cmd);
@@ -123,11 +123,7 @@ fn assert_history(
 #[test]
 fn unknown_esc_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(
-            *mode,
-            &[(K::UnknownEscSeq, M::NONE), (K::Enter, M::NONE)],
-            "",
-        );
+        assert_line(*mode, &[E(K::UnknownEscSeq, M::NONE), E::ENTER], "");
     }
 }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -8,7 +8,7 @@ use crate::edit::init_state;
 use crate::highlight::Highlighter;
 use crate::hint::Hinter;
 use crate::keymap::{Cmd, InputState};
-use crate::keys::KeyPress;
+use crate::keys::{KeyEvent, KeyCode as K, Modifiers as M};
 use crate::tty::Sink;
 use crate::validate::Validator;
 use crate::{Context, Editor, Helper, Result};
@@ -19,7 +19,7 @@ mod history;
 mod vi_cmd;
 mod vi_insert;
 
-fn init_editor(mode: EditMode, keys: &[KeyPress]) -> Editor<()> {
+fn init_editor(mode: EditMode, keys: &[KeyEvent]) -> Editor<()> {
     let config = Config::builder().edit_mode(mode).build();
     let mut editor = Editor::<()>::with_config(config);
     editor.term.keys.extend(keys.iter().cloned());
@@ -59,8 +59,8 @@ fn complete_line() {
     let mut s = init_state(&mut out, "rus", 3, helper.as_ref(), &history);
     let config = Config::default();
     let mut input_state = InputState::new(&config, Arc::new(RwLock::new(HashMap::new())));
-    let keys = vec![KeyPress::Enter];
-    let mut rdr: IntoIter<KeyPress> = keys.into_iter();
+    let keys = vec![(K::Enter, M::NONE)];
+    let mut rdr: IntoIter<KeyEvent> = keys.into_iter();
     let cmd = super::complete_line(&mut rdr, &mut s, &mut input_state, &Config::default()).unwrap();
     assert_eq!(Some(Cmd::AcceptLine), cmd);
     assert_eq!("rust", s.line.as_str());
@@ -69,7 +69,7 @@ fn complete_line() {
 
 // `keys`: keys to press
 // `expected_line`: line after enter key
-fn assert_line(mode: EditMode, keys: &[KeyPress], expected_line: &str) {
+fn assert_line(mode: EditMode, keys: &[KeyEvent], expected_line: &str) {
     let mut editor = init_editor(mode, keys);
     let actual_line = editor.readline(">>").unwrap();
     assert_eq!(expected_line, actual_line);
@@ -81,7 +81,7 @@ fn assert_line(mode: EditMode, keys: &[KeyPress], expected_line: &str) {
 fn assert_line_with_initial(
     mode: EditMode,
     initial: (&str, &str),
-    keys: &[KeyPress],
+    keys: &[KeyEvent],
     expected_line: &str,
 ) {
     let mut editor = init_editor(mode, keys);
@@ -92,7 +92,7 @@ fn assert_line_with_initial(
 // `initial`: line status before `keys` pressed: strings before and after cursor
 // `keys`: keys to press
 // `expected`: line status before enter key: strings before and after cursor
-fn assert_cursor(mode: EditMode, initial: (&str, &str), keys: &[KeyPress], expected: (&str, &str)) {
+fn assert_cursor(mode: EditMode, initial: (&str, &str), keys: &[KeyEvent], expected: (&str, &str)) {
     let mut editor = init_editor(mode, keys);
     let actual_line = editor.readline_with_initial("", initial).unwrap();
     assert_eq!(expected.0.to_owned() + expected.1, actual_line);
@@ -105,7 +105,7 @@ fn assert_cursor(mode: EditMode, initial: (&str, &str), keys: &[KeyPress], expec
 fn assert_history(
     mode: EditMode,
     entries: &[&str],
-    keys: &[KeyPress],
+    keys: &[KeyEvent],
     prompt: &str,
     expected: (&str, &str),
 ) {
@@ -123,7 +123,7 @@ fn assert_history(
 #[test]
 fn unknown_esc_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
-        assert_line(*mode, &[KeyPress::UnknownEscSeq, KeyPress::Enter], "");
+        assert_line(*mode, &[(K::UnknownEscSeq, M::NONE), (K::Enter, M::NONE)], "");
     }
 }
 

--- a/src/test/vi_cmd.rs
+++ b/src/test/vi_cmd.rs
@@ -1,14 +1,14 @@
 //! Vi command mode specific key bindings
 use super::{assert_cursor, assert_history};
 use crate::config::EditMode;
-use crate::keys::KeyPress;
+use crate::keys::{KeyCode as K, Modifiers as M};
 
 #[test]
 fn dollar() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hi"),
-        &[KeyPress::Esc, KeyPress::Char('$'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('$'), M::NONE), (K::Enter, M::NONE)],
         ("Hi", ""), // FIXME
     );
 }
@@ -24,11 +24,11 @@ fn semi_colon() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('f'),
-            KeyPress::Char('o'),
-            KeyPress::Char(';'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('f'), M::NONE),
+            (K::Char('o'), M::NONE),
+            (K::Char(';'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, w", "orld!"),
     );
@@ -40,11 +40,11 @@ fn comma() {
         EditMode::Vi,
         ("Hello, w", "orld!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('f'),
-            KeyPress::Char('l'),
-            KeyPress::Char(','),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('f'), M::NONE),
+            (K::Char('l'), M::NONE),
+            (K::Char(','), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hel", "lo, world!"),
     );
@@ -55,7 +55,7 @@ fn zero() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[KeyPress::Esc, KeyPress::Char('0'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('0'), M::NONE), (K::Enter, M::NONE)],
         ("", "Hi"),
     );
 }
@@ -65,7 +65,7 @@ fn caret() {
     assert_cursor(
         EditMode::Vi,
         (" Hi", ""),
-        &[KeyPress::Esc, KeyPress::Char('^'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('^'), M::NONE), (K::Enter, M::NONE)],
         (" ", "Hi"),
     );
 }
@@ -76,10 +76,10 @@ fn a() {
         EditMode::Vi,
         ("B", "e"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('a'),
-            KeyPress::Char('y'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('a'), M::NONE),
+            (K::Char('y'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("By", "e"),
     );
@@ -91,10 +91,10 @@ fn uppercase_a() {
         EditMode::Vi,
         ("", "By"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('A'),
-            KeyPress::Char('e'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('A'), M::NONE),
+            (K::Char('e'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Bye", ""),
     );
@@ -105,17 +105,17 @@ fn b() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[KeyPress::Esc, KeyPress::Char('b'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('b'), M::NONE), (K::Enter, M::NONE)],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('b'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('2'), M::NONE),
+            (K::Char('b'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello", ", world!"),
     );
@@ -126,17 +126,17 @@ fn uppercase_b() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[KeyPress::Esc, KeyPress::Char('B'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('B'), M::NONE), (K::Enter, M::NONE)],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('B'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('2'), M::NONE),
+            (K::Char('B'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("", "Hello, world!"),
     );
@@ -148,10 +148,10 @@ fn uppercase_c() {
         EditMode::Vi,
         ("Hello, w", "orld!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('C'),
-            KeyPress::Char('i'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('C'), M::NONE),
+            (K::Char('i'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, i", ""),
     );
@@ -159,23 +159,23 @@ fn uppercase_c() {
 
 #[test]
 fn ctrl_k() {
-    for key in &[KeyPress::Char('D'), KeyPress::Ctrl('K')] {
+    for key in &[(K::Char('D'), M::NONE), (K::Char('K'), M::CTRL)] {
         assert_cursor(
             EditMode::Vi,
             ("Hi", ""),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             ("H", ""),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             ("", ""),
         );
         assert_cursor(
             EditMode::Vi,
             ("By", "e"),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             ("B", ""),
         );
     }
@@ -186,17 +186,17 @@ fn e() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[KeyPress::Esc, KeyPress::Char('e'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('e'), M::NONE), (K::Enter, M::NONE)],
         ("Hell", "o, world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('e'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('2'), M::NONE),
+            (K::Char('e'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, worl", "d!"),
     );
@@ -207,17 +207,17 @@ fn uppercase_e() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[KeyPress::Esc, KeyPress::Char('E'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('E'), M::NONE), (K::Enter, M::NONE)],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('E'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('2'), M::NONE),
+            (K::Char('E'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, world", "!"),
     );
@@ -229,10 +229,10 @@ fn f() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('f'),
-            KeyPress::Char('r'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('f'), M::NONE),
+            (K::Char('r'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, wo", "rld!"),
     );
@@ -240,11 +240,11 @@ fn f() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('3'),
-            KeyPress::Char('f'),
-            KeyPress::Char('l'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('3'), M::NONE),
+            (K::Char('f'), M::NONE),
+            (K::Char('l'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, wor", "ld!"),
     );
@@ -256,10 +256,10 @@ fn uppercase_f() {
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('F'),
-            KeyPress::Char('r'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('F'), M::NONE),
+            (K::Char('r'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, wo", "rld!"),
     );
@@ -267,11 +267,11 @@ fn uppercase_f() {
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('3'),
-            KeyPress::Char('F'),
-            KeyPress::Char('l'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('3'), M::NONE),
+            (K::Char('F'), M::NONE),
+            (K::Char('l'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("He", "llo, world!"),
     );
@@ -283,10 +283,10 @@ fn i() {
         EditMode::Vi,
         ("Be", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('i'),
-            KeyPress::Char('y'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('i'), M::NONE),
+            (K::Char('y'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("By", "e"),
     );
@@ -298,10 +298,10 @@ fn uppercase_i() {
         EditMode::Vi,
         ("Be", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('I'),
-            KeyPress::Char('y'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('I'), M::NONE),
+            (K::Char('y'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("y", "Be"),
     );
@@ -313,10 +313,10 @@ fn u() {
         EditMode::Vi,
         ("Hello, ", "world"),
         &[
-            KeyPress::Esc,
-            KeyPress::Ctrl('W'),
-            KeyPress::Char('u'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('W'), M::CTRL),
+            (K::Char('u'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello,", " world"),
     );
@@ -327,17 +327,17 @@ fn w() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[KeyPress::Esc, KeyPress::Char('w'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('w'), M::NONE), (K::Enter, M::NONE)],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('w'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('2'), M::NONE),
+            (K::Char('w'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, ", "world!"),
     );
@@ -348,17 +348,17 @@ fn uppercase_w() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[KeyPress::Esc, KeyPress::Char('W'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('W'), M::NONE), (K::Enter, M::NONE)],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('2'),
-            KeyPress::Char('W'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('2'), M::NONE),
+            (K::Char('W'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, world", "!"),
     );
@@ -369,7 +369,7 @@ fn x() {
     assert_cursor(
         EditMode::Vi,
         ("", "a"),
-        &[KeyPress::Esc, KeyPress::Char('x'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('x'), M::NONE), (K::Enter, M::NONE)],
         ("", ""),
     );
 }
@@ -379,7 +379,7 @@ fn uppercase_x() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[KeyPress::Esc, KeyPress::Char('X'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('X'), M::NONE), (K::Enter, M::NONE)],
         ("", "i"),
     );
 }
@@ -387,20 +387,20 @@ fn uppercase_x() {
 #[test]
 fn h() {
     for key in &[
-        KeyPress::Char('h'),
-        KeyPress::Ctrl('H'),
-        KeyPress::Backspace,
+        (K::Char('h'), M::NONE),
+        (K::Char('H'), M::CTRL),
+        (K::Backspace, M::NONE),
     ] {
         assert_cursor(
             EditMode::Vi,
             ("Bye", ""),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             ("B", "ye"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Bye", ""),
-            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), (K::Char('2'), M::NONE), *key, (K::Enter, M::NONE)],
             ("", "Bye"),
         );
     }
@@ -408,17 +408,17 @@ fn h() {
 
 #[test]
 fn l() {
-    for key in &[KeyPress::Char('l'), KeyPress::Char(' ')] {
+    for key in &[(K::Char('l'), M::NONE), (K::Char(' '), M::NONE)] {
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             ("H", "i"),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), (K::Char('2'), M::NONE), *key, (K::Enter, M::NONE)],
             ("Hi", ""),
         );
     }
@@ -426,25 +426,25 @@ fn l() {
 
 #[test]
 fn j() {
-    for key in &[KeyPress::Char('j'), KeyPress::Char('+')] {
+    for key in &[(K::Char('j'), M::NONE), (K::Char('+'), M::NONE)] {
         assert_cursor(
             EditMode::Vi,
             ("Hel", "lo,\nworld!"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             ("Hello,\nwo", "rld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "One\nTwo\nThree"),
-            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), (K::Char('2'), M::NONE), *key, (K::Enter, M::NONE)],
             ("One\nTwo\n", "Three"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Hel", "lo,\nworld!"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, KeyPress::Char('7'), *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), (K::Char('7'), M::NONE), *key, (K::Enter, M::NONE)],
             ("Hello,\nwo", "rld!"),
         );
     }
@@ -452,32 +452,32 @@ fn j() {
 
 #[test]
 fn k() {
-    for key in &[KeyPress::Char('k'), KeyPress::Char('-')] {
+    for key in &[(K::Char('k'), M::NONE), (K::Char('-'), M::NONE)] {
         assert_cursor(
             EditMode::Vi,
             ("Hello,\nworl", "d!"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             ("Hel", "lo,\nworld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("One\nTwo\nT", "hree"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, KeyPress::Char('2'), *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), (K::Char('2'), M::NONE), *key, (K::Enter, M::NONE)],
             ("", "One\nTwo\nThree"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Hello,\nworl", "d!"),
             // NOTE: escape moves backwards on char
-            &[KeyPress::Esc, KeyPress::Char('5'), *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), (K::Char('5'), M::NONE), *key, (K::Enter, M::NONE)],
             ("Hel", "lo,\nworld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("first line\nshort\nlong line", ""),
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             ("first line\nshort", "\nlong line"),
         );
     }
@@ -485,16 +485,16 @@ fn k() {
 
 #[test]
 fn ctrl_n() {
-    for key in &[KeyPress::Ctrl('N')] {
+    for key in &[(K::Char('N'), M::CTRL)] {
         assert_history(
             EditMode::Vi,
             &["line1", "line2"],
             &[
-                KeyPress::Esc,
-                KeyPress::Ctrl('P'),
-                KeyPress::Ctrl('P'),
+                (K::Esc, M::NONE),
+                (K::Char('P'), M::CTRL),
+                (K::Char('P'), M::CTRL),
                 *key,
-                KeyPress::Enter,
+                (K::Enter, M::NONE),
             ],
             "",
             ("line2", ""),
@@ -504,11 +504,11 @@ fn ctrl_n() {
 
 #[test]
 fn ctrl_p() {
-    for key in &[KeyPress::Ctrl('P')] {
+    for key in &[(K::Char('P'), M::CTRL)] {
         assert_history(
             EditMode::Vi,
             &["line1"],
-            &[KeyPress::Esc, *key, KeyPress::Enter],
+            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
             "",
             ("line1", ""),
         );
@@ -521,10 +521,10 @@ fn p() {
         EditMode::Vi,
         ("Hello, ", "world"),
         &[
-            KeyPress::Esc,
-            KeyPress::Ctrl('W'),
-            KeyPress::Char('p'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('W'), M::CTRL),
+            (K::Char('p'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         (" Hello", ",world"),
     );
@@ -536,10 +536,10 @@ fn uppercase_p() {
         EditMode::Vi,
         ("Hello, ", "world"),
         &[
-            KeyPress::Esc,
-            KeyPress::Ctrl('W'),
-            KeyPress::Char('P'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('W'), M::CTRL),
+            (K::Char('P'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello", ", world"),
     );
@@ -551,10 +551,10 @@ fn r() {
         EditMode::Vi,
         ("Hi", ", world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('r'),
-            KeyPress::Char('o'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('r'), M::NONE),
+            (K::Char('o'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("H", "o, world!"),
     );
@@ -562,11 +562,11 @@ fn r() {
         EditMode::Vi,
         ("He", "llo, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('4'),
-            KeyPress::Char('r'),
-            KeyPress::Char('i'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('4'), M::NONE),
+            (K::Char('r'), M::NONE),
+            (K::Char('i'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hiii", "i, world!"),
     );
@@ -578,10 +578,10 @@ fn s() {
         EditMode::Vi,
         ("Hi", ", world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('s'),
-            KeyPress::Char('o'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('s'), M::NONE),
+            (K::Char('o'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Ho", ", world!"),
     );
@@ -589,11 +589,11 @@ fn s() {
         EditMode::Vi,
         ("He", "llo, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('4'),
-            KeyPress::Char('s'),
-            KeyPress::Char('i'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('4'), M::NONE),
+            (K::Char('s'), M::NONE),
+            (K::Char('i'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hi", ", world!"),
     );
@@ -604,7 +604,7 @@ fn uppercase_s() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, ", "world"),
-        &[KeyPress::Esc, KeyPress::Char('S'), KeyPress::Enter],
+        &[(K::Esc, M::NONE), (K::Char('S'), M::NONE), (K::Enter, M::NONE)],
         ("", ""),
     );
 }
@@ -615,10 +615,10 @@ fn t() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('t'),
-            KeyPress::Char('r'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('t'), M::NONE),
+            (K::Char('r'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, w", "orld!"),
     );
@@ -626,11 +626,11 @@ fn t() {
         EditMode::Vi,
         ("", "Hello, world!"),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('3'),
-            KeyPress::Char('t'),
-            KeyPress::Char('l'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('3'), M::NONE),
+            (K::Char('t'), M::NONE),
+            (K::Char('l'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, wo", "rld!"),
     );
@@ -642,10 +642,10 @@ fn uppercase_t() {
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('T'),
-            KeyPress::Char('r'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('T'), M::NONE),
+            (K::Char('r'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hello, wor", "ld!"),
     );
@@ -653,11 +653,11 @@ fn uppercase_t() {
         EditMode::Vi,
         ("Hello, world!", ""),
         &[
-            KeyPress::Esc,
-            KeyPress::Char('3'),
-            KeyPress::Char('T'),
-            KeyPress::Char('l'),
-            KeyPress::Enter,
+            (K::Esc, M::NONE),
+            (K::Char('3'), M::NONE),
+            (K::Char('T'), M::NONE),
+            (K::Char('l'), M::NONE),
+            (K::Enter, M::NONE),
         ],
         ("Hel", "lo, world!"),
     );

--- a/src/test/vi_cmd.rs
+++ b/src/test/vi_cmd.rs
@@ -1,18 +1,14 @@
 //! Vi command mode specific key bindings
 use super::{assert_cursor, assert_history};
 use crate::config::EditMode;
-use crate::keys::{KeyCode as K, Modifiers as M};
+use crate::keys::KeyEvent as E;
 
 #[test]
 fn dollar() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hi"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('$'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('$'), E::ENTER],
         ("Hi", ""), // FIXME
     );
 }
@@ -27,13 +23,7 @@ fn semi_colon() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('f'), M::NONE),
-            (K::Char('o'), M::NONE),
-            (K::Char(';'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('f'), E::from('o'), E::from(';'), E::ENTER],
         ("Hello, w", "orld!"),
     );
 }
@@ -43,13 +33,7 @@ fn comma() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, w", "orld!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('f'), M::NONE),
-            (K::Char('l'), M::NONE),
-            (K::Char(','), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('f'), E::from('l'), E::from(','), E::ENTER],
         ("Hel", "lo, world!"),
     );
 }
@@ -59,11 +43,7 @@ fn zero() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('0'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('0'), E::ENTER],
         ("", "Hi"),
     );
 }
@@ -73,11 +53,7 @@ fn caret() {
     assert_cursor(
         EditMode::Vi,
         (" Hi", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('^'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('^'), E::ENTER],
         (" ", "Hi"),
     );
 }
@@ -87,12 +63,7 @@ fn a() {
     assert_cursor(
         EditMode::Vi,
         ("B", "e"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('a'), M::NONE),
-            (K::Char('y'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('a'), E::from('y'), E::ENTER],
         ("By", "e"),
     );
 }
@@ -102,12 +73,7 @@ fn uppercase_a() {
     assert_cursor(
         EditMode::Vi,
         ("", "By"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('A'), M::NONE),
-            (K::Char('e'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('A'), E::from('e'), E::ENTER],
         ("Bye", ""),
     );
 }
@@ -117,22 +83,13 @@ fn b() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('b'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('b'), E::ENTER],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('2'), M::NONE),
-            (K::Char('b'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('2'), E::from('b'), E::ENTER],
         ("Hello", ", world!"),
     );
 }
@@ -142,22 +99,13 @@ fn uppercase_b() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('B'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('B'), E::ENTER],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('2'), M::NONE),
-            (K::Char('B'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('2'), E::from('B'), E::ENTER],
         ("", "Hello, world!"),
     );
 }
@@ -167,35 +115,30 @@ fn uppercase_c() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, w", "orld!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('C'), M::NONE),
-            (K::Char('i'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('C'), E::from('i'), E::ENTER],
         ("Hello, i", ""),
     );
 }
 
 #[test]
 fn ctrl_k() {
-    for key in &[(K::Char('D'), M::NONE), (K::Char('K'), M::CTRL)] {
+    for key in &[E::from('D'), E::ctrl('K')] {
         assert_cursor(
             EditMode::Vi,
             ("Hi", ""),
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             ("H", ""),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             ("", ""),
         );
         assert_cursor(
             EditMode::Vi,
             ("By", "e"),
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             ("B", ""),
         );
     }
@@ -206,22 +149,13 @@ fn e() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('e'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('e'), E::ENTER],
         ("Hell", "o, world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('2'), M::NONE),
-            (K::Char('e'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('2'), E::from('e'), E::ENTER],
         ("Hello, worl", "d!"),
     );
 }
@@ -231,22 +165,13 @@ fn uppercase_e() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('E'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('E'), E::ENTER],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('2'), M::NONE),
-            (K::Char('E'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('2'), E::from('E'), E::ENTER],
         ("Hello, world", "!"),
     );
 }
@@ -256,24 +181,13 @@ fn f() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('f'), M::NONE),
-            (K::Char('r'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('f'), E::from('r'), E::ENTER],
         ("Hello, wo", "rld!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('3'), M::NONE),
-            (K::Char('f'), M::NONE),
-            (K::Char('l'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('3'), E::from('f'), E::from('l'), E::ENTER],
         ("Hello, wor", "ld!"),
     );
 }
@@ -283,24 +197,13 @@ fn uppercase_f() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('F'), M::NONE),
-            (K::Char('r'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('F'), E::from('r'), E::ENTER],
         ("Hello, wo", "rld!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('3'), M::NONE),
-            (K::Char('F'), M::NONE),
-            (K::Char('l'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('3'), E::from('F'), E::from('l'), E::ENTER],
         ("He", "llo, world!"),
     );
 }
@@ -310,12 +213,7 @@ fn i() {
     assert_cursor(
         EditMode::Vi,
         ("Be", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('i'), M::NONE),
-            (K::Char('y'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('i'), E::from('y'), E::ENTER],
         ("By", "e"),
     );
 }
@@ -325,12 +223,7 @@ fn uppercase_i() {
     assert_cursor(
         EditMode::Vi,
         ("Be", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('I'), M::NONE),
-            (K::Char('y'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('I'), E::from('y'), E::ENTER],
         ("y", "Be"),
     );
 }
@@ -340,12 +233,7 @@ fn u() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, ", "world"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('W'), M::CTRL),
-            (K::Char('u'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::ctrl('W'), E::from('u'), E::ENTER],
         ("Hello,", " world"),
     );
 }
@@ -355,22 +243,13 @@ fn w() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('w'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('w'), E::ENTER],
         ("Hello", ", world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('2'), M::NONE),
-            (K::Char('w'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('2'), E::from('w'), E::ENTER],
         ("Hello, ", "world!"),
     );
 }
@@ -380,22 +259,13 @@ fn uppercase_w() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('W'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('W'), E::ENTER],
         ("Hello, ", "world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('2'), M::NONE),
-            (K::Char('W'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('2'), E::from('W'), E::ENTER],
         ("Hello, world", "!"),
     );
 }
@@ -405,11 +275,7 @@ fn x() {
     assert_cursor(
         EditMode::Vi,
         ("", "a"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('x'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('x'), E::ENTER],
         ("", ""),
     );
 }
@@ -419,37 +285,24 @@ fn uppercase_x() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('X'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('X'), E::ENTER],
         ("", "i"),
     );
 }
 
 #[test]
 fn h() {
-    for key in &[
-        (K::Char('h'), M::NONE),
-        (K::Char('H'), M::CTRL),
-        (K::Backspace, M::NONE),
-    ] {
+    for key in &[E::from('h'), E::ctrl('H'), E::BACKSPACE] {
         assert_cursor(
             EditMode::Vi,
             ("Bye", ""),
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             ("B", "ye"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Bye", ""),
-            &[
-                (K::Esc, M::NONE),
-                (K::Char('2'), M::NONE),
-                *key,
-                (K::Enter, M::NONE),
-            ],
+            &[E::ESC, E::from('2'), *key, E::ENTER],
             ("", "Bye"),
         );
     }
@@ -457,22 +310,17 @@ fn h() {
 
 #[test]
 fn l() {
-    for key in &[(K::Char('l'), M::NONE), (K::Char(' '), M::NONE)] {
+    for key in &[E::from('l'), E::from(' ')] {
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             ("H", "i"),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[
-                (K::Esc, M::NONE),
-                (K::Char('2'), M::NONE),
-                *key,
-                (K::Enter, M::NONE),
-            ],
+            &[E::ESC, E::from('2'), *key, E::ENTER],
             ("Hi", ""),
         );
     }
@@ -480,35 +328,25 @@ fn l() {
 
 #[test]
 fn j() {
-    for key in &[(K::Char('j'), M::NONE), (K::Char('+'), M::NONE)] {
+    for key in &[E::from('j'), E::from('+')] {
         assert_cursor(
             EditMode::Vi,
             ("Hel", "lo,\nworld!"),
             // NOTE: escape moves backwards on char
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             ("Hello,\nwo", "rld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("", "One\nTwo\nThree"),
-            &[
-                (K::Esc, M::NONE),
-                (K::Char('2'), M::NONE),
-                *key,
-                (K::Enter, M::NONE),
-            ],
+            &[E::ESC, E::from('2'), *key, E::ENTER],
             ("One\nTwo\n", "Three"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Hel", "lo,\nworld!"),
             // NOTE: escape moves backwards on char
-            &[
-                (K::Esc, M::NONE),
-                (K::Char('7'), M::NONE),
-                *key,
-                (K::Enter, M::NONE),
-            ],
+            &[E::ESC, E::from('7'), *key, E::ENTER],
             ("Hello,\nwo", "rld!"),
         );
     }
@@ -516,42 +354,32 @@ fn j() {
 
 #[test]
 fn k() {
-    for key in &[(K::Char('k'), M::NONE), (K::Char('-'), M::NONE)] {
+    for key in &[E::from('k'), E::from('-')] {
         assert_cursor(
             EditMode::Vi,
             ("Hello,\nworl", "d!"),
             // NOTE: escape moves backwards on char
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             ("Hel", "lo,\nworld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("One\nTwo\nT", "hree"),
             // NOTE: escape moves backwards on char
-            &[
-                (K::Esc, M::NONE),
-                (K::Char('2'), M::NONE),
-                *key,
-                (K::Enter, M::NONE),
-            ],
+            &[E::ESC, E::from('2'), *key, E::ENTER],
             ("", "One\nTwo\nThree"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Hello,\nworl", "d!"),
             // NOTE: escape moves backwards on char
-            &[
-                (K::Esc, M::NONE),
-                (K::Char('5'), M::NONE),
-                *key,
-                (K::Enter, M::NONE),
-            ],
+            &[E::ESC, E::from('5'), *key, E::ENTER],
             ("Hel", "lo,\nworld!"),
         );
         assert_cursor(
             EditMode::Vi,
             ("first line\nshort\nlong line", ""),
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             ("first line\nshort", "\nlong line"),
         );
     }
@@ -559,17 +387,11 @@ fn k() {
 
 #[test]
 fn ctrl_n() {
-    for key in &[(K::Char('N'), M::CTRL)] {
+    for key in &[E::ctrl('N')] {
         assert_history(
             EditMode::Vi,
             &["line1", "line2"],
-            &[
-                (K::Esc, M::NONE),
-                (K::Char('P'), M::CTRL),
-                (K::Char('P'), M::CTRL),
-                *key,
-                (K::Enter, M::NONE),
-            ],
+            &[E::ESC, E::ctrl('P'), E::ctrl('P'), *key, E::ENTER],
             "",
             ("line2", ""),
         );
@@ -578,11 +400,11 @@ fn ctrl_n() {
 
 #[test]
 fn ctrl_p() {
-    for key in &[(K::Char('P'), M::CTRL)] {
+    for key in &[E::ctrl('P')] {
         assert_history(
             EditMode::Vi,
             &["line1"],
-            &[(K::Esc, M::NONE), *key, (K::Enter, M::NONE)],
+            &[E::ESC, *key, E::ENTER],
             "",
             ("line1", ""),
         );
@@ -594,12 +416,7 @@ fn p() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, ", "world"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('W'), M::CTRL),
-            (K::Char('p'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::ctrl('W'), E::from('p'), E::ENTER],
         (" Hello", ",world"),
     );
 }
@@ -609,12 +426,7 @@ fn uppercase_p() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, ", "world"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('W'), M::CTRL),
-            (K::Char('P'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::ctrl('W'), E::from('P'), E::ENTER],
         ("Hello", ", world"),
     );
 }
@@ -624,24 +436,13 @@ fn r() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ", world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('r'), M::NONE),
-            (K::Char('o'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('r'), E::from('o'), E::ENTER],
         ("H", "o, world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("He", "llo, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('4'), M::NONE),
-            (K::Char('r'), M::NONE),
-            (K::Char('i'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('4'), E::from('r'), E::from('i'), E::ENTER],
         ("Hiii", "i, world!"),
     );
 }
@@ -651,24 +452,13 @@ fn s() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ", world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('s'), M::NONE),
-            (K::Char('o'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('s'), E::from('o'), E::ENTER],
         ("Ho", ", world!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("He", "llo, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('4'), M::NONE),
-            (K::Char('s'), M::NONE),
-            (K::Char('i'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('4'), E::from('s'), E::from('i'), E::ENTER],
         ("Hi", ", world!"),
     );
 }
@@ -678,11 +468,7 @@ fn uppercase_s() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, ", "world"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('S'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('S'), E::ENTER],
         ("", ""),
     );
 }
@@ -692,24 +478,13 @@ fn t() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('t'), M::NONE),
-            (K::Char('r'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('t'), E::from('r'), E::ENTER],
         ("Hello, w", "orld!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('3'), M::NONE),
-            (K::Char('t'), M::NONE),
-            (K::Char('l'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('3'), E::from('t'), E::from('l'), E::ENTER],
         ("Hello, wo", "rld!"),
     );
 }
@@ -719,24 +494,13 @@ fn uppercase_t() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('T'), M::NONE),
-            (K::Char('r'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('T'), E::from('r'), E::ENTER],
         ("Hello, wor", "ld!"),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[
-            (K::Esc, M::NONE),
-            (K::Char('3'), M::NONE),
-            (K::Char('T'), M::NONE),
-            (K::Char('l'), M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::ESC, E::from('3'), E::from('T'), E::from('l'), E::ENTER],
         ("Hel", "lo, world!"),
     );
 }

--- a/src/test/vi_cmd.rs
+++ b/src/test/vi_cmd.rs
@@ -8,7 +8,11 @@ fn dollar() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hi"),
-        &[(K::Esc, M::NONE), (K::Char('$'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('$'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("Hi", ""), // FIXME
     );
 }
@@ -55,7 +59,11 @@ fn zero() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[(K::Esc, M::NONE), (K::Char('0'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('0'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("", "Hi"),
     );
 }
@@ -65,7 +73,11 @@ fn caret() {
     assert_cursor(
         EditMode::Vi,
         (" Hi", ""),
-        &[(K::Esc, M::NONE), (K::Char('^'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('^'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         (" ", "Hi"),
     );
 }
@@ -105,7 +117,11 @@ fn b() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[(K::Esc, M::NONE), (K::Char('b'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('b'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("Hello, ", "world!"),
     );
     assert_cursor(
@@ -126,7 +142,11 @@ fn uppercase_b() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, world!", ""),
-        &[(K::Esc, M::NONE), (K::Char('B'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('B'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("Hello, ", "world!"),
     );
     assert_cursor(
@@ -186,7 +206,11 @@ fn e() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[(K::Esc, M::NONE), (K::Char('e'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('e'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("Hell", "o, world!"),
     );
     assert_cursor(
@@ -207,7 +231,11 @@ fn uppercase_e() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[(K::Esc, M::NONE), (K::Char('E'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('E'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("Hello", ", world!"),
     );
     assert_cursor(
@@ -327,7 +355,11 @@ fn w() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[(K::Esc, M::NONE), (K::Char('w'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('w'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("Hello", ", world!"),
     );
     assert_cursor(
@@ -348,7 +380,11 @@ fn uppercase_w() {
     assert_cursor(
         EditMode::Vi,
         ("", "Hello, world!"),
-        &[(K::Esc, M::NONE), (K::Char('W'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('W'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("Hello, ", "world!"),
     );
     assert_cursor(
@@ -369,7 +405,11 @@ fn x() {
     assert_cursor(
         EditMode::Vi,
         ("", "a"),
-        &[(K::Esc, M::NONE), (K::Char('x'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('x'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("", ""),
     );
 }
@@ -379,7 +419,11 @@ fn uppercase_x() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[(K::Esc, M::NONE), (K::Char('X'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('X'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("", "i"),
     );
 }
@@ -400,7 +444,12 @@ fn h() {
         assert_cursor(
             EditMode::Vi,
             ("Bye", ""),
-            &[(K::Esc, M::NONE), (K::Char('2'), M::NONE), *key, (K::Enter, M::NONE)],
+            &[
+                (K::Esc, M::NONE),
+                (K::Char('2'), M::NONE),
+                *key,
+                (K::Enter, M::NONE),
+            ],
             ("", "Bye"),
         );
     }
@@ -418,7 +467,12 @@ fn l() {
         assert_cursor(
             EditMode::Vi,
             ("", "Hi"),
-            &[(K::Esc, M::NONE), (K::Char('2'), M::NONE), *key, (K::Enter, M::NONE)],
+            &[
+                (K::Esc, M::NONE),
+                (K::Char('2'), M::NONE),
+                *key,
+                (K::Enter, M::NONE),
+            ],
             ("Hi", ""),
         );
     }
@@ -437,14 +491,24 @@ fn j() {
         assert_cursor(
             EditMode::Vi,
             ("", "One\nTwo\nThree"),
-            &[(K::Esc, M::NONE), (K::Char('2'), M::NONE), *key, (K::Enter, M::NONE)],
+            &[
+                (K::Esc, M::NONE),
+                (K::Char('2'), M::NONE),
+                *key,
+                (K::Enter, M::NONE),
+            ],
             ("One\nTwo\n", "Three"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Hel", "lo,\nworld!"),
             // NOTE: escape moves backwards on char
-            &[(K::Esc, M::NONE), (K::Char('7'), M::NONE), *key, (K::Enter, M::NONE)],
+            &[
+                (K::Esc, M::NONE),
+                (K::Char('7'), M::NONE),
+                *key,
+                (K::Enter, M::NONE),
+            ],
             ("Hello,\nwo", "rld!"),
         );
     }
@@ -464,14 +528,24 @@ fn k() {
             EditMode::Vi,
             ("One\nTwo\nT", "hree"),
             // NOTE: escape moves backwards on char
-            &[(K::Esc, M::NONE), (K::Char('2'), M::NONE), *key, (K::Enter, M::NONE)],
+            &[
+                (K::Esc, M::NONE),
+                (K::Char('2'), M::NONE),
+                *key,
+                (K::Enter, M::NONE),
+            ],
             ("", "One\nTwo\nThree"),
         );
         assert_cursor(
             EditMode::Vi,
             ("Hello,\nworl", "d!"),
             // NOTE: escape moves backwards on char
-            &[(K::Esc, M::NONE), (K::Char('5'), M::NONE), *key, (K::Enter, M::NONE)],
+            &[
+                (K::Esc, M::NONE),
+                (K::Char('5'), M::NONE),
+                *key,
+                (K::Enter, M::NONE),
+            ],
             ("Hel", "lo,\nworld!"),
         );
         assert_cursor(
@@ -604,7 +678,11 @@ fn uppercase_s() {
     assert_cursor(
         EditMode::Vi,
         ("Hello, ", "world"),
-        &[(K::Esc, M::NONE), (K::Char('S'), M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Esc, M::NONE),
+            (K::Char('S'), M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("", ""),
     );
 }

--- a/src/test/vi_insert.rs
+++ b/src/test/vi_insert.rs
@@ -50,7 +50,11 @@ fn esc() {
     assert_cursor(
         EditMode::Vi,
         ("", ""),
-        &[(K::Char('a'), M::NONE), (K::Esc, M::NONE), (K::Enter, M::NONE)],
+        &[
+            (K::Char('a'), M::NONE),
+            (K::Esc, M::NONE),
+            (K::Enter, M::NONE),
+        ],
         ("", "a"),
     );
 }

--- a/src/test/vi_insert.rs
+++ b/src/test/vi_insert.rs
@@ -1,16 +1,11 @@
 //! Vi insert mode specific key bindings
 use super::assert_cursor;
 use crate::config::EditMode;
-use crate::keys::{KeyCode as K, Modifiers as M};
+use crate::keys::KeyEvent as E;
 
 #[test]
 fn insert_mode_by_default() {
-    assert_cursor(
-        EditMode::Vi,
-        ("", ""),
-        &[(K::Char('a'), M::NONE), (K::Enter, M::NONE)],
-        ("a", ""),
-    );
+    assert_cursor(EditMode::Vi, ("", ""), &[E::from('a'), E::ENTER], ("a", ""));
 }
 
 #[test]
@@ -18,29 +13,24 @@ fn ctrl_h() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[(K::Char('H'), M::CTRL), (K::Enter, M::NONE)],
+        &[E::ctrl('H'), E::ENTER],
         ("H", ""),
     );
 }
 
 #[test]
 fn backspace() {
-    assert_cursor(
-        EditMode::Vi,
-        ("", ""),
-        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
-        ("", ""),
-    );
+    assert_cursor(EditMode::Vi, ("", ""), &[E::BACKSPACE, E::ENTER], ("", ""));
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
+        &[E::BACKSPACE, E::ENTER],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hi"),
-        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
+        &[E::BACKSPACE, E::ENTER],
         ("", "Hi"),
     );
 }
@@ -50,11 +40,7 @@ fn esc() {
     assert_cursor(
         EditMode::Vi,
         ("", ""),
-        &[
-            (K::Char('a'), M::NONE),
-            (K::Esc, M::NONE),
-            (K::Enter, M::NONE),
-        ],
+        &[E::from('a'), E::ESC, E::ENTER],
         ("", "a"),
     );
 }

--- a/src/test/vi_insert.rs
+++ b/src/test/vi_insert.rs
@@ -1,14 +1,14 @@
 //! Vi insert mode specific key bindings
 use super::assert_cursor;
 use crate::config::EditMode;
-use crate::keys::KeyPress;
+use crate::keys::{KeyCode as K, Modifiers as M};
 
 #[test]
 fn insert_mode_by_default() {
     assert_cursor(
         EditMode::Vi,
         ("", ""),
-        &[KeyPress::Char('a'), KeyPress::Enter],
+        &[(K::Char('a'), M::NONE), (K::Enter, M::NONE)],
         ("a", ""),
     );
 }
@@ -18,7 +18,7 @@ fn ctrl_h() {
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[KeyPress::Ctrl('H'), KeyPress::Enter],
+        &[(K::Char('H'), M::CTRL), (K::Enter, M::NONE)],
         ("H", ""),
     );
 }
@@ -28,19 +28,19 @@ fn backspace() {
     assert_cursor(
         EditMode::Vi,
         ("", ""),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
         ("", ""),
     );
     assert_cursor(
         EditMode::Vi,
         ("Hi", ""),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
         ("H", ""),
     );
     assert_cursor(
         EditMode::Vi,
         ("", "Hi"),
-        &[KeyPress::Backspace, KeyPress::Enter],
+        &[(K::Backspace, M::NONE), (K::Enter, M::NONE)],
         ("", "Hi"),
     );
 }
@@ -50,7 +50,7 @@ fn esc() {
     assert_cursor(
         EditMode::Vi,
         ("", ""),
-        &[KeyPress::Char('a'), KeyPress::Esc, KeyPress::Enter],
+        &[(K::Char('a'), M::NONE), (K::Esc, M::NONE), (K::Enter, M::NONE)],
         ("", "a"),
     );
 }

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -4,7 +4,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::highlight::Highlighter;
-use crate::keys::KeyPress;
+use crate::keys::KeyEvent;
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -18,7 +18,7 @@ pub trait RawMode: Sized {
 /// Translate bytes read from stdin to keys.
 pub trait RawReader {
     /// Blocking read of key pressed.
-    fn next_key(&mut self, single_esc_abort: bool) -> Result<KeyPress>;
+    fn next_key(&mut self, single_esc_abort: bool) -> Result<KeyEvent>;
     /// For CTRL-V support
     #[cfg(unix)]
     fn next_char(&mut self) -> Result<char>;

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -7,7 +7,7 @@ use super::{RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error::ReadlineError;
 use crate::highlight::Highlighter;
-use crate::keys::{KeyEvent, KeyCode as K, Modifiers as M};
+use crate::keys::KeyEvent;
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -48,6 +48,7 @@ impl RawReader for IntoIter<KeyEvent> {
 
     #[cfg(unix)]
     fn next_char(&mut self) -> Result<char> {
+        use crate::keys::{KeyCode as K, Modifiers as M};
         match self.next() {
             Some((K::Char(c), M::NONE)) => Ok(c),
             None => Err(ReadlineError::Eof),

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -7,7 +7,7 @@ use super::{RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error::ReadlineError;
 use crate::highlight::Highlighter;
-use crate::keys::KeyPress;
+use crate::keys::{KeyEvent, KeyCode as K, Modifiers as M};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -20,8 +20,8 @@ impl RawMode for Mode {
     }
 }
 
-impl<'a> RawReader for Iter<'a, KeyPress> {
-    fn next_key(&mut self, _: bool) -> Result<KeyPress> {
+impl<'a> RawReader for Iter<'a, KeyEvent> {
+    fn next_key(&mut self, _: bool) -> Result<KeyEvent> {
         match self.next() {
             Some(key) => Ok(*key),
             None => Err(ReadlineError::Eof),
@@ -38,8 +38,8 @@ impl<'a> RawReader for Iter<'a, KeyPress> {
     }
 }
 
-impl RawReader for IntoIter<KeyPress> {
-    fn next_key(&mut self, _: bool) -> Result<KeyPress> {
+impl RawReader for IntoIter<KeyEvent> {
+    fn next_key(&mut self, _: bool) -> Result<KeyEvent> {
         match self.next() {
             Some(key) => Ok(key),
             None => Err(ReadlineError::Eof),
@@ -49,7 +49,7 @@ impl RawReader for IntoIter<KeyPress> {
     #[cfg(unix)]
     fn next_char(&mut self) -> Result<char> {
         match self.next() {
-            Some(KeyPress::Char(c)) => Ok(c),
+            Some((K::Char(c), M::NONE)) => Ok(c),
             None => Err(ReadlineError::Eof),
             _ => unimplemented!(),
         }
@@ -69,7 +69,7 @@ impl Sink {
 }
 
 impl Renderer for Sink {
-    type Reader = IntoIter<KeyPress>;
+    type Reader = IntoIter<KeyEvent>;
 
     fn move_cursor(&mut self, _: Position, _: Position) -> Result<()> {
         Ok(())
@@ -123,7 +123,7 @@ impl Renderer for Sink {
         false
     }
 
-    fn move_cursor_at_leftmost(&mut self, _: &mut IntoIter<KeyPress>) -> Result<()> {
+    fn move_cursor_at_leftmost(&mut self, _: &mut IntoIter<KeyEvent>) -> Result<()> {
         Ok(())
     }
 }
@@ -132,7 +132,7 @@ pub type Terminal = DummyTerminal;
 
 #[derive(Clone, Debug)]
 pub struct DummyTerminal {
-    pub keys: Vec<KeyPress>,
+    pub keys: Vec<KeyEvent>,
     pub cursor: usize, // cursor position before last command
     pub color_mode: ColorMode,
     pub bell_style: BellStyle,
@@ -140,7 +140,7 @@ pub struct DummyTerminal {
 
 impl Term for DummyTerminal {
     type Mode = Mode;
-    type Reader = IntoIter<KeyPress>;
+    type Reader = IntoIter<KeyEvent>;
     type Writer = Sink;
 
     fn new(
@@ -183,7 +183,7 @@ impl Term for DummyTerminal {
         Ok(())
     }
 
-    fn create_reader(&self, _: &Config) -> Result<IntoIter<KeyPress>> {
+    fn create_reader(&self, _: &Config) -> Result<IntoIter<KeyEvent>> {
         Ok(self.keys.clone().into_iter())
     }
 

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -48,9 +48,9 @@ impl RawReader for IntoIter<KeyEvent> {
 
     #[cfg(unix)]
     fn next_char(&mut self) -> Result<char> {
-        use crate::keys::{KeyCode as K, Modifiers as M};
+        use crate::keys::{KeyCode as K, KeyEvent as E, Modifiers as M};
         match self.next() {
-            Some((K::Char(c), M::NONE)) => Ok(c),
+            Some(E(K::Char(c), M::NONE)) => Ok(c),
             None => Err(ReadlineError::Eof),
             _ => unimplemented!(),
         }

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -17,7 +17,7 @@ use super::{width, RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error;
 use crate::highlight::Highlighter;
-use crate::keys::{self, KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
+use crate::keys::{KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -617,7 +617,7 @@ impl RawReader for PosixRawReader {
     fn next_key(&mut self, single_esc_abort: bool) -> Result<KeyEvent> {
         let c = self.next_char()?;
 
-        let mut key = keys::char_to_key_event(c, M::NONE);
+        let mut key = KeyEvent::new(c, M::NONE);
         if key == E::ESC {
             let timeout_ms = if single_esc_abort && self.timeout_ms == -1 {
                 0

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -488,8 +488,8 @@ impl PosixRawReader {
                         (CTRL_ALT_SHIFT, 'w') => (K::Char('7'), M::CTRL_ALT_SHIFT),
                         (CTRL_ALT_SHIFT, 'x') => (K::Char('8'), M::CTRL_ALT_SHIFT),
                         (CTRL_ALT_SHIFT, 'y') => (K::Char('9'), M::CTRL_ALT_SHIFT),
-                        ('9', UP) => (K::Up, M::ALT), /* Meta + arrow on (some?) Macs when using
-                                                        * iTerm defaults */
+                        // Meta + arrow on (some?) Macs when using iTerm defaults
+                        ('9', UP) => (K::Up, M::ALT),
                         ('9', DOWN) => (K::Down, M::ALT),
                         ('9', RIGHT) => (K::Right, M::ALT),
                         ('9', LEFT) => (K::Left, M::ALT),

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -17,7 +17,7 @@ use super::{width, RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error;
 use crate::highlight::Highlighter;
-use crate::keys::{self, KeyEvent, KeyCode as K, Modifiers as M};
+use crate::keys::{self, KeyCode as K, KeyEvent, Modifiers as M};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -269,10 +269,10 @@ impl PosixRawReader {
                 //'M' => (K::, M::), // kmous
                 //'P' => (K::Delete, M::NONE), // dch1
                 'Z' => (K::BackTab, M::NONE),
-                'a' => (K::Up, M::SHIFT), // rxvt: kind or kUP
-                'b' => (K::Down, M::SHIFT), // rxvt: kri or kDN
+                'a' => (K::Up, M::SHIFT),    // rxvt: kind or kUP
+                'b' => (K::Down, M::SHIFT),  // rxvt: kri or kDN
                 'c' => (K::Right, M::SHIFT), // rxvt
-                'd' => (K::Left, M::SHIFT), // rxvt
+                'd' => (K::Left, M::SHIFT),  // rxvt
                 _ => {
                     debug!(target: "rustyline", "unsupported esc sequence: \\E[{:?}", seq2);
                     (K::UnknownEscSeq, M::NONE)
@@ -393,11 +393,11 @@ impl PosixRawReader {
                 let seq5 = self.next_char()?;
                 if seq5.is_digit(10) {
                     self.next_char()?; // 'R' expected
-                    //('1', '0', UP) => (K::, M::), // Alt + Shift + Up
+                                       //('1', '0', UP) => (K::, M::), // Alt + Shift + Up
                     Ok((K::UnknownEscSeq, M::NONE))
                 } else if seq2 == '1' {
                     Ok(match (seq4, seq5) {
-                        (SHIFT, UP) => (K::Up, M::SHIFT), // ~ key_sr
+                        (SHIFT, UP) => (K::Up, M::SHIFT),     // ~ key_sr
                         (SHIFT, DOWN) => (K::Down, M::SHIFT), // ~ key_sf
                         (SHIFT, RIGHT) => (K::Right, M::SHIFT),
                         (SHIFT, LEFT) => (K::Left, M::SHIFT),
@@ -488,7 +488,8 @@ impl PosixRawReader {
                         (CTRL_ALT_SHIFT, 'w') => (K::Char('7'), M::CTRL_ALT_SHIFT),
                         (CTRL_ALT_SHIFT, 'x') => (K::Char('8'), M::CTRL_ALT_SHIFT),
                         (CTRL_ALT_SHIFT, 'y') => (K::Char('9'), M::CTRL_ALT_SHIFT),
-                        ('9', UP) => (K::Up, M::ALT), // Meta + arrow on (some?) Macs when using iTerm defaults
+                        ('9', UP) => (K::Up, M::ALT), /* Meta + arrow on (some?) Macs when using
+                                                        * iTerm defaults */
                         ('9', DOWN) => (K::Down, M::ALT),
                         ('9', RIGHT) => (K::Right, M::ALT),
                         ('9', LEFT) => (K::Left, M::ALT),
@@ -498,7 +499,7 @@ impl PosixRawReader {
                             (K::UnknownEscSeq, M::NONE)
                         }
                     })
-                } else if seq5 == '~'{
+                } else if seq5 == '~' {
                     Ok(match (seq2, seq4) {
                         (INSERT, SHIFT) => (K::Insert, M::SHIFT),
                         (INSERT, ALT) => (K::Insert, M::ALT),
@@ -583,8 +584,8 @@ impl PosixRawReader {
             LEFT => (K::Left, M::NONE),
             //'E' => (K::, M::),// key_b2, kb2
             END => (K::End, M::NONE),   // kend
-            HOME => (K::Home, M::NONE),  // khome
-            'M' => (K::Enter, M::NONE),  // kent
+            HOME => (K::Home, M::NONE), // khome
+            'M' => (K::Enter, M::NONE), // kent
             'P' => (K::F(1), M::NONE),  // kf1
             'Q' => (K::F(2), M::NONE),  // kf2
             'R' => (K::F(3), M::NONE),  // kf3
@@ -597,7 +598,7 @@ impl PosixRawReader {
             't' => (K::F(5), M::NONE),  // kf5 or kb1
             'u' => (K::F(6), M::NONE),  // kf6 or kb2
             'v' => (K::F(7), M::NONE),  // kf7 or kb3
-            'w' => (K::F(9), M::NONE), // kf9 or ka1
+            'w' => (K::F(9), M::NONE),  // kf9 or ka1
             'x' => (K::F(10), M::NONE), // kf10 or ka2
             _ => {
                 debug!(target: "rustyline", "unsupported esc sequence: \\EO{:?}", seq2);

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -616,7 +616,7 @@ impl RawReader for PosixRawReader {
     fn next_key(&mut self, single_esc_abort: bool) -> Result<KeyEvent> {
         let c = self.next_char()?;
 
-        let mut key = keys::char_to_key_press(c);
+        let mut key = keys::char_to_key_press(c, M::NONE);
         if key == (K::Esc, M::NONE) {
             let timeout_ms = if single_esc_abort && self.timeout_ms == -1 {
                 0

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -219,8 +219,7 @@ impl PosixRawReader {
             // ...
             Ok(E::ESC)
         } else {
-            // TODO ESC-R (r): Undo all changes made to this line.
-            Ok(E(K::Char(seq1), M::ALT))
+            Ok(E::alt(seq1))
         }
     }
 

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -1,7 +1,7 @@
 //! Windows specific definitions
 #![allow(clippy::try_err)] // suggested fix does not work (cannot infer...)
 
-use std::io::{self, ErrorKind, Write};
+use std::io::{self, Write};
 use std::mem;
 use std::sync::atomic;
 
@@ -140,19 +140,19 @@ impl RawReader for ConsoleRawReader {
             let ctrl = key_event.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED) != 0;
             let meta = alt && !alt_gr;
             let shift = key_event.dwControlKeyState & SHIFT_PRESSED != 0;
+            let mut mods = M::NONE;
+            if ctrl {
+                mods |= M::CTRL;
+            }
+            if meta {
+                mods |= M::ALT;
+            }
+            if shift {
+                mods |= M::SHIFT;
+            }
 
             let utf16 = unsafe { *key_event.uChar.UnicodeChar() };
             if utf16 == 0 {
-                let mut mods = M::NONE;
-                if ctl {
-                    mods |= M::CTRL:
-                }
-                if meta {
-                    mods |= M::ALT:
-                }
-                if shift {
-                    mods |= M::SHIFT:
-                }
                 match i32::from(key_event.wVirtualKeyCode) {
                     winuser::VK_LEFT => {
                         return Ok((K::Left, mods));

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -17,7 +17,7 @@ use super::{width, RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error;
 use crate::highlight::Highlighter;
-use crate::keys::{self, KeyEvent, KeyCode as K, Modifiers as M};
+use crate::keys::{self, KeyCode as K, KeyEvent, Modifiers as M};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -150,33 +150,36 @@ impl RawReader for ConsoleRawReader {
 
             let utf16 = unsafe { *key_event.uChar.UnicodeChar() };
             let key = if utf16 == 0 {
-                (match i32::from(key_event.wVirtualKeyCode) {
-                    winuser::VK_LEFT => K::Left,
-                    winuser::VK_RIGHT => K::Right,
-                    winuser::VK_UP => K::Up,
-                    winuser::VK_DOWN => K::Down,
-                    winuser::VK_DELETE => K::Delete,
-                    winuser::VK_HOME => K::Home,
-                    winuser::VK_END => K::End,
-                    winuser::VK_PRIOR => K::PageUp,
-                    winuser::VK_NEXT => K::PageDown,
-                    winuser::VK_INSERT => K::Insert,
-                    winuser::VK_F1 => K::F(1),
-                    winuser::VK_F2 => K::F(2),
-                    winuser::VK_F3 => K::F(3),
-                    winuser::VK_F4 => K::F(4),
-                    winuser::VK_F5 => K::F(5),
-                    winuser::VK_F6 => K::F(6),
-                    winuser::VK_F7 => K::F(7),
-                    winuser::VK_F8 => K::F(8),
-                    winuser::VK_F9 => K::F(9),
-                    winuser::VK_F10 => K::F(10),
-                    winuser::VK_F11 => K::F(11),
-                    winuser::VK_F12 => K::F(12),
-                    // winuser::VK_BACK is correctly handled because the key_event.UnicodeChar is
-                    // also set.
-                    _ => continue,
-                }, mods)
+                (
+                    match i32::from(key_event.wVirtualKeyCode) {
+                        winuser::VK_LEFT => K::Left,
+                        winuser::VK_RIGHT => K::Right,
+                        winuser::VK_UP => K::Up,
+                        winuser::VK_DOWN => K::Down,
+                        winuser::VK_DELETE => K::Delete,
+                        winuser::VK_HOME => K::Home,
+                        winuser::VK_END => K::End,
+                        winuser::VK_PRIOR => K::PageUp,
+                        winuser::VK_NEXT => K::PageDown,
+                        winuser::VK_INSERT => K::Insert,
+                        winuser::VK_F1 => K::F(1),
+                        winuser::VK_F2 => K::F(2),
+                        winuser::VK_F3 => K::F(3),
+                        winuser::VK_F4 => K::F(4),
+                        winuser::VK_F5 => K::F(5),
+                        winuser::VK_F6 => K::F(6),
+                        winuser::VK_F7 => K::F(7),
+                        winuser::VK_F8 => K::F(8),
+                        winuser::VK_F9 => K::F(9),
+                        winuser::VK_F10 => K::F(10),
+                        winuser::VK_F11 => K::F(11),
+                        winuser::VK_F12 => K::F(12),
+                        // winuser::VK_BACK is correctly handled because the key_event.UnicodeChar
+                        // is also set.
+                        _ => continue,
+                    },
+                    mods,
+                )
             } else if utf16 == 27 {
                 (K::Esc, mods)
             } else {

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -137,17 +137,14 @@ impl RawReader for ConsoleRawReader {
             let alt_gr = key_event.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_ALT_PRESSED)
                 == (LEFT_CTRL_PRESSED | RIGHT_ALT_PRESSED);
             let alt = key_event.dwControlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED) != 0;
-            let ctrl = key_event.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED) != 0;
-            let meta = alt && !alt_gr;
-            let shift = key_event.dwControlKeyState & SHIFT_PRESSED != 0;
             let mut mods = M::NONE;
-            if ctrl {
+            if key_event.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED) != 0 {
                 mods |= M::CTRL;
             }
-            if meta {
+            if alt && !alt_gr {
                 mods |= M::ALT;
             }
-            if shift {
+            if key_event.dwControlKeyState & SHIFT_PRESSED != 0 {
                 mods |= M::SHIFT;
             }
 
@@ -179,7 +176,7 @@ impl RawReader for ConsoleRawReader {
                     // winuser::VK_BACK is correctly handled because the key_event.UnicodeChar is
                     // also set.
                     _ => continue,
-                }, mods);
+                }, mods));
             } else if utf16 == 27 {
                 return Ok((K::Esc, mods));
             } else {

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -17,7 +17,7 @@ use super::{width, RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error;
 use crate::highlight::Highlighter;
-use crate::keys::{self, KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
+use crate::keys::{KeyCode as K, KeyEvent, Modifiers as M};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -150,7 +150,7 @@ impl RawReader for ConsoleRawReader {
 
             let utf16 = unsafe { *key_event.uChar.UnicodeChar() };
             let key = if utf16 == 0 {
-                (
+                KeyEvent(
                     match i32::from(key_event.wVirtualKeyCode) {
                         winuser::VK_LEFT => K::Left,
                         winuser::VK_RIGHT => K::Right,
@@ -181,7 +181,7 @@ impl RawReader for ConsoleRawReader {
                     mods,
                 )
             } else if utf16 == 27 {
-                E(K::Esc, mods)
+                KeyEvent(K::Esc, mods)
             } else {
                 if utf16 >= 0xD800 && utf16 < 0xDC00 {
                     surrogate = utf16;
@@ -198,7 +198,7 @@ impl RawReader for ConsoleRawReader {
                     return Err(error::ReadlineError::Eof);
                 };
                 let c = rc?;
-                keys::char_to_key_event(c, mods)
+                KeyEvent::new(c, mods)
             };
             debug!(target: "rustyline", "key: {:?}", key);
             return Ok(key);

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -17,7 +17,7 @@ use super::{width, RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error;
 use crate::highlight::Highlighter;
-use crate::keys::{self, KeyCode as K, KeyEvent, Modifiers as M};
+use crate::keys::{self, KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -181,7 +181,7 @@ impl RawReader for ConsoleRawReader {
                     mods,
                 )
             } else if utf16 == 27 {
-                (K::Esc, mods)
+                E(K::Esc, mods)
             } else {
                 if utf16 >= 0xD800 && utf16 < 0xDC00 {
                     surrogate = utf16;
@@ -198,7 +198,7 @@ impl RawReader for ConsoleRawReader {
                     return Err(error::ReadlineError::Eof);
                 };
                 let c = rc?;
-                keys::char_to_key_press(c, mods)
+                keys::char_to_key_event(c, mods)
             };
             debug!(target: "rustyline", "key: {:?}", key);
             return Ok(key);

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -198,7 +198,6 @@ impl RawReader for ConsoleRawReader {
                     return Err(error::ReadlineError::Eof);
                 };
                 let c = rc?;
-                // TODO Check Alt-A ...
                 keys::char_to_key_press(c, mods)
             };
             debug!(target: "rustyline", "key: {:?}", key);

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -153,41 +153,33 @@ impl RawReader for ConsoleRawReader {
 
             let utf16 = unsafe { *key_event.uChar.UnicodeChar() };
             if utf16 == 0 {
-                match i32::from(key_event.wVirtualKeyCode) {
-                    winuser::VK_LEFT => {
-                        return Ok((K::Left, mods));
-                    }
-                    winuser::VK_RIGHT => {
-                        return Ok((K::Right, mods));
-                    }
-                    winuser::VK_UP => {
-                        return Ok((K::Up, mods));
-                    }
-                    winuser::VK_DOWN => {
-                        return Ok((K::Down, mods));
-                    }
-                    winuser::VK_DELETE => return Ok((K::Delete, mods)),
-                    winuser::VK_HOME => return Ok((K::Home, mods)),
-                    winuser::VK_END => return Ok((K::End, mods)),
-                    winuser::VK_PRIOR => return Ok((K::PageUp, mods)),
-                    winuser::VK_NEXT => return Ok((K::PageDown, mods)),
-                    winuser::VK_INSERT => return Ok((K::Insert, mods)),
-                    winuser::VK_F1 => return Ok((K::F(1), mods)),
-                    winuser::VK_F2 => return Ok((K::F(2), mods)),
-                    winuser::VK_F3 => return Ok((K::F(3), mods)),
-                    winuser::VK_F4 => return Ok((K::F(4), mods)),
-                    winuser::VK_F5 => return Ok((K::F(5), mods)),
-                    winuser::VK_F6 => return Ok((K::F(6), mods)),
-                    winuser::VK_F7 => return Ok((K::F(7), mods)),
-                    winuser::VK_F8 => return Ok((K::F(8), mods)),
-                    winuser::VK_F9 => return Ok((K::F(9), mods)),
-                    winuser::VK_F10 => return Ok((K::F(10), mods)),
-                    winuser::VK_F11 => return Ok((K::F(11), mods)),
-                    winuser::VK_F12 => return Ok((K::F(12), mods)),
+                return Ok((match i32::from(key_event.wVirtualKeyCode) {
+                    winuser::VK_LEFT => K::Left,
+                    winuser::VK_RIGHT => K::Right,
+                    winuser::VK_UP => K::Up,
+                    winuser::VK_DOWN => K::Down,
+                    winuser::VK_DELETE => K::Delete,
+                    winuser::VK_HOME => K::Home,
+                    winuser::VK_END => K::End,
+                    winuser::VK_PRIOR => K::PageUp,
+                    winuser::VK_NEXT => K::PageDown,
+                    winuser::VK_INSERT => K::Insert,
+                    winuser::VK_F1 => K::F(1),
+                    winuser::VK_F2 => K::F(2),
+                    winuser::VK_F3 => K::F(3),
+                    winuser::VK_F4 => K::F(4),
+                    winuser::VK_F5 => K::F(5),
+                    winuser::VK_F6 => K::F(6),
+                    winuser::VK_F7 => K::F(7),
+                    winuser::VK_F8 => K::F(8),
+                    winuser::VK_F9 => K::F(9),
+                    winuser::VK_F10 => K::F(10),
+                    winuser::VK_F11 => K::F(11),
+                    winuser::VK_F12 => K::F(12),
                     // winuser::VK_BACK is correctly handled because the key_event.UnicodeChar is
                     // also set.
                     _ => continue,
-                };
+                }, mods);
             } else if utf16 == 27 {
                 return Ok((K::Esc, mods));
             } else {

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -17,7 +17,7 @@ use super::{width, RawMode, RawReader, Renderer, Term};
 use crate::config::{BellStyle, ColorMode, Config, OutputStreamType};
 use crate::error;
 use crate::highlight::Highlighter;
-use crate::keys::{self, KeyPress};
+use crate::keys::{self, KeyEvent, KeyCode};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::Result;
@@ -101,7 +101,7 @@ impl ConsoleRawReader {
 }
 
 impl RawReader for ConsoleRawReader {
-    fn next_key(&mut self, _: bool) -> Result<KeyPress> {
+    fn next_key(&mut self, _: bool) -> Result<KeyEvent> {
         use std::char::decode_utf16;
         use winapi::um::wincon::{
             LEFT_ALT_PRESSED, LEFT_CTRL_PRESSED, RIGHT_ALT_PRESSED, RIGHT_CTRL_PRESSED,
@@ -146,64 +146,64 @@ impl RawReader for ConsoleRawReader {
                 match i32::from(key_event.wVirtualKeyCode) {
                     winuser::VK_LEFT => {
                         return Ok(if ctrl {
-                            KeyPress::ControlLeft
+                            (K::Left, M::CTRL)
                         } else if shift {
-                            KeyPress::ShiftLeft
+                            (K::Left, M::SHIFT)
                         } else {
-                            KeyPress::Left
+                            KeyCode::Left
                         });
                     }
                     winuser::VK_RIGHT => {
                         return Ok(if ctrl {
-                            KeyPress::ControlRight
+                            (K::Right, M::CTRL)
                         } else if shift {
-                            KeyPress::ShiftRight
+                            (K::Right, M::SHIFT)
                         } else {
-                            KeyPress::Right
+                            KeyCode::Right
                         });
                     }
                     winuser::VK_UP => {
                         return Ok(if ctrl {
-                            KeyPress::ControlUp
+                            (K::Up, M::CTRL)
                         } else if shift {
-                            KeyPress::ShiftUp
+                            (K::Up, M::SHIFT)
                         } else {
-                            KeyPress::Up
+                            KeyCode::Up
                         });
                     }
                     winuser::VK_DOWN => {
                         return Ok(if ctrl {
-                            KeyPress::ControlDown
+                            (K::Down, M::CTRL)
                         } else if shift {
-                            KeyPress::ShiftDown
+                            (K::Down, M::SHIFT)
                         } else {
-                            KeyPress::Down
+                            KeyCode::Down
                         });
                     }
-                    winuser::VK_DELETE => return Ok(KeyPress::Delete),
-                    winuser::VK_HOME => return Ok(KeyPress::Home),
-                    winuser::VK_END => return Ok(KeyPress::End),
-                    winuser::VK_PRIOR => return Ok(KeyPress::PageUp),
-                    winuser::VK_NEXT => return Ok(KeyPress::PageDown),
-                    winuser::VK_INSERT => return Ok(KeyPress::Insert),
-                    winuser::VK_F1 => return Ok(KeyPress::F(1)),
-                    winuser::VK_F2 => return Ok(KeyPress::F(2)),
-                    winuser::VK_F3 => return Ok(KeyPress::F(3)),
-                    winuser::VK_F4 => return Ok(KeyPress::F(4)),
-                    winuser::VK_F5 => return Ok(KeyPress::F(5)),
-                    winuser::VK_F6 => return Ok(KeyPress::F(6)),
-                    winuser::VK_F7 => return Ok(KeyPress::F(7)),
-                    winuser::VK_F8 => return Ok(KeyPress::F(8)),
-                    winuser::VK_F9 => return Ok(KeyPress::F(9)),
-                    winuser::VK_F10 => return Ok(KeyPress::F(10)),
-                    winuser::VK_F11 => return Ok(KeyPress::F(11)),
-                    winuser::VK_F12 => return Ok(KeyPress::F(12)),
+                    winuser::VK_DELETE => return Ok(KeyCode::Delete),
+                    winuser::VK_HOME => return Ok(KeyCode::Home),
+                    winuser::VK_END => return Ok(KeyCode::End),
+                    winuser::VK_PRIOR => return Ok(KeyCode::PageUp),
+                    winuser::VK_NEXT => return Ok(KeyCode::PageDown),
+                    winuser::VK_INSERT => return Ok(KeyCode::Insert),
+                    winuser::VK_F1 => return Ok(KeyCode::F(1)),
+                    winuser::VK_F2 => return Ok(KeyCode::F(2)),
+                    winuser::VK_F3 => return Ok(KeyCode::F(3)),
+                    winuser::VK_F4 => return Ok(KeyCode::F(4)),
+                    winuser::VK_F5 => return Ok(KeyCode::F(5)),
+                    winuser::VK_F6 => return Ok(KeyCode::F(6)),
+                    winuser::VK_F7 => return Ok(KeyCode::F(7)),
+                    winuser::VK_F8 => return Ok(KeyCode::F(8)),
+                    winuser::VK_F9 => return Ok(KeyCode::F(9)),
+                    winuser::VK_F10 => return Ok(KeyCode::F(10)),
+                    winuser::VK_F11 => return Ok(KeyCode::F(11)),
+                    winuser::VK_F12 => return Ok(KeyCode::F(12)),
                     // winuser::VK_BACK is correctly handled because the key_event.UnicodeChar is
                     // also set.
                     _ => continue,
                 };
             } else if utf16 == 27 {
-                return Ok(KeyPress::Esc);
+                return Ok(KeyCode::Esc);
             } else {
                 if utf16 >= 0xD800 && utf16 < 0xDC00 {
                     surrogate = utf16;
@@ -221,13 +221,13 @@ impl RawReader for ConsoleRawReader {
                 };
                 let c = rc?;
                 if meta {
-                    return Ok(KeyPress::Meta(c));
+                    return Ok(KeyCode::Meta(c));
                 } else {
                     let mut key = keys::char_to_key_press(c);
-                    if key == KeyPress::Tab && shift {
-                        key = KeyPress::BackTab;
-                    } else if key == KeyPress::Char(' ') && ctrl {
-                        key = KeyPress::Ctrl(' ');
+                    if key == KeyCode::Tab && shift {
+                        key = KeyCode::BackTab;
+                    } else if key == KeyCode::Char(' ') && ctrl {
+                        key = KeyCode::Ctrl(' ');
                     }
                     return Ok(key);
                 }

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -149,8 +149,8 @@ impl RawReader for ConsoleRawReader {
             }
 
             let utf16 = unsafe { *key_event.uChar.UnicodeChar() };
-            if utf16 == 0 {
-                return Ok((match i32::from(key_event.wVirtualKeyCode) {
+            let key = if utf16 == 0 {
+                (match i32::from(key_event.wVirtualKeyCode) {
                     winuser::VK_LEFT => K::Left,
                     winuser::VK_RIGHT => K::Right,
                     winuser::VK_UP => K::Up,
@@ -176,9 +176,9 @@ impl RawReader for ConsoleRawReader {
                     // winuser::VK_BACK is correctly handled because the key_event.UnicodeChar is
                     // also set.
                     _ => continue,
-                }, mods));
+                }, mods)
             } else if utf16 == 27 {
-                return Ok((K::Esc, mods));
+                (K::Esc, mods)
             } else {
                 if utf16 >= 0xD800 && utf16 < 0xDC00 {
                     surrogate = utf16;
@@ -196,9 +196,10 @@ impl RawReader for ConsoleRawReader {
                 };
                 let c = rc?;
                 // TODO Check Alt-A ...
-                let key = keys::char_to_key_press(c, mods);
-                return Ok(key);
-            }
+                keys::char_to_key_press(c, mods)
+            };
+            debug!(target: "rustyline", "key: {:?}", key);
+            return Ok(key);
         }
     }
 


### PR DESCRIPTION
Validate:
* Pros and cons of tuple struct versus  struct ?
* Tuple struct order: `(key, mods)` versus `(mods, key)` ?
* Remove `BackTab` and keep only `SHIFT-Tab` ?
* Remove `Modifiers::CTRL_SHIFT`, ... ?
* Normalize:
    - Ctrl-a => Ctrl-A
    - Shift-A => A

Todo:
\E\E[ sequences on unix (we should use `poll`).

This PR replaces/enhances:
* #333 (except \E\E[ sequences)
* #422
* #121 (should we support `SUPER` modifier ?)

This PR should fixes:
* #318
* #421