### PR TITLE
Refactor highlighting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = ["rustyline-derive"]
 [dependencies]
 # For convenience, you can highlight the whole input buffer, ansi-str helps to split
 ansi-str = { version = "0.8.0", optional = true }
+anstyle = { version = "1.0.8", optional = true }
 bitflags = "2.6"
 cfg-if = "1.0"
 # For file completion
@@ -108,6 +109,7 @@ features = [
     "with-file-history",
     "with-fuzzy",
     "split-highlight",
+    "anstyle",
 ]
 all-features = false
 no-default-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ members = ["rustyline-derive"]
 
 [dependencies]
 # For convenience, you can highlight the whole input buffer, ansi-str helps to split
-ansi-str = { package="ansi-str-forked", path="../ansi-str", optional = true }
-# ansi-str = { package="ansi-str-forked", version = "0.8.0", optional = true }
+ansi-str = { package="ansi-str-forked", version = "0.8.0", optional = true }
 anstyle = { version = "1.0.8", optional = true }
 bitflags = "2.6"
 cfg-if = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ maintenance = { status = "actively-developed" }
 members = ["rustyline-derive"]
 
 [dependencies]
+# For highlighting
+# TODO make it optional
+ansi-str = { version = "0.8.0", optional = false }
 bitflags = "2.6"
 cfg-if = "1.0"
 # For file completion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ members = ["rustyline-derive"]
 
 [dependencies]
 # For convenience, you can highlight the whole input buffer, ansi-str helps to split
-ansi-str = { version = "0.8.0", optional = true }
+ansi-str = { package="ansi-str-forked", path="../ansi-str", optional = true }
+# ansi-str = { package="ansi-str-forked", version = "0.8.0", optional = true }
 anstyle = { version = "1.0.8", optional = true }
 bitflags = "2.6"
 cfg-if = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,8 @@ maintenance = { status = "actively-developed" }
 members = ["rustyline-derive"]
 
 [dependencies]
-# For highlighting
-# TODO make it optional
-ansi-str = { version = "0.8.0", optional = false }
+# For convenience, you can highlight the whole input buffer, ansi-str helps to split
+ansi-str = { version = "0.8.0", optional = true }
 bitflags = "2.6"
 cfg-if = "1.0"
 # For file completion
@@ -72,6 +71,9 @@ with-file-history = ["fd-lock"]
 with-sqlite-history = ["rusqlite"]
 with-fuzzy = ["skim"]
 case_insensitive_history_search = ["regex"]
+# For continuation prompt, indentation, scrolling
+# TODO make ansi-str optional
+split-highlight = ["ansi-str"]
 
 [[example]]
 name = "custom_key_bindings"
@@ -99,7 +101,14 @@ name = "sqlite_history"
 required-features = ["with-sqlite-history"]
 
 [package.metadata.docs.rs]
-features = ["custom-bindings", "derive", "with-dirs", "with-file-history", "with-fuzzy"]
+features = [
+    "custom-bindings",
+    "derive",
+    "with-dirs",
+    "with-file-history",
+    "with-fuzzy",
+    "split-highlight",
+]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -7,7 +7,6 @@ use unicode_width::UnicodeWidthChar;
 
 use super::{Context, Helper, Result};
 use crate::error::ReadlineError;
-use crate::highlight::Highlighter;
 use crate::hint::Hint;
 use crate::history::SearchDirection;
 use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
@@ -70,9 +69,9 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         }
     }
 
-    pub fn highlighter(&self) -> Option<&dyn Highlighter> {
+    pub fn highlighter(&self) -> Option<&'out H> {
         if self.out.colors_enabled() {
-            self.helper.map(|h| h as &dyn Highlighter)
+            self.helper
         } else {
             None
         }
@@ -168,11 +167,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             Info::Hint => self.hint.as_ref().map(|h| h.display()),
             Info::Msg(msg) => msg,
         };
-        let highlighter = if self.out.colors_enabled() {
-            self.helper.map(|h| h as &dyn Highlighter)
-        } else {
-            None
-        };
+        let highlighter = self.highlighter();
 
         let new_layout = self
             .out

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -115,17 +115,13 @@ pub trait Highlighter {
 
     /// Takes the currently edited `line` with the cursor `pos`ition and
     /// returns the styled blocks.
-    // #[cfg(feature = "split-highlight")]
-    // #[cfg_attr(docsrs, doc(cfg(feature = "split-highlight")))]
-    // fn highlight_line<'l>(&self, line: &'l str, pos: usize) -> impl Iterator<Item = impl StyledBlock> {
+    #[cfg(feature = "split-highlight")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "split-highlight")))]
+    // fn highlight_line<'l>(&self, line: &'l str, pos: usize) -> ansi_str::AnsiBlockIter<'l> {
+    fn highlight_line<'l>(&self, line: &'l str, pos: usize) -> impl Iterator<Item = impl 'l+StyledBlock> {
         // it doesn't seem possible to return an AnsiBlockIter directly
