### PR TITLE
Adding `final_highlight` method to `Highlighter` trait.  Issue 726

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -25,7 +25,7 @@ pub fn execute<H: Helper>(
 
     match cmd {
         Cmd::EndOfFile | Cmd::AcceptLine | Cmd::AcceptOrInsertLine { .. } | Cmd::Newline => {
-            if s.has_hint() || !s.is_default_prompt() {
+            if s.needs_final_refresh()  {
                 // Force a refresh without hints to leave the previous
                 // line as the user typed it after a newline.
                 s.refresh_line_with_msg(None)?;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -225,6 +225,12 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         self.layout.default_prompt
     }
 
+    pub fn needs_final_refresh(&self) -> bool {
+        let highlighter_needs_refresh = self.highlighter()
+            .map_or(false, |h| h.final_highlight(self.line.as_str()));
+        self.has_hint() || !self.is_default_prompt() || highlighter_needs_refresh
+    }
+
     pub fn validate(&mut self) -> Result<ValidationResult> {
         if let Some(validator) = self.helper {
             self.changes.begin();

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -141,7 +141,7 @@ impl Highlighter for MatchingBracketHighlighter {
     }
 
     fn highlight_char(&self, line: &str, pos: usize) -> bool {
-        if line.len() != pos {
+        if pos == 0 || line.len() != pos {
             self.is_final.set(false);
         }
         // will highlight matching brace/bracket/parenthesis if it exists


### PR DESCRIPTION
Adding `final_highlight` method to `Highlighter` trait,
Updating MatchingBracketHighlighter to re-render line without highlighting

Issue https://github.com/kkawakam/rustyline/issues/726

Thank you.