### PR TITLE
Use termios from termios crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "
 utf8parse = "0.2"
 skim = { version = "0.10", optional = true, default-features = false }
 signal-hook = { version = "0.3", optional = true, default-features = false }
+termios = "0.3.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "synchapi", "minwindef", "processenv", "std", "winbase", "wincon", "winuser"] }


### PR DESCRIPTION
The termios interface from the nix crate is lacking a thought through design. Severely broken on at least one platform. Please see [#2071][] for details.

The termios crate stays closer to the C API and thus both works with illumos and reduces the risk of bugs on other platforms.

[#2071]: https://github.com/nix-rust/nix/issues/2071