### PR TITLE
Use `nix` APIs for `umask` munging in `history` module

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -552,21 +552,21 @@ cfg_if::cfg_if! {
 
         fn fix_perm(_: &File) {}
     } else if #[cfg(unix)] {
-        fn umask() -> libc::mode_t {
-            unsafe { libc::umask(libc::S_IXUSR | libc::S_IRWXG | libc::S_IRWXO) }
+        fn umask() -> nix::sys::stat::Mode {
+            use nix::sys::stat::Mode;
+
+            nix::sys::stat::umask(Mode::S_IXUSR | Mode::S_IRWXG | Mode::S_IRWXO)
         }
 
-        fn restore_umask(old_umask: libc::mode_t) {
-            unsafe {
-                libc::umask(old_umask);
-            }
+        fn restore_umask(old_umask: nix::sys::stat::Mode) {
+            nix::sys::stat::umask(old_umask);
         }
 
         fn fix_perm(file: &File) {
             use std::os::unix::io::AsRawFd;
-            unsafe {
-                libc::fchmod(file.as_raw_fd(), libc::S_IRUSR | libc::S_IWUSR);
-            }
+            use nix::sys::stat::{fchmod, Mode};
+
+            let _ = fchmod(file.as_raw_fd(), Mode::S_IRUSR | Mode::S_IWUSR);
         }
     }
 }


### PR DESCRIPTION
Remove some unsafe code by using `nix`'s APIs for setting `umask`s on
the history files. This changes these function signatures to take and
return `nix::sys::stat::Mode` instead of `c_int` which constrains the
valid representations of the `mode` parameter to `umask` and `fchmod`.

This is a drive-by refactoring I noticed while mucking around with keybindings in #615.