### PR TITLE
Derive Completer, Highlighter, Hinter, Validator from struct fields

### DIFF
--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -1,23 +1,15 @@
 use std::borrow::Cow::{self, Borrowed, Owned};
 
 use rustyline::highlight::Highlighter;
-use rustyline::hint::{Hinter, HistoryHinter};
+use rustyline::hint::HistoryHinter;
 use rustyline::{
-    Cmd, ConditionalEventHandler, Context, Editor, Event, EventContext, EventHandler, KeyEvent,
-    RepeatCount, Result,
+    Cmd, ConditionalEventHandler, Editor, Event, EventContext, EventHandler, KeyEvent, RepeatCount,
+    Result,
 };
-use rustyline_derive::{Completer, Helper, Validator};
+use rustyline_derive::{Completer, Helper, Hinter, Validator};
 
-#[derive(Completer, Helper, Validator)]
-struct MyHelper(HistoryHinter);
-
-impl Hinter for MyHelper {
-    type Hint = String;
-
-    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
-        self.0.hint(line, pos, ctx)
-    }
-}
+#[derive(Completer, Helper, Hinter, Validator)]
+struct MyHelper(#[rustyline(Hinter)] HistoryHinter);
 
 impl Highlighter for MyHelper {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,41 +1,23 @@
 use std::borrow::Cow::{self, Borrowed, Owned};
 
-use rustyline::completion::{Completer, FilenameCompleter, Pair};
+use rustyline::completion::FilenameCompleter;
 use rustyline::error::ReadlineError;
 use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
-use rustyline::hint::{Hinter, HistoryHinter};
-use rustyline::validate::{self, MatchingBracketValidator, Validator};
-use rustyline::{Cmd, CompletionType, Config, Context, EditMode, Editor, KeyEvent};
-use rustyline_derive::Helper;
+use rustyline::hint::HistoryHinter;
+use rustyline::validate::MatchingBracketValidator;
+use rustyline::{Cmd, CompletionType, Config, EditMode, Editor, KeyEvent};
+use rustyline_derive::{Completer, Helper, Hinter, Validator};
 
-#[derive(Helper)]
+#[derive(Helper, Completer, Hinter, Validator)]
 struct MyHelper {
+    #[rustyline(Completer)]
     completer: FilenameCompleter,
     highlighter: MatchingBracketHighlighter,
+    #[rustyline(Validator)]
     validator: MatchingBracketValidator,
+    #[rustyline(Hinter)]
     hinter: HistoryHinter,
     colored_prompt: String,
-}
-
-impl Completer for MyHelper {
-    type Candidate = Pair;
-
-    fn complete(
-        &self,
-        line: &str,
-        pos: usize,
-        ctx: &Context<'_>,
-    ) -> Result<(usize, Vec<Pair>), ReadlineError> {
-        self.completer.complete(line, pos, ctx)
-    }
-}
-
-impl Hinter for MyHelper {
-    type Hint = String;
-
-    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
-        self.hinter.hint(line, pos, ctx)
-    }
 }
 
 impl Highlighter for MyHelper {
@@ -61,19 +43,6 @@ impl Highlighter for MyHelper {
 
     fn highlight_char(&self, line: &str, pos: usize) -> bool {
         self.highlighter.highlight_char(line, pos)
-    }
-}
-
-impl Validator for MyHelper {
-    fn validate(
-        &self,
-        ctx: &mut validate::ValidationContext,
-    ) -> rustyline::Result<validate::ValidationResult> {
-        self.validator.validate(ctx)
-    }
-
-    fn validate_while_typing(&self) -> bool {
-        self.validator.validate_while_typing()
     }
 }
 

--- a/examples/input_multiline.rs
+++ b/examples/input_multiline.rs
@@ -1,18 +1,11 @@
-use rustyline::validate::{
-    MatchingBracketValidator, ValidationContext, ValidationResult, Validator,
-};
+use rustyline::validate::MatchingBracketValidator;
 use rustyline::{Editor, Result};
-use rustyline_derive::{Completer, Helper, Highlighter, Hinter};
+use rustyline_derive::{Completer, Helper, Highlighter, Hinter, Validator};
 
-#[derive(Completer, Helper, Highlighter, Hinter)]
+#[derive(Completer, Helper, Highlighter, Hinter, Validator)]
 struct InputValidator {
+    #[rustyline(Validator)]
     brackets: MatchingBracketValidator,
-}
-
-impl Validator for InputValidator {
-    fn validate(&self, ctx: &mut ValidationContext) -> Result<ValidationResult> {
-        self.brackets.validate(ctx)
-    }
 }
 
 fn main() -> Result<()> {

--- a/rustyline-derive/Cargo.toml
+++ b/rustyline-derive/Cargo.toml
@@ -21,3 +21,4 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", default-features = false, features = ["derive", "parsing", "printing", "proc-macro"] }
 quote = { version = "1.0", default-features = false }
+proc-macro2 = { version = "1.0", default-features = false }

--- a/rustyline-derive/src/lib.rs
+++ b/rustyline-derive/src/lib.rs
@@ -1,19 +1,78 @@
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, Data, DeriveInput, Field, Index, Path};
 
-#[proc_macro_derive(Completer)]
+fn get_field_by_attr<'a>(data: &'a Data, ident: &str) -> Option<(usize, &'a Field)> {
+    if let Data::Struct(struct_data) = &data {
+        let mut fields = struct_data.fields.iter().enumerate().filter(|(_, field)| {
+            field.attrs.iter().any(|attr| {
+                attr.path.is_ident("rustyline")
+                    && attr
+                        .parse_args::<Path>()
+                        .map_or(false, |arg| arg.is_ident(ident))
+            })
+        });
+
+        let field = fields.next();
+
+        if fields.next().is_some() {
+            panic!("Only one {:} field is allowed.", ident);
+        }
+
+        field
+    } else {
+        None
+    }
+}
+
+fn field_name_or_index_token(index: usize, field: &Field) -> TokenStream2 {
+    if let Some(ident) = field.ident.as_ref() {
+        quote!(#ident)
+    } else {
+        let index = Index::from(index);
+        quote!(#index)
+    }
+}
+
+#[proc_macro_derive(Completer, attributes(rustyline))]
 pub fn completer_macro_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let generics = input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let expanded = quote! {
-        #[automatically_derived]
-        impl #impl_generics ::rustyline::completion::Completer for #name #ty_generics #where_clause {
-            type Candidate = ::std::string::String;
+    let expanded = if let Some((index, field)) = get_field_by_attr(&input.data, "Completer") {
+        let field_name_or_index = field_name_or_index_token(index, field);
+        let field_type = &field.ty;
+
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics ::rustyline::completion::Completer for #name #ty_generics #where_clause {
+                type Candidate = <#field_type as ::rustyline::completion::Completer>::Candidate;
+
+                fn complete(
+                    &self,
+                    line: &str,
+                    pos: usize,
+                    ctx: &::rustyline::Context<'_>,
+                ) -> ::rustyline::Result<(usize, ::std::vec::Vec<Self::Candidate>)> {
+                    ::rustyline::completion::Completer::complete(&self.#field_name_or_index, line, pos, ctx)
+                }
+
+                fn update(&self, line: &mut ::rustyline::line_buffer::LineBuffer, start: usize, elected: &str) {
+                    ::rustyline::completion::Completer::update(&self.#field_name_or_index, line, start, elected)
+                }
+            }
+        }
+    } else {
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics ::rustyline::completion::Completer for #name #ty_generics #where_clause {
+                type Candidate = ::std::string::String;
+            }
         }
     };
+
     TokenStream::from(expanded)
 }
 
@@ -31,44 +90,117 @@ pub fn helper_macro_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-#[proc_macro_derive(Highlighter)]
+#[proc_macro_derive(Highlighter, attributes(rustyline))]
 pub fn highlighter_macro_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let generics = input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let expanded = quote! {
-        #[automatically_derived]
-        impl #impl_generics ::rustyline::highlight::Highlighter for #name #ty_generics #where_clause {
+    let expanded = if let Some((index, field)) = get_field_by_attr(&input.data, "Highlighter") {
+        let field_name_or_index = field_name_or_index_token(index, field);
+
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics ::rustyline::highlight::Highlighter for #name #ty_generics #where_clause {
+                fn highlight<'l>(&self, line: &'l str, pos: usize) -> ::std::borrow::Cow<'l, str> {
+                    ::rustyline::highlight::Highlighter::highlight(&self.#field_name_or_index, line, pos)
+                }
+
+                fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
+                    &'s self,
+                    prompt: &'p str,
+                    default: bool,
+                ) -> ::std::borrow::Cow<'b, str> {
+                    ::rustyline::highlight::Highlighter::highlight_prompt(&self.#field_name_or_index, prompt, default)
+                }
+
+                fn highlight_hint<'h>(&self, hint: &'h str) -> ::std::borrow::Cow<'h, str> {
+                    ::rustyline::highlight::Highlighter::highlight_hint(&self.#field_name_or_index, hint)
+                }
+
+                fn highlight_candidate<'c>(
+                    &self,
+                    candidate: &'c str,
+                    completion: ::rustyline::config::CompletionType,
+                ) -> ::std::borrow::Cow<'c, str> {
+                    ::rustyline::highlight::Highlighter::highlight_candidate(&self.#field_name_or_index, candidate, completion)
+                }
+
+                fn highlight_char(&self, line: &str, pos: usize) -> bool {
+                    ::rustyline::highlight::Highlighter::highlight_char(&self.#field_name_or_index, line, pos)
+                }
+            }
+        }
+    } else {
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics ::rustyline::highlight::Highlighter for #name #ty_generics #where_clause {
+            }
         }
     };
     TokenStream::from(expanded)
 }
 
