### PR TITLE
Document Validator::validate_while_typing not being implemented

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -64,7 +64,8 @@ pub trait Validator {
     /// when user presses the Enter key.
     ///
     /// Default is `false`.
-    // TODO we can implement this later.
+    ///
+    /// This feature is not yet implemented, so this function is currently a no-op
     fn validate_while_typing(&self) -> bool {
         false
     }


### PR DESCRIPTION
This was previously not apparent to library consumers, and can/has lead
to confusion when the function doesn't/didn't work as users expect(ed).
This commit makes it more clear to users that the function is a no-op by
exposing such information through rustdoc.