### PR TITLE
map C-f in Emacs mode to complete hints iff at end of line

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -583,6 +583,8 @@ impl InputState {
                 Movement::ForwardChar(n)
             }),
             E(K::Char('E'), M::CTRL) => Cmd::Move(Movement::EndOfLine),
+            // Don't complete hints when the cursor is not at the end of a line
+            E(K::Char('F'), M::CTRL) if wrt.has_hint() && wrt.is_cursor_at_end() => Cmd::CompleteHint,
             E(K::Char('F'), M::CTRL) => Cmd::Move(if positive {
                 Movement::ForwardChar(n)
             } else {


### PR DESCRIPTION
This doesn't affect the behaviour of C-f if in the middle of a line, so I expect there'd be minimal unexpected impact.
This is just a QOL improvement that would be nice to have for C-f (even though the Right arrow key already does this), as popular programs like zsh already have this behaviour for C-f and there is very little current support for conditional/overloading mappings through the API for rustyline.