### PR TITLE
Fixing hints when not editing at end of line

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -128,7 +128,8 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         if self.layout.cursor == cursor {
             return Ok(());
         }
-        if self.highlight_char() {
+        if self.highlight_char() || self.has_hint() {
+            self.hint = None;
             let prompt_size = self.prompt_size;
             self.refresh(self.prompt, prompt_size, true, Info::NoHint)?;
         } else {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -562,8 +562,8 @@ impl<'b> InputState<'b> {
                     Cmd::CompleteBackward
                 }
             }
-            // Don't complete hints when the cursor is not at the end of a line
             E(K::Right, M::NONE) if wrt.has_hint() && wrt.is_cursor_at_end() => Cmd::CompleteHint,
+            E(K::Right, M::ALT) if wrt.has_hint() => Cmd::CompleteHint,
             E(K::Char('K'), M::CTRL) => Cmd::Kill(if positive {
                 Movement::EndOfLine
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,6 @@ fn complete_hint_line<H: Helper>(s: &mut State<'_, '_, H>) -> Result<()> {
         Some(hint) => hint,
         None => return Ok(()),
     };
-    s.line.move_end();
     if let Some(text) = hint.completion() {
         if s.line.yank(text, 1, &mut s.changes).is_none() {
             s.out.beep()?;

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -979,11 +979,21 @@ impl Renderer for PosixRenderer {
         }
         // display hint
         if let Some(hint) = hint {
+            // position the cursor within the line
+            if cursor.col > 0 {
+                write!(self.buffer, "\r\x1b[{}C", cursor.col).unwrap();
+            } else {
+                self.buffer.push('\r');
+            }
+            // enter insert mode:
+            write!(self.buffer, "\x1b[4h").unwrap();
             if let Some(highlighter) = highlighter {
                 self.buffer.push_str(&highlighter.highlight_hint(hint));
             } else {
                 self.buffer.push_str(hint);
             }
+            // leave insert mode:
+            write!(self.buffer, "\x1b[4l").unwrap();
         }
         // we have to generate our own newline on line wrap
         if end_pos.col == 0


### PR DESCRIPTION
Currently, hints are only working correctly when editing at the end of the line.
Let me describe the current behaviour using a simple example:
The line contains "abcd" and the cursor is at position zero when typing "123". That text has the hint "1234567890_".

1) rustyline displays: 123|abcd{456789_}
2) After typing a 4: 1234|abcd{56789_}
3) After cursor right: 1234a|bcd{56789_}
4) After cursor right: 1234ab|cd{56789_}
5) After cursor right: 1234abc|d{56789_}
6) After cursor right: 1234abcd|{56789_}
7) After cursor right: 1234abcd56789_|

The pipe character indicates the cursor position. The curly braces do contain the hint.

Multiple issues:
- Hint is displayed at end of line, not directly right of cursor.
- Hint stays active when moving the cursor.
- Remaining part of hint is finally inserted at the end of the line.
- No possibility to complete a hint when not at end of line.

This pull request fixes all four issues.