### PR TITLE
Don't set height for skim

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,6 @@ fn complete_line<H: Helper>(
                 // by default skim multi select is off so only expect one selection
 
                 let options = SkimOptionsBuilder::default()
-                    .height(Some("20%"))
                     .prompt(Some("? "))
                     .reverse(true)
                     .build()


### PR DESCRIPTION
skim does not clear the screen correctly when `height` is set
https://github.com/lotabout/skim/issues/494