### PR TITLE
Initial invoke trait and auto-indent example

### DIFF
--- a/examples/auto_indent.rs
+++ b/examples/auto_indent.rs
@@ -1,0 +1,69 @@
+use std::cmp::Ordering;
+use std::io::Write;
+use std::cell::RefCell;
+
+use rustyline::error::ReadlineError;
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
+use rustyline::Editor;
+use rustyline_derive::{Completer, Helper, Highlighter, Hinter};
+use rustyline::{Cmd, Movement};
+
+#[derive(Completer, Helper, Highlighter, Hinter)]
+struct InputValidator {
+    stack_protect: RefCell<()>,
+}
+
+const INDENT_SIZE: usize = 2;  // default
+
+impl Validator for InputValidator {
+    fn validate(&self, ctx: &mut ValidationContext) -> Result<ValidationResult, ReadlineError> {
+        let input = ctx.input();
+        let _protect = if let Ok(cell) = self.stack_protect.try_borrow_mut() {
+            cell
+        } else {
+            // This is reached when `NewLine` is called below
+            return Ok(ValidationResult::Valid(None));
+        };
+        if let Some(line) = input.lines().last() {
+            let indent_chars = line.len() - line.trim_start().len();
+            writeln!(std::fs::File::create("./pipe").unwrap(),
+                "Indent_chars {}", indent_chars).unwrap();
+            let cur_indent = indent_chars / INDENT_SIZE;
+            let open_braces = line.chars().filter(|c| *c == '{').count();
+            let close_braces = line.chars().filter(|c| *c == '}').count();
+            let indent = match open_braces.cmp(&close_braces) {
+                Ordering::Greater => cur_indent + 1,
+                Ordering::Equal => cur_indent,
+                Ordering::Less => cur_indent.saturating_sub(1),
+            };
+            // dedent just edited line with single brace
+            if line.trim() == "}" {
+                ctx.invoke(Cmd::Dedent(Movement::WholeLine))?;
+            }
+            // indent new line as needed
+            ctx.invoke(Cmd::Newline)?;
+            writeln!(std::fs::File::create("./pipe").unwrap(),
+                "INDENT {}", indent).unwrap();
+            for _ in 0..indent {
+                ctx.invoke(Cmd::Indent(Movement::WholeLine))?;
+            }
+            // Example always returns invalid, so you can type any text
+            //
+            // But Valid or Invalid result should contain empty string as
+            // an error description to prevent newline being inserted, as we
+            // already inserted newline above
+            return Ok(ValidationResult::Invalid(Some(String::new())));
+        }
+        Ok(ValidationResult::Valid(None))
+    }
+}
+
+fn main() -> rustyline::Result<()> {
+    let h = InputValidator { stack_protect: RefCell::new(()) };
+    let mut rl = Editor::new();
+    rl.set_helper(Some(h));
+
+    let input = rl.readline("> ")?;
+    println!("Input: {}", input);
+    Ok(())
+}

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -12,12 +12,11 @@ use crate::highlight::Highlighter;
 use crate::hint::Hint;
 use crate::history::Direction;
 use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
-use crate::keymap::{InputState, Invoke, Refresher};
+use crate::keymap::{InputState, Refresher};
 use crate::layout::{Layout, Position};
 use crate::line_buffer::{LineBuffer, WordAction, MAX_LINE};
 use crate::tty::{Renderer, Term, Terminal};
 use crate::undo::Changeset;
-use crate::validate::{ValidationContext, ValidationResult};
 
 /// Represent the state during line editing.
 /// Implement rendering.