-        // StyledBlock::Whole(s)
-    // }
-    #[cfg(feature = "ansi-str")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "ansi-str")))]
-    fn highlight_line<'l>(&self, line: &'l str, pos: usize) -> ansi_str::AnsiBlockIter<'l> {
         let s = self.highlight(line, pos);
-        ansi_str::get_blocks(s)
+        Ansi(s).into_iter()
     }
 
     /// Takes the `prompt` and

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -80,6 +80,8 @@ impl StyledBlock for (anstyle::Style, &str) {
     }
 }
 
+#[cfg(feature = "split-highlight")]
+#[cfg_attr(docsrs, doc(cfg(feature = "split-highlight")))]
 struct Ansi<'s>(Cow<'s, str>);
 
 /// Ordered list of styled block

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -118,7 +118,11 @@ pub trait Highlighter {
     #[cfg(feature = "split-highlight")]
     #[cfg_attr(docsrs, doc(cfg(feature = "split-highlight")))]
     // fn highlight_line<'l>(&self, line: &'l str, pos: usize) -> ansi_str::AnsiBlockIter<'l> {
-    fn highlight_line<'l>(&self, line: &'l str, pos: usize) -> impl Iterator<Item = impl 'l+StyledBlock> {
+    fn highlight_line<'l>(
+        &self,
+        line: &'l str,
+        pos: usize,
+    ) -> impl Iterator<Item = impl 'l + StyledBlock> {
         // it doesn't seem possible to return an AnsiBlockIter directly
         let s = self.highlight(line, pos);
         Ansi(s).into_iter()
@@ -390,10 +394,21 @@ mod tests {
     pub fn styled_text() {
         use ansi_str::get_blocks;
 
-        let mut blocks = get_blocks(std::borrow::Cow::Borrowed("\x1b[1;32mHello \x1b[3mworld\x1b[23m!\x1b[0m"));
-        assert_eq!(blocks.next(), get_blocks(std::borrow::Cow::Borrowed("\x1b[1;32mHello ")).next());
-        assert_eq!(blocks.next(), get_blocks(std::borrow::Cow::Borrowed("\x1b[1;32m\x1b[3mworld")).next());
-        assert_eq!(blocks.next(), get_blocks(std::borrow::Cow::Borrowed("\x1b[1;32m!")).next());
+        let mut blocks = get_blocks(std::borrow::Cow::Borrowed(
+            "\x1b[1;32mHello \x1b[3mworld\x1b[23m!\x1b[0m",
+        ));
+        assert_eq!(
+            blocks.next(),
+            get_blocks(std::borrow::Cow::Borrowed("\x1b[1;32mHello ")).next()
+        );
+        assert_eq!(
+            blocks.next(),
+            get_blocks(std::borrow::Cow::Borrowed("\x1b[1;32m\x1b[3mworld")).next()
+        );
+        assert_eq!(
+            blocks.next(),
+            get_blocks(std::borrow::Cow::Borrowed("\x1b[1;32m!")).next()
+        );
         assert!(blocks.next().is_none())
     }
 }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -15,6 +15,28 @@ pub trait Style {
     /// Produce a ansi sequences which ends the graphic mode
     fn end(&self) -> impl Display;
 }
+#[cfg(feature = "ansi-str")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ansi-str")))]
+impl Style for ansi_str::Style {
+    fn start(&self) -> impl Display {
+        self.start()
+    }
+
+    fn end(&self) -> impl Display {
+        self.end()
+    }
+}
+#[cfg(feature = "anstyle")]
+#[cfg_attr(docsrs, doc(cfg(feature = "anstyle")))]
+impl Style for anstyle::Style {
+    fn start(&self) -> impl Display {
+        self.render()
+    }
+
+    fn end(&self) -> impl Display {
+        self.render_reset()
+    }
+}
 
 /// Styled text
 #[cfg(feature = "split-highlight")]