-#[proc_macro_derive(Hinter)]
+#[proc_macro_derive(Hinter, attributes(rustyline))]
 pub fn hinter_macro_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let generics = input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let expanded = quote! {
-        #[automatically_derived]
-        impl #impl_generics ::rustyline::hint::Hinter for #name #ty_generics #where_clause {
-            type Hint = ::std::string::String;
+    let expanded = if let Some((index, field)) = get_field_by_attr(&input.data, "Hinter") {
+        let field_name_or_index = field_name_or_index_token(index, field);
+        let field_type = &field.ty;
+
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics ::rustyline::hint::Hinter for #name #ty_generics #where_clause {
+                type Hint = <#field_type as ::rustyline::hint::Hinter>::Hint;
+
+                fn hint(&self, line: &str, pos: usize, ctx: &::rustyline::Context<'_>) -> ::std::option::Option<Self::Hint> {
+                    ::rustyline::hint::Hinter::hint(&self.#field_name_or_index, line, pos, ctx)
+                }
+            }
+        }
+    } else {
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics ::rustyline::hint::Hinter for #name #ty_generics #where_clause {
+                type Hint = ::std::string::String;
+            }
         }
     };
     TokenStream::from(expanded)
 }
 
-#[proc_macro_derive(Validator)]
+#[proc_macro_derive(Validator, attributes(rustyline))]
 pub fn validator_macro_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let generics = input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let expanded = quote! {
-        #[automatically_derived]
-        impl #impl_generics ::rustyline::validate::Validator for #name #ty_generics #where_clause {
+    let expanded = if let Some((index, field)) = get_field_by_attr(&input.data, "Validator") {
+        let field_name_or_index = field_name_or_index_token(index, field);
+
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics ::rustyline::validate::Validator for #name #ty_generics #where_clause {
+                fn validate(
+                    &self,
+                    ctx: &mut ::rustyline::validate::ValidationContext,
+                ) -> ::rustyline::Result<::rustyline::validate::ValidationResult> {
+                    ::rustyline::validate::Validator::validate(&self.#field_name_or_index, ctx)
+                }
+
+                fn validate_while_typing(&self) -> bool {
+                    ::rustyline::validate::Validator::validate_while_typing(&self.#field_name_or_index)
+                }
+            }
+        }
+    } else {
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics ::rustyline::validate::Validator for #name #ty_generics #where_clause {
+            }
         }
     };
     TokenStream::from(expanded)


