### PR TITLE
Support multiline inputs in non TTY contexts

### DIFF
--- a/examples/input_multiline.rs
+++ b/examples/input_multiline.rs
@@ -1,0 +1,29 @@
+use rustyline::validate::{
+    MatchingBracketValidator, ValidationContext, ValidationResult, Validator,
+};
+use rustyline::{Editor, Result};
+use rustyline_derive::{Completer, Helper, Highlighter, Hinter};
+
+#[derive(Completer, Helper, Highlighter, Hinter)]
+struct InputValidator {
+    brackets: MatchingBracketValidator,
+}
+
+impl Validator for InputValidator {
+    fn validate(&self, ctx: &mut ValidationContext) -> Result<ValidationResult> {
+        self.brackets.validate(ctx)
+    }
+}
+
+fn main() -> Result<()> {
+    let h = InputValidator {
+        brackets: MatchingBracketValidator::new(),
+    };
+    let mut rl = Editor::new();
+    rl.set_helper(Some(h));
+
+    let input = rl.readline("> ")?;
+    println!("Input: {}", input);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,17 +644,7 @@ fn readline_direct(
                 match validator.as_ref() {
                     None => return Ok(input),
                     Some(v) => {
-                        struct SimpleInvoke<'a> {
-                            s: &'a str,
-                        }
-
-                        impl<'a> keymap::Invoke for SimpleInvoke<'a> {
-                            fn input(&self) -> &str {
-                                self.s
-                            }
-                        }
-
-                        let mut ctx = SimpleInvoke { s: &input };
+                        let mut ctx = input.as_str();
                         let mut ctx = validate::ValidationContext::new(&mut ctx);
 
                         match v.validate(&mut ctx)? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -780,13 +780,13 @@ impl<H: Helper> Editor<H> {
             stdout.write_all(prompt.as_bytes())?;
             stdout.flush()?;
 
-            readline_direct(io::stdin().lock(), io::stdout(), &self.helper)
+            readline_direct(io::stdin().lock(), io::stderr(), &self.helper)
         } else if self.term.is_stdin_tty() {
             readline_raw(prompt, initial, self)
         } else {
             debug!(target: "rustyline", "stdin is not a tty");
             // Not a tty: read from file / pipe.
-            readline_direct(io::stdin().lock(), io::stdout(), &self.helper)
+            readline_direct(io::stdin().lock(), io::stderr(), &self.helper)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -642,7 +642,6 @@ fn readline_direct(validator: &Option<impl Validator>) -> Result<String> {
                             validate::ValidationResult::Incomplete => {}
                             validate::ValidationResult::Invalid(_msg) => {
                                 // TODO: present the msg back to stdout?
-                                break;
                             }
                             validate::ValidationResult::Valid(_msg) => {
                                 // TODO: present the msg back to stdout?

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -12,7 +12,7 @@ use crate::keymap::{Cmd, InputState};
 use crate::keys::{KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
 use crate::tty::Sink;
 use crate::validate::Validator;
-use crate::{apply_backspace_direct, Context, Editor, Helper, Result};
+use crate::{apply_backspace_direct, readline_direct, Context, Editor, Helper, Result};
 
 mod common;
 mod emacs;
@@ -151,4 +151,22 @@ fn test_apply_backspace_direct() {
         &apply_backspace_direct("Hel\u{0008}\u{0008}el\u{0008}llo ☹\u{0008}☺"),
         "Hello ☺"
     );
+}
+
+#[test]
+fn test_readline_direct() {
+    use std::io::Cursor;
+
+    let mut write_buf = vec![];
+    let output = readline_direct(
+        Cursor::new("([)\n\u{0008}\u{0008}\n])".as_bytes()),
+        Cursor::new(&mut write_buf),
+        &Some(crate::validate::MatchingBracketValidator::new()),
+    );
+
+    assert_eq!(
+        &write_buf,
+        b"Mismatched brackets: '[' is not properly closed"
+    );
+    assert_eq!(&output.unwrap(), "([\n])");
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -12,7 +12,7 @@ use crate::keymap::{Cmd, InputState};
 use crate::keys::{KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
 use crate::tty::Sink;
 use crate::validate::Validator;
-use crate::{Context, Editor, Helper, Result};
+use crate::{apply_backspace_direct, Context, Editor, Helper, Result};
 
 mod common;
 mod emacs;
@@ -143,4 +143,12 @@ fn test_send() {
 fn test_sync() {
     fn assert_sync<T: Sync>() {}
     assert_sync::<Editor<()>>();
+}
+
+#[test]
+fn test_apply_backspace_direct() {
+    assert_eq!(
+        &apply_backspace_direct("Hel\u{0008}\u{0008}el\u{0008}llo ☹\u{0008}☺"),
+        "Hello ☺"
+    );
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -159,7 +159,7 @@ fn test_readline_direct() {
 
     let mut write_buf = vec![];
     let output = readline_direct(
-        Cursor::new("([)\n\u{0008}\n])".as_bytes()),
+        Cursor::new("([)\n\u{0008}\n\n\r\n])".as_bytes()),
         Cursor::new(&mut write_buf),
         &Some(crate::validate::MatchingBracketValidator::new()),
     );
@@ -168,5 +168,5 @@ fn test_readline_direct() {
         &write_buf,
         b"Mismatched brackets: '[' is not properly closed"
     );
-    assert_eq!(&output.unwrap(), "([\n])");
+    assert_eq!(&output.unwrap(), "([\n\n\r\n])");
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -159,7 +159,7 @@ fn test_readline_direct() {
 
     let mut write_buf = vec![];
     let output = readline_direct(
-        Cursor::new("([)\n\u{0008}\u{0008}\n])".as_bytes()),
+        Cursor::new("([)\n\u{0008}\n])".as_bytes()),
         Cursor::new(&mut write_buf),
         &Some(crate::validate::MatchingBracketValidator::new()),
     );


### PR DESCRIPTION
This PR add supports for multiline inputs (via the `Validator` API) for the case where stdin isn't a TTY (or is an unsupported terminal).

I have added a new example `input_multiline` to make quickly showcase how this works.

This lets us do:
```
echo -e "(\n\n)" | cargo run --example input_multiline
```

And have readline correctly read this as a single multiline input instead of 3 separate inputs (if it was called in a loop).
Even in the single line case, there was a difference between the TTY and the non-TTY versions of readline: the non-TTY version would keep the trailing newline character.

My main motivation for this change is to be able to easily test a REPL made using `rustyline` by piping my inputs in without having to mock the TTY part of it. It also make `rustyline` more consistent this way.