### PR TITLE
Do not validate if the command is 'NewLine'

### DIFF
--- a/examples/input_multiline.rs
+++ b/examples/input_multiline.rs
@@ -1,5 +1,5 @@
 use rustyline::validate::MatchingBracketValidator;
-use rustyline::{Editor, Result};
+use rustyline::{Cmd, Editor, EventHandler, KeyCode, KeyEvent, Modifiers, Result};
 use rustyline_derive::{Completer, Helper, Highlighter, Hinter, Validator};
 
 #[derive(Completer, Helper, Highlighter, Hinter, Validator)]
@@ -14,6 +14,10 @@ fn main() -> Result<()> {
     };
     let mut rl = Editor::new()?;
     rl.set_helper(Some(h));
+    rl.bind_sequence(
+        KeyEvent(KeyCode::Char('s'), Modifiers::CTRL),
+        EventHandler::Simple(Cmd::Newline),
+    );
 
     let input = rl.readline("> ")?;
     println!("Input: {}", input);

--- a/src/command.rs
+++ b/src/command.rs
@@ -26,6 +26,16 @@ pub fn execute<H: Helper>(
     use Status::{Proceed, Submit};
 
     match cmd {
+        Cmd::EndOfFile | Cmd::AcceptLine | Cmd::AcceptOrInsertLine { .. } | Cmd::Newline => {
+            if s.has_hint() || !s.is_default_prompt() {
+                // Force a refresh without hints to leave the previous
+                // line as the user typed it after a newline.
+                s.refresh_line_with_msg(None)?;
+            }
+        }
+        _ => {}
+    };
+    match cmd {
         Cmd::CompleteHint => {
             complete_hint_line(s)?;
         }
@@ -58,11 +68,6 @@ pub fn execute<H: Helper>(
             s.edit_overwrite_char(c)?;
         }
         Cmd::EndOfFile => {
-            if s.has_hint() || !s.is_default_prompt() {
-                // Force a refresh without hints to leave the previous
-                // line as the user typed it after a newline.
-                s.refresh_line_with_msg(None)?;
-            }
             if s.line.is_empty() {
                 return Err(error::ReadlineError::Eof);
             } else if !input_state.is_emacs_mode() {
@@ -119,12 +124,10 @@ pub fn execute<H: Helper>(
                 kill_ring.kill(&text, Mode::Append);
             }
         }
-        Cmd::AcceptLine | Cmd::AcceptOrInsertLine { .. } | Cmd::Newline => {
-            if s.has_hint() || !s.is_default_prompt() {
-                // Force a refresh without hints to leave the previous
-                // line as the user typed it after a newline.
-                s.refresh_line_with_msg(None)?;
-            }
+        Cmd::Newline => {
+            s.edit_insert('\n', 1)?;
+        }
+        Cmd::AcceptLine | Cmd::AcceptOrInsertLine { .. } => {
             let validation_result = s.validate()?;
             let valid = validation_result.is_valid();
             let end = s.line.is_end_of_input();
@@ -145,9 +148,6 @@ pub fn execute<H: Helper>(
                     if valid || !validation_result.has_message() {
                         s.edit_insert('\n', 1)?;
                     }
-                }
-                (Cmd::Newline, ..) => {
-                    s.edit_insert('\n', 1)?;
                 }
                 _ => unreachable!(),
             }

--- a/src/command.rs
+++ b/src/command.rs
@@ -140,12 +140,14 @@ pub fn execute<H: Helper>(
                 ) => {
                     return Ok(Submit);
                 }
-                (Cmd::Newline, ..)
-                | (Cmd::AcceptOrInsertLine { .. }, false, _)
+                (Cmd::AcceptOrInsertLine { .. }, false, _)
                 | (Cmd::AcceptOrInsertLine { .. }, true, false) => {
                     if valid || !validation_result.has_message() {
                         s.edit_insert('\n', 1)?;
                     }
+                }
+                (Cmd::Newline, ..) => {
+                    s.edit_insert('\n', 1)?;
                 }
                 _ => unreachable!(),
             }


### PR DESCRIPTION
`NewLine` is in my experience used when the user actually want to force a newline regardless of the result of the validation.

This pr exempt newline from validation.

demo: (I first hit enter each time then ctrl-s)
![rl](https://user-images.githubusercontent.com/22427111/178805508-059866fb-33f1-4192-8af2-416955ef1b73.gif)

