### PR TITLE
Don't call poll when keyseq_timeout is set to 0 to avoid broken poll implementation for devices on MacOS.

### DIFF
--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -799,16 +799,26 @@ impl RawReader for PosixRawReader {
             } else {
                 self.timeout_ms
             };
-            match self.poll(timeout_ms) {
-                Ok(0) => {
-                    // single escape
-                }
-                Ok(_) => {
-                    // escape sequence
+            if timeout_ms == PollTimeout::ZERO {
+                // Don't bother polling at all if [timeout_ms] is 0. (Also because
+                // calling [poll] on /dev/tty on MacOS is broken.) If there's any
+                // buffered input we'll treat it as an escape sequence, and otherwise
+                // we'll assume it's a single escape.
+                if !self.tty_in.buffer().is_empty() {
                     key = self.escape_sequence()?
                 }
-                // Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
-                Err(e) => return Err(e),
+            } else {
+                match self.poll(timeout_ms) {
+                    Ok(0) => {
+                        // single escape
+                    }
+                    Ok(_) => {
+                        // escape sequence
+                        key = self.escape_sequence()?
+                    }
+                    // Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                    Err(e) => return Err(e),
+                }
             }
         }
         debug!(target: "rustyline", "c: {:?} => key: {:?}", c, key);


### PR DESCRIPTION
The poll system call is [broken on MacOS](https://nathancraddock.com/blog/macos-dev-tty-polling/) and doesn't work properly for devices, such as `/dev/tty`.

As a result, reading single escapes is broken when using `Behavior::PreferTerm`, which causes `rustyline` to read from `/dev/tty`. After reading a single escape character, the subsequent call to `poll` will always return `Ok(1)`, so `rustyline` will try to parse an escape sequence.

This PR makes a small change to at least improve the behavior when `keyseq_timeout` is set to `Some(0)`. In this case, we bypass the call to `poll` altogether, and instead check whether there is any buffered input to determine whether a single escape keypress has been entered or if an escape sequence has been entered, which is a pretty effective heuristic.

I don't know if there's any good workaround for the broken poll implementation when `keyseq_timeout` is non-zero, but this is at least an improvement.

This should resolve https://github.com/kkawakam/rustyline/issues/607.