### PR TITLE
Make MemHistory::default() be a wrapper around MemHistory::new() to avoid that max_len is defaulted to 0.

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -175,7 +175,6 @@ pub trait History {
 }
 
 /// Transient in-memory history implementation.
-#[derive(Default)]
 pub struct MemHistory {
     entries: VecDeque<String>,
     max_len: usize,
@@ -275,6 +274,12 @@ impl MemHistory {
             self.entries.pop_front();
         }
         self.entries.push_back(line);
+    }
+}
+
+impl Default for MemHistory {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
I found that when creating `MemHistory` from `Default::default()`, the `max_len` (that is the maximum size of the history) is initialized to `0` due to the `#[derive(Default)]` on the `MemHistory` struct.
This is counter intuative since the history doesn't work as a history at all in that case.

I changed the `Default` implementation to call `MemHistory::new()` instead. Then the history max length will be initialized to `100` instead.
