### PR TITLE
Declare minimum version of `log` crate required to successfully build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dirs-next = { version = "2.0", optional = true }
 # For History
 fd-lock = "3.0.0"
 libc = "0.2"
-log = "0.4"
+log = "0.4.5"
 unicode-width = "0.1"
 unicode-segmentation = "1.0"
 memchr = "2.0"


### PR DESCRIPTION
`log` < 0.4.5 fail to build with a macro resolution error.

When building `rustyline` with no default features and without any of its dev dependencies, the `-Zminimal-versions` flag to `cargo generate-lockfile` pulls in `log` 0.4.0 which fails to build.

Declare the minimum version of `log` as 0.4.5.

As an aside, would it be possible to make the `log` dependency optional? It looks like it is primarily used for debugging while developing `rustyline` itself.

## Reproduction

To reproduce, this diff to `Cargo.toml` is required to remove dev and optional dependencies that have higher `log` dependency constraints. These dependencies are not included when building `rustyline` with no default features on Linux and macOS.

```diff
diff --git a/Cargo.toml b/Cargo.toml
index da47a8c..deb3b8e 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ members = ["rustyline-derive"]
 [dependencies]
 bitflags = "1.3"
 cfg-if = "1.0"
-# For file completion
-# https://rustsec.org/advisories/RUSTSEC-2020-0053.html
-dirs-next = { version = "2.0", optional = true }
 # For History
 fd-lock = "3.0.0"
 libc = "0.2"
@@ -34,12 +31,10 @@ memchr = "2.0"
 # https://rustsec.org/advisories/RUSTSEC-2021-0003.html
 smallvec = "1.6.1"
 radix_trie = "0.2"
-regex = { version = "1.5.4", optional = true }

 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
 utf8parse = "0.2"
-skim = { version = "0.9", optional = true }

 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "minwindef", "processenv", "std", "winbase", "wincon", "winuser"] }
@@ -48,16 +43,11 @@ clipboard-win = "4.2.1"

 [dev-dependencies]
 doc-comment = "0.3"
-env_logger = { version = "0.9", default-features = false }
-tempfile = "3.1.0"
 assert_matches = "1.2"
 rustyline-derive = { version = "0.6.0", path = "rustyline-derive" }

 [features]
-default = ["with-dirs"]
-with-dirs = ["dirs-next"]
-with-fuzzy = ["skim"]
-case_insensitive_history_search = ["regex"]
+default = []

 [package.metadata.docs.rs]
 features = ["with-dirs", "with-fuzzy"]
```

And these steps:

