### PR TITLE
Allow ctrl+{n,p} to change lines in emacs mode

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -595,8 +595,10 @@ impl InputState {
                 }
             }
             E(K::Char('L'), M::CTRL) => Cmd::ClearScreen,
-            E(K::Char('N'), M::CTRL) => Cmd::NextHistory,
-            E(K::Char('P'), M::CTRL) => Cmd::PreviousHistory,
+            E(K::Char('N'), M::CTRL_SHIFT) => Cmd::NextHistory,
+            E(K::Char('P'), M::CTRL_SHIFT) => Cmd::PreviousHistory,
+            E(K::Char('N'), M::CTRL) => Cmd::LineDownOrNextHistory(1),
+            E(K::Char('P'), M::CTRL) => Cmd::LineUpOrPreviousHistory(1),
             E(K::Char('X'), M::CTRL) => {
                 if let Some(cmd) = self.custom_seq_binding(rdr, wrt, &mut evt, n, positive)? {
                     cmd


### PR DESCRIPTION
This switches ctrl+n and ctrl+p from exclusively history navigation to
history-or-line navigation.

This is consistent with the behavior of everything else I've tried
including emacs, zsh, fish, and probably more. And it makes these
shortcuts equivalent to up and down arrow, which is the behavior I've
found in absolutely everything that supports them (including
applications with no notion of histroy, like text editors and macOS
input text boxes).

At least IMO, these being equivalent to arrow keys is the "obvious"
behavior for these keybindings.

Additionally, it adds ctrl+shift+n and ctrl+shift+p supporting the old
behavior, as [this comment][issue342c2] implies that maybe it would be
useful to have "only history". I haven't seen this in anything else, but
it seems harmless.

Fixes #343

[issue342c2]: https://github.com/kkawakam/rustyline/issues/343#issuecomment-621153806