### PR TITLE
Simplify custom bindings

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,4 +1,3 @@
-use std::sync::{Arc, RwLock};
 use std::vec::IntoIter;
 
 use radix_trie::Trie;
@@ -59,7 +58,8 @@ fn complete_line() {
     let helper = Some(SimpleCompleter);
     let mut s = init_state(&mut out, "rus", 3, helper.as_ref(), &history);
     let config = Config::default();
-    let mut input_state = InputState::new(&config, Arc::new(RwLock::new(Trie::new())));
+    let bindings = Trie::new();
+    let mut input_state = InputState::new(&config, &bindings);
     let keys = vec![E::ENTER];
     let mut rdr: IntoIter<KeyEvent> = keys.into_iter();
     let cmd = super::complete_line(&mut rdr, &mut s, &mut input_state, &Config::default()).unwrap();


### PR DESCRIPTION
We don't need a Arc<RwLock<...>> because custom bindings cannot be
modified while editing.