### PR TITLE
Refactor highlighting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ maintenance = { status = "actively-developed" }
 members = ["rustyline-derive"]
 
 [dependencies]
+# For highlighting
+# TODO make it optional
+ansi-str = { version = "0.8.0", optional = false }
 bitflags = "2.6"
 cfg-if = "1.0"
 # For file completion


### PR DESCRIPTION
Introduce `Style` and `StyledBlock` traits
And their `ansi-str` implementations

- [ ] Make `ansi-str` optional
- [ ] Fix `Highlighter` trait
- [ ] Fix rendering accordingly
- [ ] Check that new API works with an hardcoded continuation prompt.

See #793, #372
See https://github.com/gwenn/rustyline-notes/blob/master/src/design.md