```console
$ cargo +nightly -Zminimal-versions generate-lockfile
    Updating crates.io index
$ cargo tree | grep log
├── log v0.4.0
$ cargo check -q
error: cannot find macro `log` in this scope
   --> src/edit.rs:168:9
    |
168 |         debug!(target: "rustyline", "old layout: {:?}", self.layout);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/edit.rs:169:9
    |
169 |         debug!(target: "rustyline", "new layout: {:?}", new_layout);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/history.rs:311:29
    |
311 | ...                   warn!(target: "rustyline", "bad escaped line: {}", line);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `warn` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/history.rs:345:9
    |
345 |         debug!(target: "rustyline", "PathInfo({:?}, {:?}, {})", path, modified, size);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/history.rs:354:17
    |
354 |                 debug!(target: "rustyline", "cannot append: {:?} <> {:?}", previous_path, path);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/history.rs:362:17
    |
362 | /                 debug!(target: "rustyline", "cannot append: {:?} < {:?} or {} < {} + {}",
363 | |                        previous_modified, modified, self.max_len, previous_size, self.new_entries);
    | |__________________________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/keymap.rs:693:9
    |
693 |         debug!(target: "rustyline", "Emacs command: {:?}", cmd);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/keymap.rs:898:9
    |
898 |         debug!(target: "rustyline", "Vi command: {:?}", cmd);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/keymap.rs:935:17
    |
935 |                 debug!(target: "rustyline", "Vi fast command mode: {}", k);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/keymap.rs:949:9
    |
949 |         debug!(target: "rustyline", "Vi insert: {:?}", cmd);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:269:21
    |
269 |                     debug!(target: "rustyline", "unsupported esc sequence: \\E[{:?}", seq2);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:287:21
    |
287 |                     debug!(target: "rustyline", "unsupported esc sequence: \\E[[{:?}", seq3);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:313:21
    |
313 |                     debug!(target: "rustyline", "unsupported esc sequence: \\E[{:?}", seq2);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:333:21
    |
333 | /                     debug!(target: "rustyline",
334 | |                            "unsupported esc sequence: \\E[{}~", seq2);
    | |_____________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:357:25
    |
357 | /                         debug!(target: "rustyline",
358 | |                                "unsupported esc sequence: \\E[{}{}~", seq2, seq3);
    | |_________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:389:33
    |
389 | / ...                   debug!(target: "rustyline",
390 | | ...                          "unsupported esc sequence: \\E[{}{};{}~", seq2, seq3, seq5);
    | |________________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:395:25
    |
395 | /                         debug!(target: "rustyline",
396 | |                                "unsupported esc sequence: \\E[{}{};{}{}", seq2, seq3, seq5, seq6);
    | |_________________________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:400:21
    |
400 | /                     debug!(target: "rustyline",
401 | |                            "unsupported esc sequence: \\E[{}{};{:?}", seq2, seq3, seq5);
    | |_______________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:411:29
    |
411 | / ...                   debug!(target: "rustyline",
412 | | ...                          "unsupported esc sequence: \\E[{}{}{}~", seq2, seq3, seq4);
    | |_______________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:417:21
    |
417 | /                     debug!(target: "rustyline",
418 | |                            "unsupported esc sequence: \\E[{}{}{}{}", seq2, seq3, seq4, seq5);
    | |____________________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:422:17
    |
422 | /                 debug!(target: "rustyline",
423 | |                        "unsupported esc sequence: \\E[{}{}{:?}", seq2, seq3, seq4);
    | |__________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:533:29
    |
533 | / ...                   debug!(target: "rustyline",
534 | | ...                          "unsupported esc sequence: \\E[1;{}{:?}", seq4, seq5);
    | |__________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:569:29
    |
569 | / ...                   debug!(target: "rustyline",
570 | | ...                          "unsupported esc sequence: \\E[{};{:?}~", seq2, seq4);
    | |__________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:575:21
    |
575 | /                     debug!(target: "rustyline",
576 | |                            "unsupported esc sequence: \\E[{};{}{:?}", seq2, seq4, seq5);
    | |_______________________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:580:17
    |
580 | /                 debug!(target: "rustyline",
581 | |                        "unsupported esc sequence: \\E[{};{:?}", seq2, seq4);
    | |___________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:605:21
    |
605 | /                     debug!(target: "rustyline",
606 | |                            "unsupported esc sequence: \\E[{}{:?}", seq2, seq3);
    | |______________________________________________________________________________^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:640:17
    |
640 |                 debug!(target: "rustyline", "unsupported esc sequence: \\EO{:?}", seq2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:686:9
    |
686 |         debug!(target: "rustyline", "c: {:?} => key: {:?}", c, key);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:729:13
    |
729 |             debug!(target: "rustyline", "terminal key binding: {:?} => {:?}", key, cmd);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:987:13
    |
987 |             debug!(target: "rustyline", "cannot request cursor location");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/tty/unix.rs:998:13
    |
998 |             warn!(target: "rustyline", "cannot read initial cursor location");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `warn` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/tty/unix.rs:1002:9
     |
1002 |         debug!(target: "rustyline", "initial cursor location: {:?}", col);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/tty/unix.rs:1043:5
     |
1043 |     debug!(target: "rustyline", "SIGWINCH");
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/tty/unix.rs:1049:5
     |
1049 |     debug!(target: "rustyline", "{}: {:?}", name, key);
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
    --> src/tty/unix.rs:1165:13
     |
1165 |             debug!(target: "rustyline", "Cannot enable bracketed paste: {}", e);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `log` is in scope, but it is a crate, not a macro
     = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/undo.rs:117:9
    |
117 |         debug!(target: "rustyline", "Changeset::begin");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/undo.rs:128:9
    |
128 |         debug!(target: "rustyline", "Changeset::end");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/undo.rs:151:9
    |
151 |         debug!(target: "rustyline", "Changeset::insert({}, {:?})", idx, c);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/undo.rs:168:9
    |
168 |         debug!(target: "rustyline", "Changeset::insert_str({}, {:?})", idx, string);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/undo.rs:180:9
    |
180 |         debug!(target: "rustyline", "Changeset::delete({}, {:?})", indx, string);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/undo.rs:225:9
    |
225 |         debug!(target: "rustyline", "Changeset::replace({}, {:?}, {:?})", indx, old_, new_);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/undo.rs:254:9
    |
254 |         debug!(target: "rustyline", "Changeset::undo");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/undo.rs:287:9
    |
287 |         debug!(target: "rustyline", "Changeset::truncate({})", len);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:776:13
    |
776 |             debug!(target: "rustyline", "unsupported terminal");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find macro `log` in this scope
   --> src/lib.rs:786:13
    |
786 |             debug!(target: "rustyline", "stdin is not a tty");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `log` is in scope, but it is a crate, not a macro
    = note: this error originates in the macro `debug` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `rustyline` due to 45 previous errors
```