### PR TITLE
Support Partial Completion

### DIFF
--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -50,7 +50,22 @@ impl ConditionalEventHandler for CompleteHintHandler {
             if *k == KeyEvent::ctrl('E') {
                 Some(Cmd::CompleteHint)
             } else if *k == KeyEvent::alt('f') && ctx.line().len() == ctx.pos() {
-                Some(Cmd::CompleteHint) // TODO give access to hint
+                let text = ctx.hint_text()?;
+                let mut start = 0;
+                if let Some(first) = text.chars().next() {
+                    if !first.is_alphanumeric() {
+                        start = text.find(|c: char| c.is_alphanumeric()).unwrap_or_default();
+                    }
+                }
+        
+                let text = text
+                    .chars()
+                    .enumerate()
+                    .take_while(|(i, c)| *i <= start || c.is_alphanumeric())
+                    .map(|(_, c)| c)
+                    .collect::<String>();
+
+                Some(Cmd::Insert(1, text))
             } else {
                 None
             }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -168,6 +168,11 @@ impl<'r> EventContext<'r> {
         self.wrt.has_hint()
     }
 
+    /// Returns the hint text that is shown after the current cursor position.
+    pub fn hint_text(&self) -> Option<&str> {
+        self.wrt.hint_text()
+    }
+
     /// currently edited line
     pub fn line(&self) -> &str {
         self.wrt.line()

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -278,6 +278,10 @@ impl<'out, 'prompt, H: Helper> Refresher for State<'out, 'prompt, H> {
         self.hint.is_some()
     }
 
+    fn hint_text(&self) -> Option<&str> {
+        self.hint.as_ref().map(|hint| hint.completion()).flatten()
+    }
+
     fn line(&self) -> &str {
         self.line.as_str()
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -376,6 +376,8 @@ pub trait Refresher {
     fn is_cursor_at_end(&self) -> bool;
     /// Returns `true` if there is a hint displayed.
     fn has_hint(&self) -> bool;
+    /// Returns the hint text that is shown after the current cursor position.
+    fn hint_text(&self) -> Option<&str>;
     /// currently edited line
     fn line(&self) -> &str;
     /// Current cursor position (byte position)


### PR DESCRIPTION
This commit adds the ability to complete the current line with the word of the hint. When the cursor is at the end of the current line and CTRL + right arrow has been pressed, the next word of the hint will be added to the editor's line.

Closes #413 