### PR TITLE
User-specified continuation prompt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ required-features = ["custom-bindings", "derive"]
 name = "input_multiline"
 required-features = ["custom-bindings", "derive"]
 [[example]]
+name = "continuation_prompt"
+required-features = ["custom-bindings", "derive"]
+[[example]]
 name = "input_validation"
 required-features = ["derive"]
 [[example]]

--- a/examples/continuation_prompt.rs
+++ b/examples/continuation_prompt.rs
@@ -1,0 +1,35 @@
+use rustyline::validate::MatchingBracketValidator;
+use rustyline::{Cmd, Editor, EventHandler, KeyCode, KeyEvent, Modifiers, Result, highlight::Highlighter};
+use rustyline::{Completer, Helper, Hinter, Validator};
+use std::borrow::Cow::{self, Borrowed};
+#[derive(Completer, Helper, Hinter, Validator)]
+struct InputValidator {
+    #[rustyline(Validator)]
+    brackets: MatchingBracketValidator,
+}
+
+impl Highlighter for InputValidator {
+    fn continuation_prompt<'p, 'b>(
+        &self,
+        prompt: &'p str,
+        default: bool,
+    ) -> Option<Cow<'b, str>> {
+        Some(Borrowed(".... "))
+    }
+}
+
+fn main() -> Result<()> {
+    let h = InputValidator {
+        brackets: MatchingBracketValidator::new(),
+    };
+    let mut rl = Editor::new()?;
+    rl.set_helper(Some(h));
+    rl.bind_sequence(
+        KeyEvent(KeyCode::Char('s'), Modifiers::CTRL),
+        EventHandler::Simple(Cmd::Newline),
+    );
+    let input = rl.readline(">>>> ")?;
+    println!("Input:\n{input}");
+
+    Ok(())
+}

--- a/examples/continuation_prompt.rs
+++ b/examples/continuation_prompt.rs
@@ -28,8 +28,10 @@ fn main() -> Result<()> {
         KeyEvent(KeyCode::Char('s'), Modifiers::CTRL),
         EventHandler::Simple(Cmd::Newline),
     );
-    let input = rl.readline(">>>> ")?;
-    println!("Input:\n{input}");
+    loop {
+        let input = rl.readline(">>>> ")?;
+        println!("Input:\n{input}");
+    }
 
     Ok(())
 }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -11,10 +11,6 @@ use std::cell::Cell;
 /// Currently, the highlighted version *must* have the same display width as
 /// the original input.
 pub trait Highlighter {
-    #[allow(unused_variables)]
-    fn continuation_prompt<'p,'b>(&self, prompt: &'p str, default: bool) -> Option<Cow<'b, str>> {
-        None
-    }
     /// Takes the currently edited `line` with the cursor `pos`ition and
     /// returns the highlighted version (with ANSI color).
     ///
@@ -33,6 +29,13 @@ pub trait Highlighter {
     ) -> Cow<'b, str> {
         let _ = default;
         Borrowed(prompt)
+    }
+    /// Takes the `prompt` and
+    /// returns the continuation prompt.
+    /// See more at [PR #793](https://github.com/kkawakam/rustyline/pull/793)
+    #[allow(unused_variables)]
+    fn continuation_prompt<'p,'b>(&self, prompt: &'p str, default: bool) -> Option<Cow<'b, str>> {
+        None
     }
     /// Takes the `hint` and
     /// returns the highlighted version (with ANSI color).

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -11,6 +11,10 @@ use std::cell::Cell;
 /// Currently, the highlighted version *must* have the same display width as
 /// the original input.
 pub trait Highlighter {
+    #[allow(unused_variables)]
+    fn continuation_prompt<'p,'b>(&self, prompt: &'p str, default: bool) -> Option<Cow<'b, str>> {
+        None
+    }
     /// Takes the currently edited `line` with the cursor `pos`ition and
     /// returns the highlighted version (with ANSI color).
     ///

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -996,14 +996,18 @@ impl Renderer for PosixRenderer {
         let end_pos = new_layout.end;
 
         self.clear_old_rows(old_layout);
-
         if let Some(highlighter) = highlighter {
             // display the prompt
             self.buffer
                 .push_str(&highlighter.highlight_prompt(prompt, default_prompt));
+            // add continuation prompt to line if `highlighter.continuation_prompt` is not None
+            let line_str = match highlighter.continuation_prompt(prompt, default_prompt){
+                Some(continuation_prompt) => &line.as_str().replace('\n', &format!("\n{}", &continuation_prompt)),
+                None => line.as_str(),
+            };
             // display the input line
             self.buffer
-                .push_str(&highlighter.highlight(line, line.pos()));
+                .push_str(&highlighter.highlight(line_str, line.pos()));
         } else {
             // display the prompt
             self.buffer.push_str(prompt);

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -448,8 +448,14 @@ impl Renderer for ConsoleRenderer {
             // TODO handle ansi escape code (SetConsoleTextAttribute)
             // append the prompt
             col = self.wrap_at_eol(&highlighter.highlight_prompt(prompt, default_prompt), col);
+            // TODO need test for windows user
+            // add continuation prompt to line if `highlighter.continuation_prompt` is not None
+            let line_str = match highlighter.continuation_prompt(prompt, default_prompt){
+                Some(continuation_prompt) => &line.as_str().replace('\n', &format!("\n{}", &continuation_prompt)),
+                None => line.as_str(),
+            };
             // append the input line
-            col = self.wrap_at_eol(&highlighter.highlight(line, line.pos()), col);
+            col = self.wrap_at_eol(&highlighter.highlight(line_str, line.pos()), col);
         } else if self.colors_enabled {
             // append the prompt
             col = self.wrap_at_eol(prompt, col);


### PR DESCRIPTION
I believe the user-specified continuation prompt is a crucial feature, especially in scenarios where indentation is important (such as Python shell). I have implemented this feature by replacing the '\n' character in multi-line input with `\n`+`continuation_prompt` in display phase (in `Renderer::refresh_line`). This approach can cause a misalignment between the displayed cursor position and the actual editing position. To address this, I used `State::continuation_prompt_move_cursor` to correct these misalignments.

Additionally, I have added an example. You can run it with the following command:

``` shell
cargo run --release --example continuation_prompt --features="custom-bindings derive"
```
And the demo results:
![image](https://github.com/user-attachments/assets/d8531ad4-46b5-4620-bbc6-15e6ec41600e)

However, the current implementation only meets the minimum use case (i.e., continuation prompt works when pasting multi-line text into rustyline), but I have still encountered some bugs:

+ Cursor misalignment when inserting/deleting text.
+ Cursor misalignment when moving the cursor to the top or bottom of the input.
+ Cursor misalignment when using `Cmd::Newline`.

Since I'm not very familiar with rustyline, I want to share my current implementation and seek help and suggestions here. Thank you!