### PR TITLE
Add `HistoryHinter::default()` and `HistoryHinter::new()`

### DIFF
--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -87,7 +87,7 @@ impl ConditionalEventHandler for TabEventHandler {
 
 fn main() -> Result<()> {
     let mut rl = Editor::<MyHelper, DefaultHistory>::new()?;
-    rl.set_helper(Some(MyHelper(HistoryHinter {})));
+    rl.set_helper(Some(MyHelper(HistoryHinter::new())));
 
     let ceh = Box::new(CompleteHintHandler);
     rl.bind_sequence(KeyEvent::ctrl('E'), EventHandler::Conditional(ceh.clone()));

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -58,7 +58,7 @@ fn main() -> rustyline::Result<()> {
     let h = MyHelper {
         completer: FilenameCompleter::new(),
         highlighter: MatchingBracketHighlighter::new(),
-        hinter: HistoryHinter {},
+        hinter: HistoryHinter::new(),
         colored_prompt: "".to_owned(),
         validator: MatchingBracketValidator::new(),
     };

--- a/src/hint.rs
+++ b/src/hint.rs
@@ -50,7 +50,15 @@ impl<'r, H: ?Sized + Hinter> Hinter for &'r H {
 
 /// Add suggestion based on previous history entries matching current user
 /// input.
+#[derive(Default)]
 pub struct HistoryHinter {}
+
+impl HistoryHinter {
+    /// Create a new `HistoryHinter`
+    pub fn new() -> HistoryHinter {
+        HistoryHinter::default()
+    }
+}
 
 impl Hinter for HistoryHinter {
     type Hint = String;


### PR DESCRIPTION
This allows me to `#[derive(Default)]` when using a `HistoryHinter` (like the other provided rustyline utilities).