@@ -200,39 +199,6 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
 
     pub fn is_default_prompt(&self) -> bool {
         self.layout.default_prompt
-    }
-
-    pub fn validate(&mut self) -> Result<ValidationResult> {
-        if let Some(validator) = self.helper {
-            self.changes.borrow_mut().begin();
-            let result = validator.validate(&mut ValidationContext::new(self))?;
-            let corrected = self.changes.borrow_mut().end();
-            match result {
-                ValidationResult::Incomplete => {}
-                ValidationResult::Valid(ref msg) => {
-                    // Accept the line regardless of where the cursor is.
-                    if corrected || self.has_hint() || msg.is_some() {
-                        // Force a refresh without hints to leave the previous
-                        // line as the user typed it after a newline.
-                        self.refresh_line_with_msg(msg.as_deref())?;
-                    }
-                }
-                ValidationResult::Invalid(ref msg) => {
-                    if corrected || self.has_hint() || msg.is_some() {
-                        self.refresh_line_with_msg(msg.as_deref())?;
-                    }
-                }
-            }
-            Ok(result)
-        } else {
-            Ok(ValidationResult::Valid(None))
-        }
-    }
-}
-
-impl<'out, 'prompt, H: Helper> Invoke for State<'out, 'prompt, H> {
-    fn input(&self) -> &str {
-        self.line.as_str()
     }
 }
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, RwLock};
 use log::debug;
 
 use super::Result;
+use crate::command;
 use crate::config::Config;
 use crate::config::EditMode;
 use crate::keys::{KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
@@ -354,8 +355,7 @@ pub struct InputState {
 pub trait Invoke {
     /// currently edited line
     fn input(&self) -> &str;
-    // TODO
-    //fn invoke(&mut self, cmd: Cmd) -> Result<?>;
+    fn invoke(&mut self, cmd: Cmd) -> Result<command::Status>;
 }
 
 pub trait Refresher {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,13 @@ fn readline_edit<H: Helper>(
         }
 
         // Execute things can be done solely on a state object
-        match command::execute(cmd, &mut s, &input_state, &editor.kill_ring, &editor.config)? {
+        let mut ctx = command::InvokeContext {
+            state: &mut s,
+            input_state: &input_state,
+            kill_ring: &editor.kill_ring,
+            config: &editor.config,
+        };
+        match command::execute(cmd, &mut ctx)? {
             command::Status::Proceed => continue,
             command::Status::Submit => break,
         }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,7 +1,8 @@
 //! Input validation API (Multi-line editing)
 
-use crate::keymap::Invoke;
+use crate::keymap::{Cmd, Invoke};
 use crate::Result;
+use crate::command;
 
 /// Input validation result
 #[non_exhaustive]
@@ -40,10 +41,10 @@ impl<'i> ValidationContext<'i> {
         self.i.input()
     }
 
-    // TODO
-    //fn invoke(&mut self, cmd: Cmd) -> Result<?> {
-    //    self.i.invoke(cmd)
-    //}
+    /// Invokes arbitrary command
+    pub fn invoke(&mut self, cmd: Cmd) -> Result<command::Status> {
+        self.i.invoke(cmd)
+    }
 }
 
 /// This trait provides an extension interface for determining whether


### PR DESCRIPTION
Here is a somewhat minimal implementation of invoking commands from validator trait.

General notes: it's unclear what to do with `command::Status` which can be `Proceed` or `Submit`. Currently it's ignored. But we may want to disable (i.e. assert on) commands returning `Submit` in validator and don't expose `Status` type to the user?

About auto-indent (#453), I've put mostly working example, but there are few ugly parts of the implementation:
1. Data validated without newline. So to indent the new line, validator inserts line manually
2. Which is a problem as any NewLine command triggers validation again (infinite recursion), so I protect for that in validator itself using RefCell, but this seems ugly. Should we disable validation for commands run from validator? Or in future anywhere except typed by keys?
3. After inserting NewLine i need avoid it inserting by the execute trait. I use "empty message trick". But I'm not sure it's future-proof.

So while auto-indentation is just one use case for `invoke`, I think at least (3) should be fixed somehow. Quick options are:
1. Insert newline before validation (probably breaks too much stuff)
2. Add a validator option method, like `validate_after_newline() -> bool { false }` that makes it optional for validator. Or (2a) have a config option, or (2b) have different method for post-validation.
3. Add some `ValidationContext::skip_newline()` method, to skip adding newline after validation

(note: (1) and (2) fix `RefCell` issue too, unlike (3))