### PR TITLE
fix: bracketed paste multiline accept only one line

### DIFF
--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -233,7 +233,7 @@ impl PosixRawReader {
         pipe_reader: Option<PipeReader>,
     ) -> Self {
         Self {
-            tty_in: BufReader::with_capacity(1024, TtyIn { fd, sigwinch_pipe }),
+            tty_in: BufReader::with_capacity(1, TtyIn { fd, sigwinch_pipe }),
             timeout_ms: config.keyseq_timeout(),
             parser: Parser::new(),
             key_map,


### PR DESCRIPTION
https://github.com/SalHe/rustyline/blob/e001cab7a04c36f2a113ef465325feb4c0d77f7b/src/lib.rs#L707

`RawReader` has been created and dropped when finished `readline_edit`.
`BufReader` has capacity 1024, so it might read more than `readline_edit` consumed (submitted when encouterred '\r').

For example, 
```
1
2
```
has been pasted. The buffer reads `"\033[220~1\r2\r\033[221~\000"`.
When accepted '\r', command has been submitted.

After this, we cannot retrieve rest of pasted command.
So '2\r\033[221~\000' has been ignored.