### PR DESCRIPTION
This improves the derive macros.

Instead of:

```rust
#[derive(Helper)]
struct MyHelper {
    completer: FilenameCompleter,
    highlighter: MatchingBracketHighlighter,
    validator: MatchingBracketValidator,
    hinter: HistoryHinter,
}

impl Completer for MyHelper {
    type Candidate = Pair;

    fn complete(
        &self,
        line: &str,
        pos: usize,
        ctx: &Context<'_>,
    ) -> Result<(usize, Vec<Pair>), ReadlineError> {
        self.completer.complete(line, pos, ctx)
    }
}

impl Hinter for MyHelper {
    type Hint = String;

    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
        self.hinter.hint(line, pos, ctx)
    }
}

impl Highlighter for MyHelper {
    fn highlight<'l>(&self, line: &'l str, pos: usize) -> Cow<'l, str> {
        self.highlighter.highlight(line, pos)
    }

    fn highlight_char(&self, line: &str, pos: usize) -> bool {
        self.highlighter.highlight_char(line, pos)
    }
}

impl Validator for MyHelper {
    fn validate(
        &self,
        ctx: &mut validate::ValidationContext,
    ) -> rustyline::Result<validate::ValidationResult> {
        self.validator.validate(ctx)
    }

    fn validate_while_typing(&self) -> bool {
        self.validator.validate_while_typing()
    }
}
```

Now you can write:

```rust
#[derive(Helper, Completer, Highlighter, Validator, Hinter)]
struct MyHelper {
    #[rustyline(Completer)]
    completer: FilenameCompleter,
    #[rustyline(Highlighter)]
    highlighter: MatchingBracketHighlighter,
    #[rustyline(Validator)]
    validator: MatchingBracketValidator,
    #[rustyline(Hinter)]
    hinter: HistoryHinter,
}
```

This also works for tuple structs. So instead of:

```rust
#[derive(Completer, Helper, Highlighter, Validator)]
struct MyHelper(HistoryHinter);

impl Hinter for MyHelper {
    type Hint = String;

    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
        self.0.hint(line, pos, ctx)
    }
}
```

Now you can write:

```rust
#[derive(Helper, Completer, Highlighter, Hinter, Validator)]
struct MyHelper(#[rustyline(Hinter)] HistoryHinter)
```