### PR TITLE
Fix typeahead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ utf8parse = "0.2"
 skim = { version = "0.10", optional = true, default-features = false }
 signal-hook = { version = "0.3", optional = true, default-features = false }
 termios = { version = "0.3.3", optional = true }
+buffer-redux = { version = "1.0", optional = true, default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52.0", features = ["Win32_Foundation", "Win32_System_Console", "Win32_Security", "Win32_System_Threading", "Win32_UI_Input_KeyboardAndMouse"] }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -249,6 +249,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     #[cfg(target_arch = "x86_64")]
     fn size_of_event() {
         use core::mem::size_of;

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -12,6 +12,7 @@ use crate::layout::{Layout, Position};
 use crate::line_buffer::LineBuffer;
 use crate::{Cmd, Result};
 
+pub type Buffer = ();
 pub type KeyMap = ();
 pub type Mode = ();
 
@@ -22,6 +23,8 @@ impl RawMode for Mode {
 }
 
 impl<'a> RawReader for Iter<'a, KeyEvent> {
+    type Buffer = Buffer;
+
     fn wait_for_input(&mut self, single_esc_abort: bool) -> Result<Event> {
         self.next_key(single_esc_abort).map(Event::KeyPress)
     }
@@ -45,9 +48,15 @@ impl<'a> RawReader for Iter<'a, KeyEvent> {
     fn find_binding(&self, _: &KeyEvent) -> Option<Cmd> {
         None
     }
+
+    fn unbuffer(self) -> Option<Buffer> {
+        None
+    }
 }
 
 impl RawReader for IntoIter<KeyEvent> {
+    type Buffer = Buffer;
+
     fn wait_for_input(&mut self, single_esc_abort: bool) -> Result<Event> {
         self.next_key(single_esc_abort).map(Event::KeyPress)
     }
@@ -74,6 +83,10 @@ impl RawReader for IntoIter<KeyEvent> {
     }
 
     fn find_binding(&self, _: &KeyEvent) -> Option<Cmd> {
+        None
+    }
+
+    fn unbuffer(self) -> Option<Buffer> {
         None
     }
 }
@@ -160,6 +173,7 @@ pub struct DummyTerminal {
 }
 
 impl Term for DummyTerminal {
+    type Buffer = Buffer;
     type CursorGuard = ();
     type ExternalPrinter = DummyExternalPrinter;
     type KeyMap = KeyMap;
@@ -208,7 +222,7 @@ impl Term for DummyTerminal {
         Ok(((), ()))
     }
 
-    fn create_reader(&self, _: &Config, _: KeyMap) -> Self::Reader {
+    fn create_reader(&self, _: Option<Buffer>, _: &Config, _: KeyMap) -> Self::Reader {
         self.keys.clone().into_iter()
     }
 


### PR DESCRIPTION
Fix #690

To test, you need to activate the feature like this:
```diff
diff --git a/Cargo.toml b/Cargo.toml
index 7ac2645..fd27bb7 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ name = "input_validation"
 required-features = ["derive"]
 [[example]]
 name = "numeric_input"
-required-features = ["custom-bindings"]
+required-features = ["custom-bindings", "buffer-redux"]
 [[example]]
 name = "read_password"
 required-features = ["derive"]
```