### PR TITLE
Allowing displaying a prompt during incomplete validation

### DIFF
--- a/examples/input_validation.rs
+++ b/examples/input_validation.rs
@@ -12,7 +12,7 @@ impl Validator for InputValidator {
         let result = if !input.starts_with("SELECT") {
             Invalid(Some(" --< Expect: SELECT stmt".to_owned()))
         } else if !input.ends_with(';') {
-            Incomplete
+            Incomplete(None)
         } else {
             Valid(None)
         };

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -208,7 +208,11 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             let result = validator.validate(&mut ValidationContext::new(self))?;
             let corrected = self.changes.borrow_mut().end();
             match result {
-                ValidationResult::Incomplete => {}
+                ValidationResult::Incomplete(ref msg) => {
+                    if msg.is_some() {
+                        self.refresh_line_with_msg(msg.as_deref())?;
+                    }
+                }
                 ValidationResult::Valid(ref msg) => {
                     // Accept the line regardless of where the cursor is.
                     if corrected || self.has_hint() || msg.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,13 +656,16 @@ fn readline_direct(
                             validate::ValidationResult::Invalid(Some(msg)) => {
                                 writer.write_all(msg.as_bytes())?;
                             }
-                            validate::ValidationResult::Incomplete => {
+                            validate::ValidationResult::Incomplete(msg) => {
                                 // Add newline and keep on taking input
                                 if trailing_r {
                                     input.push('\r');
                                 }
                                 if trailing_n {
                                     input.push('\n');
+                                }
+                                if let Some(msg) = msg {
+                                    writer.write_all(msg.as_bytes())?;
                                 }
                             }
                             _ => {}

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -7,7 +7,7 @@ use crate::Result;
 #[non_exhaustive]
 pub enum ValidationResult {
     /// Incomplete input
-    Incomplete,
+    Incomplete(Option<String>),
     /// Validation fails with an optional error message. User must fix the
     /// input.
     Invalid(Option<String>),
@@ -23,7 +23,9 @@ impl ValidationResult {
     pub(crate) fn has_message(&self) -> bool {
         matches!(
             self,
-            ValidationResult::Valid(Some(_)) | ValidationResult::Invalid(Some(_))
+            ValidationResult::Valid(Some(_))
+                | ValidationResult::Invalid(Some(_))
+                | ValidationResult::Incomplete(Some(_))
         )
     }
 }
@@ -142,6 +144,6 @@ fn validate_brackets(input: &str) -> ValidationResult {
     if stack.is_empty() {
         ValidationResult::Valid(None)
     } else {
-        ValidationResult::Incomplete
+        ValidationResult::Incomplete(None)
     }
 }


### PR DESCRIPTION
This change will let consumers write a custom prompt on incomplete validation result, one of the use cases is allowing REPL to display an indicator that it's expecting more input before evaluating (like `node` multi line  displaying `... ` as pseudo-prompt).

Semver major due the breaking change.