@@ -31,18 +53,6 @@ pub trait StyledBlock {
     where
         Self: Sized;
 }
-
-#[cfg(feature = "ansi-str")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ansi-str")))]
-impl Style for ansi_str::Style {
-    fn start(&self) -> impl Display {
-        self.start()
-    }
-
-    fn end(&self) -> impl Display {
-        self.end()
-    }
-}
 #[cfg(feature = "ansi-str")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ansi-str")))]
 impl StyledBlock for ansi_str::AnsiBlock<'_> {
@@ -54,6 +64,19 @@ impl StyledBlock for ansi_str::AnsiBlock<'_> {
 
     fn style(&self) -> &Self::Style {
         self.style()
+    }
+}
+#[cfg(feature = "anstyle")]
+#[cfg_attr(docsrs, doc(cfg(feature = "anstyle")))]
+impl StyledBlock for (anstyle::Style, &str) {
+    type Style = anstyle::Style;
+
+    fn text(&self) -> &str {
+        self.1
+    }
+
+    fn style(&self) -> &Self::Style {
+        &self.0
     }
 }
 

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -47,14 +47,14 @@ pub trait Renderer {
 
     /// Display `prompt`, line and cursor in terminal output
     #[allow(clippy::too_many_arguments)]
-    fn refresh_line(
+    fn refresh_line<H: Highlighter>(
         &mut self,
         prompt: &str,
         line: &LineBuffer,
         hint: Option<&str>,
         old_layout: &Layout,
         new_layout: &Layout,
-        highlighter: Option<&dyn Highlighter>,
+        highlighter: Option<&H>,
     ) -> Result<()>;
 
     /// Compute layout for rendering prompt + line + some info (either hint,
@@ -126,14 +126,14 @@ impl<'a, R: Renderer + ?Sized> Renderer for &'a mut R {
         (**self).move_cursor(old, new)
     }
 
-    fn refresh_line(
+    fn refresh_line<H: Highlighter>(
         &mut self,
         prompt: &str,
         line: &LineBuffer,
         hint: Option<&str>,
         old_layout: &Layout,
         new_layout: &Layout,
-        highlighter: Option<&dyn Highlighter>,
+        highlighter: Option<&H>,
     ) -> Result<()> {
         (**self).refresh_line(prompt, line, hint, old_layout, new_layout, highlighter)
     }

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -100,14 +100,14 @@ impl Renderer for Sink {
         Ok(())
     }
 
-    fn refresh_line(
+    fn refresh_line<H: Highlighter>(
         &mut self,
         _prompt: &str,
         _line: &LineBuffer,
         _hint: Option<&str>,
         _old_layout: &Layout,
         _new_layout: &Layout,
-        _highlighter: Option<&dyn Highlighter>,
+        _highlighter: Option<&H>,
     ) -> Result<()> {
         Ok(())
     }

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -1678,7 +1678,7 @@ mod test {
     #[derive(Debug)]
     struct DummyHighlighter;
     impl crate::highlight::Highlighter for DummyHighlighter {}
-    
+
     #[test]
     fn test_line_wrap() {
         let mut out = PosixRenderer::new(libc::STDOUT_FILENO, 4, true, BellStyle::default());
@@ -1698,7 +1698,7 @@ mod test {
         let new_layout = out.compute_layout(prompt_size, default_prompt, &line, None);
         assert_eq!(Position { col: 1, row: 1 }, new_layout.cursor);
         assert_eq!(new_layout.cursor, new_layout.end);
-        
+
         out.refresh_line::<DummyHighlighter>(prompt, &line, None, &old_layout, &new_layout, None)
             .unwrap();
         #[rustfmt::skip]


### PR DESCRIPTION
See https://github.com/kkawakam/rustyline/pull/795

1. Use [ansi-str-fork](https://github.com/zao111222333/ansi-str) to introduce 
``` rust
fn get_blocks<'a>(text: Cow<'a, str>) -> AnsiBlockIter<'a>
```
  (see more at [ansitok-fork](https://github.com/zao111222333/ansitok))
2. Fix `highlight_line` function signature into:
``` rust
fn highlight_line<'l>(&self, line: &'l str, pos: usize) -> impl Iterator<Item = impl 'l+StyledBlock>
```

3. The new `highlight_line` function signature conflicts to the `Option<&dyn Highligher>` due to https://doc.rust-lang.org/reference/items/traits.html#object-safety . So use generic `<H: Highligher>` + `Option<&H>` to replace `Option<&dyn Highligher>`