### PR TITLE
Add ClearBuffer command

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -86,6 +86,11 @@ pub fn execute<H: Helper>(
             s.clear_screen()?;
             s.refresh_line()?
         }
+        Cmd::ClearBuffer => {
+            // Clear the buffer and reset the cursor at the start
+            s.clear_buffer();
+            s.refresh_line()?;
+        }
         Cmd::NextHistory => {
             // Fetch the next command from the history list.
             s.edit_history_next(false)?

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -293,6 +293,12 @@ impl<'out, 'prompt, H: Helper> fmt::Debug for State<'out, 'prompt, H> {
 }
 
 impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
+    /// Clear the buffer and reset the line at the start
+    pub fn clear_buffer(&mut self) {
+        self.line.move_buffer_start();
+        self.line.kill_buffer();
+    }
+
     pub fn clear_screen(&mut self) -> Result<()> {
         self.out.clear_screen()?;
         self.layout.cursor = Position::default();

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -27,6 +27,8 @@ pub enum Cmd {
     BeginningOfHistory,
     /// capitalize-word
     CapitalizeWord,
+    /// Clear the buffer and resets the cursor at the start
+    ClearBuffer,
     /// clear-screen
     ClearScreen,
     /// complete


### PR DESCRIPTION
Hello,

This command is useful for repl(s).

For example IPython ctrlc does this, (it doesn't exit the shell, it only clears the buffer)