### PR TITLE
add support for arbitrary file descriptors on unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,14 @@ default = ["with-dirs"]
 with-dirs = ["dirs-next"]
 with-fuzzy = ["skim"]
 case_insensitive_history_search = ["regex"]
+arbitrary-file-descriptors=[]
 
 [package.metadata.docs.rs]
 features = ["with-dirs", "with-fuzzy"]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"
+
+[[example]]
+name = "arbitrary_file_descriptors"
+required-features = ["arbitrary-file-descriptors"]

--- a/examples/arbitrary_file_descriptors.rs
+++ b/examples/arbitrary_file_descriptors.rs
@@ -1,0 +1,29 @@
+use rustyline::{Behavior, Config, Editor, Result};
+use std::fs::OpenOptions;
+use std::io;
+
+fn main() -> Result<()> {
+    #![cfg(all(unix, not(target_arch = "wasm32")))]
+    {
+        use std::os::unix::io::IntoRawFd;
+
+        let mut path = String::new();
+        io::stdin().read_line(&mut path)?;
+        let terminal = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path.trim())?;
+        let terminal_fd = terminal.into_raw_fd();
+        let config = Config::builder()
+            .behavior(Behavior::ArbitraryFileDescriptors {
+                output: terminal_fd,
+                input: terminal_fd,
+            })
+            .build();
+        let mut rl = Editor::<()>::with_config(config);
+        loop {
+            let line = rl.readline("> ")?;
+            println!("Line: {}", line);
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -300,6 +300,17 @@ pub enum Behavior {
     /// Use terminal-style interaction whenever possible, even if 'stdin' and/or
     /// 'stdout' are not terminals.
     PreferTerm,
+
+    /// Use the provided file descriptors.
+    /// rustyline will not automatically close these file descriptors.
+    #[cfg(feature = "arbitrary-file-descriptors")]
+    #[cfg(all(unix, not(target_arch = "wasm32")))]
+    ArbitraryFileDescriptors {
+        /// the file descriptor for input
+        input: std::os::unix::io::RawFd,
+        /// the file descriptor for output
+        output: std::os::unix::io::RawFd,
+    },
     // TODO
     // Use file-style interaction, reading input from the given file.
     // useFile


### PR DESCRIPTION
This allows the use of arbitrary file descriptors on unix in response to issue #542. File Descriptors are supplied via a new variant of `config::Bhaviour`