### PR TITLE
Implement Clone for Pair

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -46,6 +46,7 @@ impl Candidate for &'_ str {
 }
 
 /// Completion candidate pair
+#[derive(Clone)]
 pub struct Pair {
     /// Text to display when listing alternatives.
     pub display: String,


### PR DESCRIPTION
This is so I can use `.clone()` directly instead of what I have [here](https://github.com/nix-community/nix-init/blob/830f34b8f29d2bb762465d844ff812ce5bf95c87/src/prompt.rs#L46-L53)