### PR TITLE
Implement completion for executables in PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Cargo.lock
 
 # default history file
 history.txt
+
+testing/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ cfg-if = "1.0"
 # For file completion
 # https://rustsec.org/advisories/RUSTSEC-2020-0053.html
 dirs-next = { version = "2.0", optional = true }
+# For PATH files completion
+searchpath = "0.1.3"
 # For History
 fd-lock = "3.0.0"
 libc = "0.2"

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1,7 +1,6 @@
 //! Completion API
 use searchpath::search_path;
 use std::borrow::Cow::{self, Borrowed, Owned};
-use std::ffi::OsString;
 use std::fs;
 use std::path::{self, Path};
 
@@ -394,10 +393,10 @@ impl Completer for BinCompleter {
 
 fn should_complete_executable(path: &str, escaped_path: &str, line: &str, pos: usize) -> bool {
     if cfg!(windows) {
-        if line.starts_with(".\\") || line.starts_with("\\") {
+        if line.starts_with(".\\") || line.starts_with('\\') {
             return false;
         }
-    } else if line.starts_with("./") || line.starts_with("/") {
+    } else if line.starts_with("./") || line.starts_with('/') {
         return false;
     }
     if if let Some((idx, quote)) = find_unclosed_quote(&line[..pos]) {
@@ -575,10 +574,9 @@ fn bin_complete(path: &str, esc_char: Option<char>, break_chars: &[u8], quote: Q
 
     for file in search_path(
         path,
-        std::env::var_os(path_var).as_ref().map(OsString::as_os_str),
+        std::env::var_os(path_var).as_deref(),
         std::env::var_os(path_var_ext)
-            .as_ref()
-            .map(OsString::as_os_str),
+            .as_deref(),
     ) {
         entries.push(Pair {
             display: file.clone(),

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -397,10 +397,8 @@ fn should_complete_executable(path: &str, escaped_path: &str, line: &str, pos: u
         if line.starts_with(".\\") || line.starts_with("\\") {
             return false;
         }
-    } else {
-        if line.starts_with("./") || line.starts_with("/") {
-            return false;
-        }
+    } else if line.starts_with("./") || line.starts_with("/") {
+        return false;
     }
     if if let Some((idx, quote)) = find_unclosed_quote(&line[..pos]) {
         let start = idx + 1;


### PR DESCRIPTION
This is a work in progress pull request. The completion works good, tested on windows and linux. Now behaves like kinda like bash.
![Windows](https://user-images.githubusercontent.com/68228472/141595002-6b66778b-e103-4324-bf39-9666f2ef70c8.png)
![Linux](https://user-images.githubusercontent.com/68228472/141595115-2f45fe4e-d769-40db-8da4-469a8d089b3c.png)

Being able to configure if it should use PATH executable completion or not in the config builder would be nice to have, since I guess everyone doesn't want their readline to work like bash.

```rs
    let config = Config::builder()
        .complete_env_executables(true) // Or false
        .build();
```
I have been trying to implement this, but with no success without making the code incredibly messy.