### PR TITLE
Replace `buf_redux` with `BufReader` from `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ regex = { version = "1.5.4", optional = true }
 nix = "0.23"
 utf8parse = "0.2"
 skim = { version = "0.9", optional = true }
-buf_redux = { version = "0.8", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "minwindef", "processenv", "std", "winbase", "wincon", "winuser"] }


### PR DESCRIPTION
`rustyline` depends on `buf_redux` for two calls to `get_len`, but these
calls can be replaced with calls to `reader.buffer().len()` using APIs
in `std` that have been available since Rust 1.37.0:

https://doc.rust-lang.org/std/io/struct.BufReader.html#method.buffer

`std::io::BufReader::buffer` does not cause any additional reads to
occur and exposes the internal buffered and unread contents of the
`BufReader`.

Motivation for this commit is reducing dependencies.