### PR TITLE
Explore removing `SmallVec` from `Event` enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,6 @@ unicode-width = "0.1"
 unicode-segmentation = "1.0"
 memchr = "2.0"
 # For custom bindings
-# https://rustsec.org/advisories/RUSTSEC-2021-0003.html
-smallvec = "1.6.1"
 radix_trie = "0.2"
 regex = { version = "1.5.4", optional = true }
 

--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -1,4 +1,3 @@
-use smallvec::smallvec;
 use std::borrow::Cow::{self, Borrowed, Owned};
 
 use rustyline::highlight::Highlighter;
@@ -105,7 +104,7 @@ fn main() -> Result<()> {
         EventHandler::Conditional(Box::new(TabEventHandler)),
     );
     rl.bind_sequence(
-        Event::KeySeq(smallvec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]),
+        Event::KeySeq(vec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]),
         EventHandler::Simple(Cmd::Suspend), // TODO external editor
     );
 

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -249,6 +249,6 @@ mod test {
 
     #[test]
     fn size_of_event() {
-        assert_eq!(size_of::<Event>(), 40);
+        assert_eq!(size_of::<Event>(), 32);
     }
 }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -214,6 +214,8 @@ pub trait ConditionalEventHandler: Send + Sync {
 
 #[cfg(test)]
 mod test {
+    use core::mem::size_of;
+
     use super::{Event, EventHandler};
     use crate::{Cmd, KeyCode, KeyEvent, Modifiers};
     use radix_trie::Trie;
@@ -246,5 +248,10 @@ mod test {
         trie.insert(E::from(K(C::Backspace, M::CTRL)), H::from(Cmd::Noop));
         trie.insert(E::from(K(C::Enter, M::CTRL)), H::from(Cmd::Noop));
         trie.insert(E::from(K(C::Tab, M::CTRL)), H::from(Cmd::Noop));
+    }
+
+    #[test]
+    fn size_of_event() {
+        assert_eq!(size_of::<Event>(), 40);
     }
 }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 
 use radix_trie::TrieKey;
-use smallvec::{smallvec, SmallVec};
 
 /// Input event
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13,8 +12,7 @@ pub enum Event {
     /// Useful if you want to filter out some keys.
     Any,
     /// Key sequence
-    // TODO Validate 2 ?
-    KeySeq(SmallVec<[KeyEvent; 2]>),
+    KeySeq(Vec<KeyEvent>),
     /// TODO Mouse event
     Mouse(),
 }
@@ -43,7 +41,7 @@ impl Event {
 
 impl From<KeyEvent> for Event {
     fn from(k: KeyEvent) -> Event {
-        Event::KeySeq(smallvec![k])
+        Event::KeySeq(vec![k])
     }
 }
 
@@ -219,12 +217,11 @@ mod test {
     use super::{Event, EventHandler};
     use crate::{Cmd, KeyCode, KeyEvent, Modifiers};
     use radix_trie::Trie;
-    use smallvec::smallvec;
 
     #[test]
     fn encode() {
         let mut trie = Trie::new();
-        let evt = Event::KeySeq(smallvec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]);
+        let evt = Event::KeySeq(vec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]);
         trie.insert(evt.clone(), EventHandler::from(Cmd::Noop));
         let prefix = Event::from(KeyEvent::ctrl('X'));
         let subtrie = trie.get_raw_descendant(&prefix);


### PR DESCRIPTION
This PR explores removing the dependency on `smallvec` and replacing it with `Vec` from `std`.

`smallvec` is a third party dependency that leaks into the public API. If applications that depend on `rustyline` wish to create custom key bindings, they must also depend on `smallvec` to construct `Event::KeySeq`.

This PR replaces `smallvec`, which is a complicated data structure with lots of unsafe code and several known security advisories, with a vocabulary type from `std`.

This has the effect of reducing the size of the `Event` enum.

Because `Event` is a public enum, changing the type of the field in `Event::KeySeq` is a breaking change. I've shown this change in the sequence of commits in this branch and the addition of a test.

Motivation of this PR is reducing dependencies.

@gwenn if you'd prefer, I'd be willing to try an alternate PR that conditionally enables `smallvec` with a Cargo feature. I think it looks easy enough to support.