### PR TITLE
feat: add openmpi compatibility feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ with-file-history = ["fd-lock"]
 with-sqlite-history = ["rusqlite"]
 with-fuzzy = ["skim"]
 case_insensitive_history_search = ["regex"]
+openmpi = []
 
 [[example]]
 name = "custom_key_bindings"

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -73,6 +73,13 @@ fn get_win_size(fd: RawFd) -> (usize, usize) {
 /// Check TERM environment variable to see if current term is in our
 /// unsupported list
 fn is_unsupported_term() -> bool {
+    #[cfg(feature = "openmpi")]
+    {
+        if std::env::var("OMPI_COMM_WORLD_SIZE").is_ok() {
+            return true;
+        }
+    }
+
     match std::env::var("TERM") {
         Ok(term) => {
             for iter in &UNSUPPORTED_TERM {


### PR DESCRIPTION
### What?

Simple OpenMPI compatibility fix.

### Why?

OpenMPI takes control of a lot of things terminal-wise, leading to any terminal effectively acting as if unsupported.

### How?

Feature flag + OpenMPI environment variable check during terminal support check.