### PR TITLE
Implement CTRL-V support on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ skim = { version = "0.9", optional = true }
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "minwindef", "processenv", "winbase", "wincon", "winuser"] }
 scopeguard = "1.1"
+clipboard-win = "4.1.0"
+error-code = "2.2.0"
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,9 @@ pub enum ReadlineError {
     /// Like Utf8Error on unix
     #[cfg(windows)]
     Decode(char::DecodeUtf16Error),
+    /// Something went wrong calling a Windows API
+    #[cfg(windows)]
+    SystemError(error_code::SystemError),
 }
 
 impl fmt::Display for ReadlineError {
@@ -47,6 +50,8 @@ impl fmt::Display for ReadlineError {
             ReadlineError::WindowResize => write!(f, "WindowResize"),
             #[cfg(windows)]
             ReadlineError::Decode(ref err) => err.fmt(f),
+            #[cfg(windows)]
+            ReadlineError::SystemError(ref err) => err.fmt(f),
         }
     }
 }
@@ -76,5 +81,12 @@ impl From<nix::Error> for ReadlineError {
 impl From<char::DecodeUtf16Error> for ReadlineError {
     fn from(err: char::DecodeUtf16Error) -> Self {
         ReadlineError::Decode(err)
+    }
+}
+
+#[cfg(windows)]
+impl From<error_code::SystemError> for ReadlineError {
+    fn from(err: error_code::SystemError) -> Self {
+        ReadlineError::SystemError(err)
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -28,6 +28,9 @@ pub enum Cmd {
     CapitalizeWord,
     /// clear-screen
     ClearScreen,
+    /// Paste from the clipboard
+    #[cfg(windows)]
+    PasteFromClipboard,
     /// complete
     Complete,
     /// complete-backward
@@ -1046,9 +1049,13 @@ impl InputState {
                 } else {
                     Cmd::Kill(Movement::EndOfLine)
                 }
-            },
-            E(K::Char('Q'), M::CTRL) | // most terminals override Ctrl+Q to resume execution
+            }
+            // most terminals override Ctrl+Q to resume execution
+            E(K::Char('Q'), M::CTRL) => Cmd::QuotedInsert,
+            #[cfg(not(windows))]
             E(K::Char('V'), M::CTRL) => Cmd::QuotedInsert,
+            #[cfg(windows)]
+            E(K::Char('V'), M::CTRL) => Cmd::PasteFromClipboard,
             E(K::Char('W'), M::CTRL) => {
                 if positive {
                     Cmd::Kill(Movement::BackwardWord(n, Word::Big))

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1034,10 +1034,9 @@ impl InputState {
                     Cmd::Move(Movement::BackwardChar(n))
                 }
             }
-            E(K::Char('J'), M::CTRL) |
-            E::ENTER => {
-                Cmd::AcceptOrInsertLine { accept_in_the_middle: true }
-            }
+            E(K::Char('J'), M::CTRL) | E::ENTER => Cmd::AcceptOrInsertLine {
+                accept_in_the_middle: true,
+            },
             E(K::Down, M::NONE) => Cmd::LineDownOrNextHistory(1),
             E(K::Up, M::NONE) => Cmd::LineUpOrPreviousHistory(1),
             E(K::Char('R'), M::CTRL) => Cmd::ReverseSearchHistory,
@@ -1076,10 +1075,10 @@ impl InputState {
             E(K::BracketedPasteStart, M::NONE) => {
                 let paste = rdr.read_pasted_text()?;
                 Cmd::Insert(1, paste)
-            },
-            _ => {
-                self.custom_seq_binding(rdr, wrt, &mut evt, n, positive)?.unwrap_or(Cmd::Unknown)
-            },
+            }
+            _ => self
+                .custom_seq_binding(rdr, wrt, &mut evt, n, positive)?
+                .unwrap_or(Cmd::Unknown),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,6 +519,13 @@ fn readline_edit<H: Helper>(
             continue;
         }
 
+        #[cfg(windows)]
+        if cmd == Cmd::PasteFromClipboard {
+            use crate::tty::RawReader;
+            let clipboard = rdr.read_pasted_text()?;
+            s.edit_yank(&input_state, &clipboard[..], Anchor::Before, 1)?;
+        }
+
         // Tiny test quirk
         #[cfg(test)]
         if matches!(

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -209,7 +209,7 @@ impl RawReader for ConsoleRawReader {
     }
 
     fn read_pasted_text(&mut self) -> Result<String> {
-        unimplemented!()
+        Ok(clipboard_win::get_clipboard_string()?)
     }
 }
 


### PR DESCRIPTION
This commit implements CTRL-V support on Windows. See #519 where this issue was raised. 

## Implementation notes

On Windows, we have 3 key changes:

* There are new Windows-only dependencies on the `clipboard-win` and `error-code` crates.
* tty/windows.rs implements `read_pasted_text` by calling the clipboard-win crate. Errors are mapped to a new Windows-only error variant.
* When CTRL-V is pressed, `QuotedInsert` will perform a yank using the text from the clipboard (inserting the text and moving the cursor).

## Testing

I made a new package:

```
cargo new testpaste
cd testpaste
cargo add rustyline
# edit Cargo.toml; make rustyline use my git fork
# edit src/lib.rs to be the contents of https://github.com/kkawakam/rustyline#example
```

As noted in #519, running this example in Windows Terminal works (CTRL-V pastes text from the system clipboard) while using Powershell or cmd.exe does not work (CTRL-V does nothing, while rightclick pastes text from the system clipboard).

After this change, CTRL-V works in all 3 shells. Mouse rightclick continues to work.

## Other

See #520 for why I reverted the change to use fd-lock.