### PR TITLE
Conditional binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,8 @@ unicode-segmentation = "1.0"
 memchr = "2.0"
 # For custom bindings
 # https://rustsec.org/advisories/RUSTSEC-2021-0003.html
-smallvec = { version = "1.6.1", features = ["serde"] }
-radix_trie = "0.2.1"
-serde = { version = "1.0", features = ["derive"] }
-bincode = "1.3.1"
+smallvec = "1.6.1"
+radix_trie = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ log = "0.4"
 unicode-width = "0.1"
 unicode-segmentation = "1.0"
 memchr = "2.0"
+# https://rustsec.org/advisories/RUSTSEC-2021-0003.html
+smallvec = "1.6.1"
+radix_trie = "0.2.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,22 @@ members = ["rustyline-derive"]
 [dependencies]
 bitflags = "1.2"
 cfg-if = "1.0"
+# For file completion
 # https://rustsec.org/advisories/RUSTSEC-2020-0053.html
 dirs-next = { version = "2.0", optional = true }
+# For History
 fs2 = "0.4"
 libc = "0.2"
 log = "0.4"
 unicode-width = "0.1"
 unicode-segmentation = "1.0"
 memchr = "2.0"
+# For custom bindings
 # https://rustsec.org/advisories/RUSTSEC-2021-0003.html
-smallvec = "1.6.1"
+smallvec = { version = "1.6.1", features = ["serde"] }
 radix_trie = "0.2.1"
+serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.19"

--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -1,3 +1,4 @@
+use smallvec::smallvec;
 use std::borrow::Cow::{self, Borrowed, Owned};
 
 use rustyline::highlight::Highlighter;
@@ -87,6 +88,10 @@ fn main() {
     rl.bind_sequence(
         KeyEvent::from('\t'),
         EventHandler::Conditional(Box::new(TabEventHandler)),
+    );
+    rl.bind_sequence(
+        Event::KeySeq(smallvec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]),
+        EventHandler::Simple(Cmd::Suspend), // TODO external editor
     );
 
     loop {

--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -1,0 +1,96 @@
+use std::borrow::Cow::{self, Borrowed, Owned};
+
+use rustyline::highlight::Highlighter;
+use rustyline::hint::{Hinter, HistoryHinter};
+use rustyline::{
+    Cmd, ConditionalEventHandler, Context, Editor, Event, EventContext, EventHandler, KeyEvent,
+    RepeatCount,
+};
+use rustyline_derive::{Completer, Helper, Validator};
+
+#[derive(Completer, Helper, Validator)]
+struct MyHelper(HistoryHinter);
+
+impl Hinter for MyHelper {
+    type Hint = String;
+
+    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
+        self.0.hint(line, pos, ctx)
+    }
+}
+
+impl Highlighter for MyHelper {
+    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
+        &'s self,
+        prompt: &'p str,
+        default: bool,
+    ) -> Cow<'b, str> {
+        if default {
+            Owned(format!("\x1b[1;32m{}\x1b[m", prompt))
+        } else {
+            Borrowed(prompt)
+        }
+    }
+
+    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+        Owned(format!("\x1b[1m{}\x1b[m", hint))
+    }
+}
+
+struct CompleteHintHandler;
+impl ConditionalEventHandler for CompleteHintHandler {
+    fn handle(&self, evt: &Event, _: RepeatCount, _: bool, ctx: &EventContext) -> Option<Cmd> {
+        debug_assert_eq!(*evt, Event::from(KeyEvent::ctrl('E')));
+        if ctx.has_hint() {
+            Some(Cmd::CompleteHint)
+        } else {
+            None // default
+        }
+    }
+}
+
+struct TabEventHandler;
+impl ConditionalEventHandler for TabEventHandler {
+    fn handle(&self, evt: &Event, n: RepeatCount, _: bool, ctx: &EventContext) -> Option<Cmd> {
+        debug_assert_eq!(*evt, Event::from(KeyEvent::from('\t')));
+        if ctx.line()[..ctx.pos()]
+            .chars()
+            .rev()
+            .next()
+            .filter(|c| c.is_whitespace())
+            .is_some()
+        {
+            Some(Cmd::SelfInsert(n, '\t'))
+        } else {
+            None // default complete
+        }
+    }
+}
+
+fn main() {
+    let mut rl = Editor::<MyHelper>::new();
+    rl.set_helper(Some(MyHelper(HistoryHinter {})));
+
+    rl.bind_sequence(
+        KeyEvent::ctrl('E'),
+        EventHandler::Conditional(Box::new(CompleteHintHandler)),
+    );
+    rl.bind_sequence(
+        KeyEvent::from('\t'),
+        EventHandler::Conditional(Box::new(TabEventHandler)),
+    );
+
+    loop {
+        let readline = rl.readline("> ");
+        match readline {
+            Ok(line) => {
+                rl.add_history_entry(line.as_str());
+                println!("Line: {}", line);
+            }
+            Err(err) => {
+                println!("Error: {:?}", err);
+                break;
+            }
+        }
+    }
+}

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -97,8 +97,8 @@ fn main() -> rustyline::Result<()> {
     };
     let mut rl = Editor::with_config(config);
     rl.set_helper(Some(h));
