### PR TITLE
Upgrade nix to 0.24, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ radix_trie = { version = "0.2", optional = true }
 regex = { version = "1.5.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.23"
+nix = { version = "0.24", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 utf8parse = "0.2"
 skim = { version = "0.9", optional = true }
 


### PR DESCRIPTION
This reduces compilation time slightly, and removes the memoffset crate as an indirect dependency.