### PR TITLE
fix(unix): restore terminal mode

### DIFF
--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -106,8 +106,7 @@ pub type Mode = PosixMode;
 impl RawMode for PosixMode {
     /// Disable RAW mode for the terminal.
     fn disable_raw_mode(&self) -> Result<()> {
-        let mut termios = self.termios;
-        tcsetattr(self.tty_in, termios::TCSADRAIN, &mut termios)?;
+        tcsetattr(self.tty_in, termios::TCSADRAIN, &self.termios)?;
         // disable bracketed paste
         if let Some(out) = self.tty_out {
             write_all(out, BRACKETED_PASTE_OFF)?;

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -14,7 +14,7 @@ use nix::errno::Errno;
 use nix::poll::{self, PollFlags};
 use nix::sys::select::{self, FdSet};
 use nix::unistd::{close, isatty, read, write};
-use termios::{tcgetattr, tcsetattr, Termios};
+use termios::{tcsetattr, Termios};
 use unicode_segmentation::UnicodeSegmentation;
 use utf8parse::{Parser, Receiver};
 
@@ -107,7 +107,7 @@ impl RawMode for PosixMode {
     /// Disable RAW mode for the terminal.
     fn disable_raw_mode(&self) -> Result<()> {
         let mut termios = self.termios;
-        tcgetattr(self.tty_in, &mut termios)?;
+        tcsetattr(self.tty_in, termios::TCSADRAIN, &mut termios)?;
         // disable bracketed paste
         if let Some(out) = self.tty_out {
             write_all(out, BRACKETED_PASTE_OFF)?;


### PR DESCRIPTION
https://github.com/kkawakam/rustyline/pull/717 migrated to the use of the `termios` crate for handling terminal modes.

Small oversight in the patch made it so the raw mode patch needed for this crate leaks into the terminal.

Repro (on master [35ea49a](https://github.com/kkawakam/rustyline/commit/35ea49aa459f48dd206d0bd714686074c6231469)):

```console
$ stty
speed 38400 baud;
lflags: echoe echok echoke echoctl pendin
oflags: -oxtabs
cflags: cs8 -parenb
$
$ # let's pick any example to run
$
$ cargo run --features derive --example example
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/examples/example`
1> ^C
Interrupted
$
$ # now, we can clearly see the leak
$
$ stty
speed 38400 baud;
lflags: -icanon -isig -iexten -echo echoe echok echoke echoctl
iflags: -icrnl -ixon -brkint
oflags: -oxtabs
cflags: cs8 -parenb
```