### PR TITLE
Bind CTRL-D to Cmd::EndOfFile on Windows

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1068,7 +1068,7 @@ impl InputState {
                     } else {
                         Movement::BackwardChar(n)
                     })
-                } else if cfg!(window) || cfg!(test) || !wrt.line().is_empty() {
+                } else if cfg!(windows) || cfg!(test) || !wrt.line().is_empty() {
                     Cmd::EndOfFile
                 } else {
                     Cmd::Unknown


### PR DESCRIPTION
- Return Cmd::EndOfFile when there is no input (nothing to kill in emacs mode).
- Fix invalid cfg! macro argument.

Fixes #586.