### PR TITLE
Fix ViFirstPrint movement

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -51,7 +51,9 @@ pub fn execute<H: Helper>(
         }
         Cmd::Move(Movement::ViFirstPrint) => {
             s.edit_move_home()?;
-            s.edit_move_to_next_word(At::Start, Word::Big, 1)?;
+            if s.line.starts_with(char::is_whitespace) {
+                s.edit_move_to_next_word(At::Start, Word::Big, 1)?;
+            }
         }
         Cmd::Move(Movement::BackwardChar(n)) => {
             // Move back a character.

--- a/src/test/vi_cmd.rs
+++ b/src/test/vi_cmd.rs
@@ -59,6 +59,16 @@ fn caret() {
 }
 
 #[test]
+fn caret_no_whitespace() {
+    assert_cursor(
+        EditMode::Vi,
+        ("Hi", ""),
+        &[E::ESC, E::from('^'), E::ENTER],
+        ("", "Hi"),
+    );
+}
+
+#[test]
 fn a() {
     assert_cursor(
         EditMode::Vi,


### PR DESCRIPTION
when there is no whitespace at the beginining of line.
Fix #645