### PR TITLE
Fix interrupted interactive search

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -222,7 +222,7 @@ pub fn execute<H: Helper>(
             // Move to end, in case cursor was in the middle of the
             // line, so that next thing application prints goes after
             // the input
-            s.edit_move_to_end()?;
+            s.move_cursor_to_end()?;
             return Err(error::ReadlineError::Interrupted);
         }
         _ => {

--- a/src/command.rs
+++ b/src/command.rs
@@ -222,7 +222,7 @@ pub fn execute<H: Helper>(
             // Move to end, in case cursor was in the middle of the
             // line, so that next thing application prints goes after
             // the input
-            s.edit_move_buffer_end()?;
+            s.edit_move_to_end()?;
             return Err(error::ReadlineError::Interrupted);
         }
         _ => {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -130,7 +130,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         Ok(())
     }
 
-    pub fn edit_move_to_end(&mut self) -> Result<()> {
+    pub fn move_cursor_to_end(&mut self) -> Result<()> {
         if self.layout.cursor == self.layout.end {
             return Ok(());
         }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -130,6 +130,15 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         Ok(())
     }
 
+    pub fn edit_move_to_end(&mut self) -> Result<()> {
+        if self.layout.cursor == self.layout.end {
+            return Ok(());
+        }
+        self.out.move_cursor(self.layout.cursor, self.layout.end)?;
+        self.layout.cursor = self.layout.end;
+        Ok(())
+    }
+
     pub fn move_cursor_at_leftmost(&mut self, rdr: &mut <Terminal as Term>::Reader) -> Result<()> {
         self.out.move_cursor_at_leftmost(rdr)
     }


### PR DESCRIPTION
We just want to move cursor to the end of actual line: either edited
line or interactive search line.
Fix #575