### PR TITLE
Enable 'std' for winapi, fixes #520

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ utf8parse = "0.2"
 skim = { version = "0.9", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["consoleapi", "handleapi", "minwindef", "processenv", "winbase", "wincon", "winuser"] }
+winapi = { version = "0.3", features = ["consoleapi", "handleapi", "minwindef", "processenv", "std", "winbase", "wincon", "winuser"] }
 scopeguard = "1.1"
 
 [dev-dependencies]


### PR DESCRIPTION
See #520 for more details.