### PR TITLE
Update custom key bindings example

### DIFF
--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -77,7 +77,7 @@ impl ConditionalEventHandler for TabEventHandler {
             .filter(|c| c.is_whitespace())
             .is_some()
         {
-            Some(Cmd::SelfInsert(n, '\t'))
+            Some(Cmd::Insert(n, "\t".into()))
         } else {
             None // default complete
         }


### PR DESCRIPTION
In my testing selfinsert doesn't seem to work, it inserts one white-space character instead of an actual tab, changing it to insert makes it work perfectly.