-    rl.bind_sequence(KeyEvent::alt('N'), Cmd::HistorySearchForward);
-    rl.bind_sequence(KeyEvent::alt('P'), Cmd::HistorySearchBackward);
+    rl.bind_sequence(KeyEvent::alt('n'), Cmd::HistorySearchForward);
+    rl.bind_sequence(KeyEvent::alt('p'), Cmd::HistorySearchBackward);
     if rl.load_history("history.txt").is_err() {
         println!("No previous history.");
     }

--- a/examples/numeric_input.rs
+++ b/examples/numeric_input.rs
@@ -6,22 +6,14 @@ use rustyline::{
 struct FilteringEventHandler;
 impl ConditionalEventHandler for FilteringEventHandler {
     fn handle(&self, evt: &Event, _: RepeatCount, _: bool, _: &EventContext) -> Option<Cmd> {
-        match evt {
-            Event::KeySeq(ks) => {
-                if let Some(KeyEvent(KeyCode::Char(c), m)) = ks.first() {
-                    if m.contains(Modifiers::CTRL)
-                        || m.contains(Modifiers::ALT)
-                        || c.is_ascii_digit()
-                    {
-                        None
-                    } else {
-                        Some(Cmd::Noop) // filter out invalid input
-                    }
-                } else {
-                    None
-                }
+        if let Some(KeyEvent(KeyCode::Char(c), m)) = evt.get(0) {
+            if m.contains(Modifiers::CTRL) || m.contains(Modifiers::ALT) || c.is_ascii_digit() {
+                None
+            } else {
+                Some(Cmd::Noop) // filter out invalid input
             }
-            _ => None,
+        } else {
+            None
         }
     }
 }

--- a/examples/numeric_input.rs
+++ b/examples/numeric_input.rs
@@ -1,0 +1,49 @@
+use rustyline::{
+    Cmd, ConditionalEventHandler, Editor, Event, EventContext, EventHandler, KeyCode, KeyEvent,
+    Modifiers, RepeatCount,
+};
+
+struct FilteringEventHandler;
+impl ConditionalEventHandler for FilteringEventHandler {
+    fn handle(&self, evt: &Event, _: RepeatCount, _: bool, _: &EventContext) -> Option<Cmd> {
+        match evt {
+            Event::KeySeq(ks) => {
+                if let Some(KeyEvent(KeyCode::Char(c), m)) = ks.first() {
+                    if m.contains(Modifiers::CTRL)
+                        || m.contains(Modifiers::ALT)
+                        || c.is_ascii_digit()
+                    {
+                        None
+                    } else {
+                        Some(Cmd::Noop) // filter out invalid input
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+fn main() {
+    let mut rl = Editor::<()>::new();
+
+    rl.bind_sequence(
+        Event::Any,
+        EventHandler::Conditional(Box::new(FilteringEventHandler)),
+    );
+
+    loop {
+        let readline = rl.readline("> ");
+        match readline {
+            Ok(line) => {
+                println!("Num: {}", line);
+            }
+            Err(err) => {
+                println!("Error: {:?}", err);
+                break;
+            }
+        }
+    }
+}

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -1,0 +1,115 @@
+/// Custom event handlers
+use crate::{Cmd, EditMode, InputMode, InputState, KeyEvent, Refresher, RepeatCount};
+
+use radix_trie::TrieKey;
+use smallvec::{smallvec, SmallVec};
+
+/// Input event
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum Event {
+    /// Key sequence
+    // TODO Validate 2 ?
+    KeySeq(SmallVec<[KeyEvent; 2]>),
+    /// TODO Mouse event
+    Mouse(),
+}
+
+impl Event {
+    /// See [`KeyEvent::normalize`]
+    pub(crate) fn normalize(mut self) -> Self {
+        if let Event::KeySeq(ref mut keys) = self {
+            for key in keys.iter_mut() {
+                *key = KeyEvent::normalize(*key);
+            }
+        }
+        self
+    }
+}
+
+impl Into<Event> for KeyEvent {
+    fn into(self) -> Event {
+        Event::KeySeq(smallvec![self])
+    }
+}
+
+impl TrieKey for Event {}
+
+/// Event handler
+pub enum EventHandler {
+    /// unconditional command
+    Simple(Cmd),
+    /// handler behaviour depends on input state
+    Conditional(Box<dyn ConditionalEventHandler>),
+    /* invoke multiple actions
+     * TODO Macro(), */
+}
+
+impl Into<EventHandler> for Cmd {
+    fn into(self) -> EventHandler {
+        EventHandler::Simple(self)
+    }
+}
+
+/// Give access to user input.
+pub struct EventContext<'r> {
+    mode: EditMode,
+    input_mode: InputMode,
+    wrt: &'r dyn Refresher,
+}
+
+impl<'r> EventContext<'r> {
+    pub(crate) fn new(is: &InputState, wrt: &'r dyn Refresher) -> Self {
+        EventContext {
+            mode: is.mode,
+            input_mode: is.input_mode,
+            wrt,
+        }
+    }
+
+    /// emacs or vi mode
+    pub fn mode(&self) -> EditMode {
+        self.mode
+    }
+
+    /// vi input mode
+    pub fn input_mode(&self) -> InputMode {
+        self.input_mode
+    }
+
+    /// Returns `true` if there is a hint displayed.
+    pub fn has_hint(&self) -> bool {
+        self.wrt.has_hint()
+    }
+
+    /// currently edited line
+    pub fn line(&self) -> &str {
+        self.wrt.line()
+    }
+
+    /// Current cursor position (byte position)
+    pub fn pos(&self) -> usize {
+        self.wrt.pos()
+    }
+}
+
+/// May behave differently depending on:
+///  * edit mode (emacs vs vi)
+///  * vi input mode (insert vs replace vs command modes)
+///  * empty line
+///  * cursor position
+///  * repeat count
+///  * original key pressed (when same command is bound to different key)
+///  * hint
+///  * ...
+pub trait ConditionalEventHandler: Send + Sync {
+    /// Takes the current input state and
+    /// returns the command to be performed or `None` to perform the default
+    /// one.
+    fn handle(
+        &self,
+        evt: &Event,
+        n: RepeatCount,
+        positive: bool,
+        ctx: &EventContext,
+    ) -> Option<Cmd>;
+}

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -29,6 +29,15 @@ impl Event {
         }
         self
     }
+
+    /// Return `i`th key event
+    pub fn get(&self, i: usize) -> Option<&KeyEvent> {
+        if let Event::KeySeq(ref ks) = self {
+            ks.get(i)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<KeyEvent> for Event {

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -5,7 +5,7 @@ use radix_trie::TrieKey;
 use smallvec::{smallvec, SmallVec};
 
 /// Input event
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Event {
     /// Wildcard.
     /// Useful if you want to filter out some keys.
@@ -142,10 +142,14 @@ mod test {
     fn encode() {
         let mut trie = Trie::new();
         let evt = Event::KeySeq(smallvec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]);
-        trie.insert(evt, EventHandler::from(Cmd::Noop));
+        trie.insert(evt.clone(), EventHandler::from(Cmd::Noop));
         let prefix = Event::from(KeyEvent::ctrl('X'));
         let subtrie = trie.get_raw_descendant(&prefix);
         assert!(subtrie.is_some());
+        let subtrie = subtrie.unwrap();
+        let sub_result = subtrie.get(&evt);
+        assert!(sub_result.is_ok());
+        assert!(sub_result.unwrap().is_some());
         let prefix = Event::from(KeyEvent::ctrl('O'));
         let subtrie = trie.get_raw_descendant(&prefix);
         assert!(subtrie.is_none())

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -2,11 +2,15 @@
 use crate::{Cmd, EditMode, InputMode, InputState, KeyEvent, Refresher, RepeatCount};
 
 use radix_trie::TrieKey;
+use serde::Serialize;
 use smallvec::{smallvec, SmallVec};
 
 /// Input event
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Serialize)]
 pub enum Event {
+    /// Wildcard.
+    /// Useful if you want to filter out some keys.
+    Any,
     /// Key sequence
     // TODO Validate 2 ?
     KeySeq(SmallVec<[KeyEvent; 2]>),
@@ -26,13 +30,17 @@ impl Event {
     }
 }
 
-impl Into<Event> for KeyEvent {
-    fn into(self) -> Event {
-        Event::KeySeq(smallvec![self])
+impl From<KeyEvent> for Event {
+    fn from(k: KeyEvent) -> Event {
+        Event::KeySeq(smallvec![k])
     }
 }
 
-impl TrieKey for Event {}
+impl TrieKey for Event {
+    fn encode_bytes(&self) -> Vec<u8> {
+        bincode::serialize(self).unwrap()
+    }
+}
 
 /// Event handler
 pub enum EventHandler {
@@ -44,9 +52,9 @@ pub enum EventHandler {
      * TODO Macro(), */
 }
 
-impl Into<EventHandler> for Cmd {
-    fn into(self) -> EventHandler {
-        EventHandler::Simple(self)
+impl From<Cmd> for EventHandler {
+    fn from(c: Cmd) -> EventHandler {
+        EventHandler::Simple(c)
     }
 }
 

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -121,3 +121,21 @@ pub trait ConditionalEventHandler: Send + Sync {
         ctx: &EventContext,
     ) -> Option<Cmd>;
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{KeyEvent, Cmd};
+    use super::{Event, EventHandler};
+    use radix_trie::Trie;
+    use smallvec::smallvec;
+
+    #[test]
+    fn encode() {
+        let mut trie = Trie::new();
+        let evt = Event::KeySeq(smallvec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]);
+        trie.insert(evt, EventHandler::from(Cmd::Noop));
+        let prefix = Event::from(KeyEvent::ctrl('X'));
+        let subtrie = trie.subtrie(&prefix);
+        assert!(subtrie.is_some())
+    }
+}

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -277,6 +277,14 @@ impl<'out, 'prompt, H: Helper> Refresher for State<'out, 'prompt, H> {
     fn has_hint(&self) -> bool {
         self.hint.is_some()
     }
+
+    fn line(&self) -> &str {
+        self.line.as_str()
+    }
+
+    fn pos(&self) -> usize {
+        self.line.pos()
+    }
 }
 
 impl<'out, 'prompt, H: Helper> fmt::Debug for State<'out, 'prompt, H> {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -473,7 +473,7 @@ impl InputState {
     ) -> Option<Cmd> {
         let bindings = self.custom_bindings.read().unwrap();
         let evt = key.into();
-        let handler = bindings.get(&evt); // TODO key sequence and subtrie
+        let handler = bindings.get(&evt).or_else(|| bindings.get(&Event::Any)); // TODO key sequence and subtrie
         if let Some(handler) = handler {
             match handler {
                 EventHandler::Simple(cmd) => Some(cmd.clone()),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -107,65 +107,6 @@ impl From<char> for KeyEvent {
     }
 }
 
-const BASE: u32 = 0x0010ffff + 1;
-const BASE_CONTROL: u32 = 0x02000000;
-const BASE_META: u32 = 0x04000000;
-const BASE_SHIFT: u32 = 0x01000000;
-const ESCAPE: u32 = 27;
-const PAGE_UP: u32 = BASE + 1;
-const PAGE_DOWN: u32 = PAGE_UP + 1;
-const DOWN: u32 = PAGE_DOWN + 1;
-const UP: u32 = DOWN + 1;
-const LEFT: u32 = UP + 1;
-const RIGHT: u32 = LEFT + 1;
-const HOME: u32 = RIGHT + 1;
-const END: u32 = HOME + 1;
-const DELETE: u32 = END + 1;
-const INSERT: u32 = DELETE + 1;
-//const F1: u32 = INSERT + 1;
-pub(crate) const MOUSE: u32 = /*F24 + 1*/ INSERT + 25;
-const PASTE_START: u32 = MOUSE + 1;
-const PASTE_FINISH: u32 = PASTE_START + 1;
-pub(crate) const ANY: u32 = PASTE_FINISH + 1;
-
-impl KeyEvent {
-    pub(crate) fn encode(&self) -> u32 {
-        let mut u = match self.0 {
-            KeyCode::UnknownEscSeq => 0,
-            KeyCode::Backspace => u32::from('H') | BASE_CONTROL,
-            KeyCode::BackTab => u32::from('I') | BASE_CONTROL | BASE_SHIFT,
-            KeyCode::BracketedPasteStart => PASTE_START,
-            KeyCode::BracketedPasteEnd => PASTE_FINISH,
-            KeyCode::Char(c) => u32::from(c),
-            KeyCode::Delete => DELETE,
-            KeyCode::Down => DOWN,
-            KeyCode::End => END,
-            KeyCode::Enter => u32::from('M') | BASE_CONTROL,
-            KeyCode::F(i) => INSERT + i as u32,
-            KeyCode::Esc => ESCAPE,
-            KeyCode::Home => HOME,
-            KeyCode::Insert => INSERT,
-            KeyCode::Left => LEFT,
-            KeyCode::Null => 0,
-            KeyCode::PageDown => PAGE_DOWN,
-            KeyCode::PageUp => PAGE_UP,
-            KeyCode::Right => RIGHT,
-            KeyCode::Tab => u32::from('I') | BASE_CONTROL,
-            KeyCode::Up => UP,
-        };
-        if self.1.contains(Modifiers::CTRL) {
-            u |= BASE_CONTROL;
-        }
-        if self.1.contains(Modifiers::ALT) {
-            u |= BASE_META;
-        }
-        if self.1.contains(Modifiers::SHIFT) {
-            u |= BASE_SHIFT;
-        }
-        u
-    }
-}
-
 /// Input key pressed
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -154,13 +154,13 @@ impl KeyEvent {
             KeyCode::Up => UP,
         };
         if self.1.contains(Modifiers::CTRL) {
-            u = u | BASE_CONTROL;
+            u |= BASE_CONTROL;
         }
         if self.1.contains(Modifiers::ALT) {
-            u = u | BASE_META;
+            u |= BASE_META;
         }
         if self.1.contains(Modifiers::SHIFT) {
-            u = u | BASE_SHIFT;
+            u |= BASE_SHIFT;
         }
         u
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -188,6 +188,11 @@ mod tests {
     }
 
     #[test]
+    fn from() {
+        assert_eq!(E(K::Tab, M::NONE), E::from('\t'));
+    }
+
+    #[test]
     fn normalize() {
         assert_eq!(E::ctrl('A'), E::normalize(E(K::Char('\x01'), M::NONE)));
         assert_eq!(E::ctrl('A'), E::normalize(E::ctrl('a')));

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,7 +1,8 @@
 //! Key constants
+use serde::Serialize;
 
 /// Input key pressed and modifiers
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct KeyEvent(pub KeyCode, pub Modifiers);
 
 impl KeyEvent {
@@ -108,7 +109,7 @@ impl From<char> for KeyEvent {
 }
 
 /// Input key pressed
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[non_exhaustive]
 pub enum KeyCode {
     /// Unsupported escape sequence (on unix platform)
@@ -157,6 +158,7 @@ pub enum KeyCode {
 
 bitflags::bitflags! {
     /// The set of modifier keys that were triggered along with a key press.
+    #[derive(Serialize)]
     pub struct Modifiers: u8 {
         /// Control modifier
         const CTRL  = 1<<3;

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,8 +1,7 @@
 //! Key constants
-use serde::Serialize;
 
 /// Input key pressed and modifiers
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct KeyEvent(pub KeyCode, pub Modifiers);
 
 impl KeyEvent {
@@ -108,8 +107,67 @@ impl From<char> for KeyEvent {
     }
 }
 
+const BASE: u32 = 0x0010ffff + 1;
+const BASE_CONTROL: u32 = 0x02000000;
+const BASE_META: u32 = 0x04000000;
+const BASE_SHIFT: u32 = 0x01000000;
+const ESCAPE: u32 = 27;
+const PAGE_UP: u32 = BASE + 1;
+const PAGE_DOWN: u32 = PAGE_UP + 1;
+const DOWN: u32 = PAGE_DOWN + 1;
+const UP: u32 = DOWN + 1;
+const LEFT: u32 = UP + 1;
+const RIGHT: u32 = LEFT + 1;
+const HOME: u32 = RIGHT + 1;
+const END: u32 = HOME + 1;
+const DELETE: u32 = END + 1;
+const INSERT: u32 = DELETE + 1;
+//const F1: u32 = INSERT + 1;
+pub(crate) const MOUSE: u32 = /*F24 + 1*/ INSERT + 25;
+const PASTE_START: u32 = MOUSE + 1;
+const PASTE_FINISH: u32 = PASTE_START + 1;
+pub(crate) const ANY: u32 = PASTE_FINISH + 1;
+
+impl KeyEvent {
+    pub(crate) fn encode(&self) -> u32 {
+        let mut u = match self.0 {
+            KeyCode::UnknownEscSeq => 0,
+            KeyCode::Backspace => u32::from('H') | BASE_CONTROL,
+            KeyCode::BackTab => u32::from('I') | BASE_CONTROL | BASE_SHIFT,
+            KeyCode::BracketedPasteStart => PASTE_START,
+            KeyCode::BracketedPasteEnd => PASTE_FINISH,
+            KeyCode::Char(c) => u32::from(c),
+            KeyCode::Delete => DELETE,
+            KeyCode::Down => DOWN,
+            KeyCode::End => END,
+            KeyCode::Enter => u32::from('M') | BASE_CONTROL,
+            KeyCode::F(i) => INSERT + i as u32,
+            KeyCode::Esc => ESCAPE,
+            KeyCode::Home => HOME,
+            KeyCode::Insert => INSERT,
+            KeyCode::Left => LEFT,
+            KeyCode::Null => 0,
+            KeyCode::PageDown => PAGE_DOWN,
+            KeyCode::PageUp => PAGE_UP,
+            KeyCode::Right => RIGHT,
+            KeyCode::Tab => u32::from('I') | BASE_CONTROL,
+            KeyCode::Up => UP,
+        };
+        if self.1.contains(Modifiers::CTRL) {
+            u = u | BASE_CONTROL;
+        }
+        if self.1.contains(Modifiers::ALT) {
+            u = u | BASE_META;
+        }
+        if self.1.contains(Modifiers::SHIFT) {
+            u = u | BASE_SHIFT;
+        }
+        u
+    }
+}
+
 /// Input key pressed
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum KeyCode {
     /// Unsupported escape sequence (on unix platform)
@@ -158,7 +216,6 @@ pub enum KeyCode {
 
 bitflags::bitflags! {
     /// The set of modifier keys that were triggered along with a key press.
-    #[derive(Serialize)]
     pub struct Modifiers: u8 {
         /// Control modifier
         const CTRL  = 1<<3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! ```
 #![warn(missing_docs)]
 
+mod binding;
 mod command;
 pub mod completion;
 pub mod config;
@@ -34,7 +35,6 @@ mod tty;
 mod undo;
 pub mod validate;
 
-use std::collections::HashMap;
 use std::fmt;
 use std::io::{self, Write};
 use std::path::Path;
@@ -42,10 +42,12 @@ use std::result;
 use std::sync::{Arc, Mutex, RwLock};
 
 use log::debug;
+use radix_trie::Trie;
 use unicode_width::UnicodeWidthStr;
 
 use crate::tty::{RawMode, Renderer, Term, Terminal};
 
+pub use crate::binding::{ConditionalEventHandler, Event, EventContext, EventHandler};
 use crate::completion::{longest_common_prefix, Candidate, Completer};
 pub use crate::config::{
     ColorMode, CompletionType, Config, EditMode, HistoryDuplicates, OutputStreamType,
@@ -54,7 +56,7 @@ use crate::edit::State;
 use crate::highlight::Highlighter;
 use crate::hint::Hinter;
 use crate::history::{Direction, History};
-pub use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
+pub use crate::keymap::{Anchor, At, CharSearch, Cmd, InputMode, Movement, RepeatCount, Word};
 use crate::keymap::{InputState, Refresher};
 pub use crate::keys::{KeyCode, KeyEvent, Modifiers};
 use crate::kill_ring::KillRing;
@@ -613,7 +615,7 @@ pub struct Editor<H: Helper> {
     helper: Option<H>,
     kill_ring: Arc<Mutex<KillRing>>,
     config: Config,
-    custom_bindings: Arc<RwLock<HashMap<KeyEvent, Cmd>>>,
+    custom_bindings: Arc<RwLock<Trie<Event, EventHandler>>>,
 }
 
 #[allow(clippy::new_without_default)]
@@ -638,7 +640,7 @@ impl<H: Helper> Editor<H> {
             helper: None,
             kill_ring: Arc::new(Mutex::new(KillRing::new(60))),
             config,
-            custom_bindings: Arc::new(RwLock::new(HashMap::new())),
+            custom_bindings: Arc::new(RwLock::new(Trie::new())),
         }
     }
 
@@ -733,18 +735,22 @@ impl<H: Helper> Editor<H> {
     }
 
     /// Bind a sequence to a command.
-    pub fn bind_sequence(&mut self, key_seq: KeyEvent, cmd: Cmd) -> Option<Cmd> {
+    pub fn bind_sequence<E: Into<Event>, R: Into<EventHandler>>(
+        &mut self,
+        key_seq: E,
+        handler: R,
+    ) -> Option<EventHandler> {
         if let Ok(mut bindings) = self.custom_bindings.write() {
-            bindings.insert(KeyEvent::normalize(key_seq), cmd)
+            bindings.insert(Event::normalize(key_seq.into()), handler.into())
         } else {
             None
         }
     }
 
     /// Remove a binding for the given sequence.
-    pub fn unbind_sequence(&mut self, key_seq: KeyEvent) -> Option<Cmd> {
+    pub fn unbind_sequence<E: Into<Event>>(&mut self, key_seq: E) -> Option<EventHandler> {
         if let Ok(mut bindings) = self.custom_bindings.write() {
-            bindings.remove(&KeyEvent::normalize(key_seq))
+            bindings.remove(&Event::normalize(key_seq.into()))
         } else {
             None
         }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::vec::IntoIter;
+
+use radix_trie::Trie;
 
 use crate::completion::Completer;
 use crate::config::{Config, EditMode};
@@ -58,7 +59,7 @@ fn complete_line() {
     let helper = Some(SimpleCompleter);
     let mut s = init_state(&mut out, "rus", 3, helper.as_ref(), &history);
     let config = Config::default();
-    let mut input_state = InputState::new(&config, Arc::new(RwLock::new(HashMap::new())));
+    let mut input_state = InputState::new(&config, Arc::new(RwLock::new(Trie::new())));
     let keys = vec![E::ENTER];
     let mut rdr: IntoIter<KeyEvent> = keys.into_iter();
     let cmd = super::complete_line(&mut rdr, &mut s, &mut input_state, &Config::default()).unwrap();

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -116,9 +116,7 @@ impl RawReader for ConsoleRawReader {
         let mut surrogate = 0;
         loop {
             // TODO GetNumberOfConsoleInputEvents
-            check(unsafe {
-                consoleapi::ReadConsoleInputW(self.handle, &mut rec, 1, &mut count)
-            })?;
+            check(unsafe { consoleapi::ReadConsoleInputW(self.handle, &mut rec, 1, &mut count) })?;
 
             if rec.EventType == wincon::WINDOW_BUFFER_SIZE_EVENT {
                 SIGWINCH.store(true, Ordering::SeqCst);
@@ -449,7 +447,9 @@ impl Renderer for ConsoleRenderer {
     }
 
     fn sigwinch(&self) -> bool {
-        SIGWINCH.compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst).unwrap_or(false)
+        SIGWINCH
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .unwrap_or(false)
     }
 
     /// Try to get the number of columns in the current terminal,


### PR DESCRIPTION
Introduce `ConditionalEventHandler` and `EventContext`.
You should be able to return different `Cmd` depending on input state.

Fixme
- [X] key sequence 

Replace #293

- [X] [Conditional Bind Sequences](https://github.com/kkawakam/rustyline/issues/269) : original issues
- [X] [Conditional Bind Sequences](https://github.com/kkawakam/rustyline/pull/293) : incomplete proposal
- [ ] [Extend Meta-F,Alt+Right feature for hint partial completion](https://github.com/kkawakam/rustyline/pull/430) ?
- [X] [Use Ctrl-E for hint completion](https://github.com/kkawakam/rustyline/pull/407)
- [X] [Insert tab when the cursor is ontop a whitespace character](https://github.com/kkawakam/rustyline/issues/488)
- [X] [Prompt for numeric entry only](https://github.com/kkawakam/rustyline/issues/436): `Event::Any`