### PR TITLE
Add option to disable newline after every command

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub struct Config {
     check_cursor_position: bool,
     /// Bracketed paste on unix platform
     enable_bracketed_paste: bool,
+    /// Write new line after accepting prompt input
+    enable_newline: bool,
 }
 
 impl Config {
@@ -193,6 +195,14 @@ impl Config {
     pub fn enable_bracketed_paste(&self) -> bool {
         self.enable_bracketed_paste
     }
+
+    /// Write new line after accepting prompt input
+    ///
+    /// By default, it's enabled.
+    #[must_use]
+    pub fn enable_newline(&self) -> bool {
+        self.enable_newline
+    }
 }
 
 impl Default for Config {
@@ -213,6 +223,7 @@ impl Default for Config {
             indent_size: 2,
             check_cursor_position: false,
             enable_bracketed_paste: true,
+            enable_newline: true,
         }
     }
 }
@@ -450,6 +461,15 @@ impl Builder {
         self
     }
 
+    /// Enable or disable newline after accepting prompt input
+    ///
+    /// By default, it's enabled.
+    #[must_use]
+    pub fn newline(mut self, enabled: bool) -> Self {
+        self.enable_newline(enabled);
+        self
+    }
+
     /// Builds a `Config` with the settings specified so far.
     #[must_use]
     pub fn build(self) -> Config {
@@ -566,5 +586,12 @@ pub trait Configurer {
     /// By default, it's enabled.
     fn enable_bracketed_paste(&mut self, enabled: bool) {
         self.config_mut().enable_bracketed_paste = enabled;
+    }
+
+    /// Enable or disable newline after accepting prompt input
+    ///
+    /// By default, it's enabled.
+    fn enable_newline(&mut self, enabled: bool) {
+        self.config_mut().enable_newline = enabled;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,7 +669,9 @@ impl<H: Helper, I: History> Editor<H, I> {
                 }
             }
             drop(guard); // disable_raw_mode(original_mode)?;
-            self.term.writeln()?;
+            if self.config.enable_newline() {
+                self.term.writeln()?;
+            }
             user_input
         } else {
             debug!(target: "rustyline", "stdin is not a tty");


### PR DESCRIPTION
I am writing a neovim clone in Rust and the unconditional `writeln()?` on the `readline_with` method makes my whole screen scroll up every time the user enters a command.

I added a new `enable_newline` flag to the config, which defaults to true and created all the wrapper methods needed. Finally I changed the `readline_with` method to check the flag before issuing the `writeln` command.