### PR TITLE
Read cursor position with cluttered input

### DIFF
--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -1119,7 +1119,7 @@ impl Renderer for PosixRenderer {
     }
 
     fn move_cursor_at_leftmost(&mut self, rdr: &mut PosixRawReader) -> Result<()> {
-        if rdr.poll(PollTimeout::ZERO)? != 0 {
+        if rdr.poll(PollTimeout::ZERO)? != 0 { // TODO fill input buffer instead
             debug!(target: "rustyline", "cannot request cursor location");
             return Ok(());
         }
@@ -1130,7 +1130,7 @@ impl Renderer for PosixRenderer {
             || rdr.next_char()? != '\x1b'
             || rdr.next_char()? != '['
             || read_digits_until(rdr, ';')?.is_none()
-        {
+        { // TODO fill input buffer instead
             warn!(target: "rustyline", "cannot read initial cursor location");
             return Ok(());
         }

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -1119,7 +1119,8 @@ impl Renderer for PosixRenderer {
     }
 
     fn move_cursor_at_leftmost(&mut self, rdr: &mut PosixRawReader) -> Result<()> {
-        if rdr.poll(PollTimeout::ZERO)? != 0 { // TODO fill input buffer instead
+        if rdr.poll(PollTimeout::ZERO)? != 0 {
+            // TODO fill input buffer instead
             debug!(target: "rustyline", "cannot request cursor location");
             return Ok(());
         }
@@ -1130,7 +1131,8 @@ impl Renderer for PosixRenderer {
             || rdr.next_char()? != '\x1b'
             || rdr.next_char()? != '['
             || read_digits_until(rdr, ';')?.is_none()
-        { // TODO fill input buffer instead
+        {
+            // TODO fill input buffer instead
             warn!(target: "rustyline", "cannot read initial cursor location");
             return Ok(());
         }


### PR DESCRIPTION
Try to read cursor position even when stdin contains / receives user input. Currently, we fail so that we don't discard any user input. But we should be able to fill the `BufReader` instead...