### PR TITLE
Support ESC ESC sequences, and bind alt+left/alt+right

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -617,7 +617,10 @@ impl InputState {
             }
             E(K::Char('<'), M::ALT) => Cmd::BeginningOfHistory,
             E(K::Char('>'), M::ALT) => Cmd::EndOfHistory,
-            E(K::Char('B'), M::ALT) | E(K::Char('b'), M::ALT) | E(K::Left, M::CTRL) => {
+            E(K::Char('B'), M::ALT)
+            | E(K::Char('b'), M::ALT)
+            | E(K::Left, M::CTRL)
+            | E(K::Left, M::ALT) => {
                 if positive {
                     Cmd::Move(Movement::BackwardWord(n, Word::Emacs))
                 } else {
@@ -632,7 +635,10 @@ impl InputState {
                     Cmd::Kill(Movement::BackwardWord(n, Word::Emacs))
                 }
             }
-            E(K::Char('F'), M::ALT) | E(K::Char('f'), M::ALT) | E(K::Right, M::CTRL) => {
+            E(K::Char('F'), M::ALT)
+            | E(K::Char('f'), M::ALT)
+            | E(K::Right, M::CTRL)
+            | E(K::Right, M::ALT) => {
                 if positive {
                     Cmd::Move(Movement::ForwardWord(n, At::AfterEnd, Word::Emacs))
                 } else {

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -200,6 +200,11 @@ impl PosixRawReader {
     /// Handle \E <seq1> sequences
     // https://invisible-island.net/xterm/xterm-function-keys.html
     fn escape_sequence(&mut self) -> Result<KeyEvent> {
+        self._do_escape_sequence(true)
+    }
+
+    /// Don't call directly, call `PosixRawReader::escape_sequence` instead
+    fn _do_escape_sequence(&mut self, allow_recurse: bool) -> Result<KeyEvent> {
         // Read the next byte representing the escape sequence.
         let seq1 = self.next_char()?;
         if seq1 == '[' {
@@ -210,14 +215,40 @@ impl PosixRawReader {
             // \EO sequences. (SS3)
             self.escape_o()
         } else if seq1 == '\x1b' {
-            // \E\E
-            // TODO poll ...
+            // \E\E — used by rxvt, iTerm (under default config), etc.
+            // ```
             // \E\E[A => Alt-Up
             // \E\E[B => Alt-Down
             // \E\E[C => Alt-Right
             // \E\E[D => Alt-Left
-            // ...
-            Ok(E::ESC)
+            // ```
+            //
+            // In general this more or less works just adding ALT to an existing
+            // key, but has a wrinkle in that `ESC ESC` without anything
+            // following should be interpreted as the the escape key.
+            //
+            // We hanlde this by polling to see if there's anything coming
+            // within our timeout, and if so, recursing once, but adding alt to
+            // what we read.
+            if !allow_recurse {
+                return Ok(E::ESC);
+            }
+            let timeout = if self.timeout_ms < 0 {
+                100
+            } else {
+                self.timeout_ms
+            };
+            match self.poll(timeout) {
+                // Ignore poll errors, it's very likely we'll pick them up on
+                // the next read anyway.
+                Ok(0) | Err(_) => Ok(E::ESC),
+                Ok(n) => {
+                    debug_assert!(n > 0, "{}", n);
+                    // recurse, and add the alt modifier.
+                    let E(k, m) = self._do_escape_sequence(false)?;
+                    Ok(E(k, m | M::ALT))
+                }
+            }
         } else {
             Ok(E::alt(seq1))
         }


### PR DESCRIPTION
This has a few more of the sequences from #333. (Note that while #435 indicated this was the only type of missing sequence, I think there are a few more still).

Anyway, in particular, this style of sequence is emitted by iTerm2 (at least, in, err, the configuration I use, which I *think* is default), and so not having support for it was a little annoying. It's also used by rxvt-family terminals, and while I've tested this in them, I don't regularly use them, so I don't care as much.

Using recursion the way this does is a bit hacky way, but in practice it works on everything I've tried. Also, this follows the actual "logic" these terminals use for the meta/alt key, so it makes a kind of sense.

---

The other thing it implements is ALT+Left and ALT+Right by-word movement. This is pretty ubiquitous (emacs, bash, every macos textbox, ...), and was the main reason I wanted to make ESC ESC sequences work, so I added it too.