### PR TITLE
[ci] Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2.2.0
       - name: Build
         run: cargo build --workspace --all-targets


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.3.0
> - Implement branch list using callbacks from exec function
> - Add in explicit reference to private checkout options
> - Fix comment typos
>
> ## v3.2.0
> - Add GitHub Action to perform release
> - Fix status badge
> - Replace datadog/squid with ubuntu/squid Docker image
> - Wrap pipeline commands for submoduleForeach in quotes
> - Update @actions/io to 1.1.2
> - Upgrading version to 3.2.0
>
> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

Still using v2 of `actions/checkout` will generate some warning like in this run: https://github.com/kkawakam/rustyline/actions/runs/4216825599

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/checkout`, because v3 uses Node.js 16.