### PR TITLE
Remove need for error-code direct usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,7 @@ skim = { version = "0.9", optional = true }
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "minwindef", "processenv", "std", "winbase", "wincon", "winuser"] }
 scopeguard = "1.1"
-clipboard-win = "4.1.0"
-error-code = "2.2.0"
+clipboard-win = "4.2.1"
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,7 @@ pub enum ReadlineError {
     Decode(char::DecodeUtf16Error),
     /// Something went wrong calling a Windows API
     #[cfg(windows)]
-    SystemError(error_code::SystemError),
+    SystemError(clipboard_win::SystemError),
 }
 
 impl fmt::Display for ReadlineError {
@@ -85,8 +85,8 @@ impl From<char::DecodeUtf16Error> for ReadlineError {
 }
 
 #[cfg(windows)]
-impl From<error_code::SystemError> for ReadlineError {
-    fn from(err: error_code::SystemError) -> Self {
+impl From<clipboard_win::SystemError> for ReadlineError {
+    fn from(err: clipboard_win::SystemError) -> Self {
         ReadlineError::SystemError(err)
     }
 }


### PR DESCRIPTION
As follow up to https://github.com/kkawakam/rustyline/pull/521#issuecomment-844457084 I removed need for user to directly pull `error-code`