### PR TITLE
Use lookup tables instead of linear search with `memchr`

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -90,36 +90,6 @@ impl<'r, H: ?Sized + Highlighter> Highlighter for &'r H {
     }
 }
 
-const OPENS: &[u8; 3] = b"{[(";
-const CLOSES: &[u8; 3] = b"}])";
-
-const OPEN_BRACKETS_LOOKUP_TABLE: [bool; 256] = {
-    let mut table = [false; 256];
-    let mut idx = 0;
-    loop {
-        if idx >= OPENS.len() {
-            break;
-        }
-        let bracket = OPENS[idx];
-        table[bracket as usize] = true;
-        idx += 1;
-    }
-    table
-};
-const CLOSE_BRACKETS_LOOKUP_TABLE: [bool; 256] = {
-    let mut table = [false; 256];
-    let mut idx = 0;
-    loop {
-        if idx >= CLOSES.len() {
-            break;
-        }
-        let bracket = CLOSES[idx];
-        table[bracket as usize] = true;
-        idx += 1;
-    }
-    table
-};
-
 // TODO versus https://python-prompt-toolkit.readthedocs.io/en/master/pages/reference.html?highlight=HighlightMatchingBracketProcessor#prompt_toolkit.layout.processors.HighlightMatchingBracketProcessor
 
 /// Highlight matching bracket when typed or cursor moved on.
@@ -251,10 +221,10 @@ const fn matching_bracket(bracket: u8) -> u8 {
     }
 }
 fn is_open_bracket(bracket: u8) -> bool {
-    OPEN_BRACKETS_LOOKUP_TABLE[usize::from(bracket)]
+    matches!(bracket, b'{' | b'[' | b'(')
 }
 fn is_close_bracket(bracket: u8) -> bool {
-    CLOSE_BRACKETS_LOOKUP_TABLE[usize::from(bracket)]
+    matches!(bracket, b'}' | b']' | b')')
 }
 
 #[cfg(test)]

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -1,7 +1,6 @@
 //! Syntax highlighting
 
 use crate::config::CompletionType;
-use memchr::memchr;
 use std::borrow::Cow::{self, Borrowed, Owned};
 use std::cell::Cell;
 
@@ -93,6 +92,33 @@ impl<'r, H: ?Sized + Highlighter> Highlighter for &'r H {
 
 const OPENS: &[u8; 3] = b"{[(";
 const CLOSES: &[u8; 3] = b"}])";
+
+const OPEN_BRACKETS_LOOKUP_TABLE: [bool; 256] = {
+    let mut table = [false; 256];
+    let mut idx = 0;
+    loop {
+        if idx >= OPENS.len() {
+            break;
+        }
+        let bracket = OPENS[idx];
+        table[bracket as usize] = true;
+        idx += 1;
+    }
+    table
+};
+const CLOSE_BRACKETS_LOOKUP_TABLE: [bool; 256] = {
+    let mut table = [false; 256];
+    let mut idx = 0;
+    loop {
+        if idx >= CLOSES.len() {
+            break;
+        }
+        let bracket = CLOSES[idx];
+        table[bracket as usize] = true;
+        idx += 1;
+    }
+    table
+};
 
 // TODO versus https://python-prompt-toolkit.readthedocs.io/en/master/pages/reference.html?highlight=HighlightMatchingBracketProcessor#prompt_toolkit.layout.processors.HighlightMatchingBracketProcessor
 
@@ -225,10 +251,10 @@ const fn matching_bracket(bracket: u8) -> u8 {
     }
 }
 fn is_open_bracket(bracket: u8) -> bool {
-    memchr(bracket, OPENS).is_some()
+    OPEN_BRACKETS_LOOKUP_TABLE[usize::from(bracket)]
 }
 fn is_close_bracket(bracket: u8) -> bool {
-    memchr(bracket, CLOSES).is_some()
+    CLOSE_BRACKETS_LOOKUP_TABLE[usize::from(bracket)]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Several places use `memchr` with a byteset. This commit refactors these
code paths to construct a lookup table from `u8` -> `bool`, where an
index is set to `true` if the byte is present in the given slice.

This change removes linear scans that occur in loops, which changes
these functions runtime complexity from `O(m * n)` to `O(m + n)`.