### PR TITLE
Support for line continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
         println!("No previous history.");
     }
     loop {
-        let readline = rl.readline(">> ");
+        let readline = rl.readline(">> ", "");
         match readline {
             Ok(line) => {
                 rl.add_history_entry(line.as_str());

--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
     );
 
     loop {
-        let line = rl.readline("> ")?;
+        let line = rl.readline("> ", "")?;
         rl.add_history_entry(line.as_str())?;
         println!("Line: {line}");
     }

--- a/examples/diy_hints.rs
+++ b/examples/diy_hints.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
     rl.set_helper(Some(h));
 
     loop {
-        let input = rl.readline("> ")?;
+        let input = rl.readline("> ", "")?;
         println!("input: {input}");
     }
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -73,7 +73,7 @@ fn main() -> rustyline::Result<()> {
     loop {
         let p = format!("{count}> ");
         rl.helper_mut().expect("No helper").colored_prompt = format!("\x1b[1;32m{p}\x1b[0m");
-        let readline = rl.readline(&p);
+        let readline = rl.readline(&p, "");
         match readline {
             Ok(line) => {
                 rl.add_history_entry(line.as_str())?;

--- a/examples/external_print.rs
+++ b/examples/external_print.rs
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
     });
 
     loop {
-        let line = rl.readline("> ")?;
+        let line = rl.readline("> ", "")?;
         rl.add_history_entry(line.as_str())?;
         println!("Line: {line}");
     }

--- a/examples/input_multiline.rs
+++ b/examples/input_multiline.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
         EventHandler::Simple(Cmd::Newline),
     );
 
-    let input = rl.readline("> ")?;
+    let input = rl.readline("ml> ", "... ")?;
     println!("Input: {input}");
 
     Ok(())

--- a/examples/input_validation.rs
+++ b/examples/input_validation.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
     let mut rl = Editor::new()?;
     rl.set_helper(Some(h));
 
-    let input = rl.readline("> ")?;
+    let input = rl.readline("> ", "")?;
     println!("Input: {input}");
     Ok(())
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -5,7 +5,7 @@ fn main() -> Result<()> {
     env_logger::init();
     let mut rl = DefaultEditor::new()?;
     loop {
-        let line = rl.readline("> ")?; // read
+        let line = rl.readline("> ", "")?; // read
         println!("Line: {line}"); // eval / print
     } // loop
 }

--- a/examples/numeric_input.rs
+++ b/examples/numeric_input.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
     );
 
     loop {
-        let line = rl.readline("> ")?;
+        let line = rl.readline("> ", "")?;
         println!("Num: {line}");
     }
 }

--- a/examples/read_password.rs
+++ b/examples/read_password.rs
@@ -35,14 +35,14 @@ fn main() -> Result<()> {
     let mut rl = Editor::new()?;
     rl.set_helper(Some(h));
 
-    let username = rl.readline("Username:")?;
+    let username = rl.readline("Username:", "")?;
     println!("Username: {username}");
 
     rl.helper_mut().expect("No helper").masking = true;
     rl.set_color_mode(ColorMode::Forced); // force masking
     rl.set_auto_add_history(false); // make sure password is not added to history
     let mut guard = rl.set_cursor_visibility(false)?;
-    let passwd = rl.readline("Password:")?;
+    let passwd = rl.readline("Password:", "")?;
     guard.take();
     println!("Secret: {passwd}");
     Ok(())

--- a/examples/sqlite_history.rs
+++ b/examples/sqlite_history.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
     };
     let mut rl: Editor<(), _> = Editor::with_history(config, history)?;
     loop {
-        let line = rl.readline("> ")?;
+        let line = rl.readline("> ", "")?;
         println!("{line}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ```
 //! let mut rl = rustyline::DefaultEditor::new()?;
-//! let readline = rl.readline(">> ");
+//! let readline = rl.readline(">> ", "");
 //! match readline {
 //!     Ok(line) => println!("Line: {:?}", line),
 //!     Err(_) => println!("No input"),
@@ -884,7 +884,7 @@ impl<H: Helper, I: History> Editor<H, I> {
     /// Iterator ends at [EOF](ReadlineError::Eof).
     /// ```
     /// let mut rl = rustyline::DefaultEditor::new()?;
-    /// for readline in rl.iter("> ") {
+    /// for readline in rl.iter("> ", "") {
     ///     match readline {
     ///         Ok(line) => {
     ///             println!("Line: {}", line);

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -157,7 +157,7 @@ fn newline_key() {
 fn eof_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
         let mut editor = init_editor(*mode, &[E::ctrl('D')]);
-        let err = editor.readline(">>");
+        let err = editor.readline(">>", "");
         assert_matches!(err, Err(ReadlineError::Eof));
     }
     assert_line(
@@ -176,16 +176,16 @@ fn eof_key() {
 fn interrupt_key() {
     for mode in &[EditMode::Emacs, EditMode::Vi] {
         let mut editor = init_editor(*mode, &[E::ctrl('C')]);
-        let err = editor.readline(">>");
+        let err = editor.readline(">>", "");
         assert_matches!(err, Err(ReadlineError::Interrupted));
 
         let mut editor = init_editor(*mode, &[E::ctrl('C')]);
-        let err = editor.readline_with_initial(">>", ("Hi", ""));
+        let err = editor.readline_with_initial(">>", "", ("Hi", ""));
         assert_matches!(err, Err(ReadlineError::Interrupted));
         if *mode == EditMode::Vi {
             // vi command mode
             let mut editor = init_editor(*mode, &[E::ESC, E::ctrl('C')]);
-            let err = editor.readline_with_initial(">>", ("Hi", ""));
+            let err = editor.readline_with_initial(">>", "", ("Hi", ""));
             assert_matches!(err, Err(ReadlineError::Interrupted));
         }
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -104,7 +104,7 @@ fn complete_symbol() {
 // `expected_line`: line after enter key
 fn assert_line(mode: EditMode, keys: &[KeyEvent], expected_line: &str) {
     let mut editor = init_editor(mode, keys);
-    let actual_line = editor.readline(">>").unwrap();
+    let actual_line = editor.readline(">>", "").unwrap();
     assert_eq!(expected_line, actual_line);
 }
 
@@ -118,7 +118,7 @@ fn assert_line_with_initial(
     expected_line: &str,
 ) {
     let mut editor = init_editor(mode, keys);
-    let actual_line = editor.readline_with_initial(">>", initial).unwrap();
+    let actual_line = editor.readline_with_initial(">>", "", initial).unwrap();
     assert_eq!(expected_line, actual_line);
 }
 
@@ -127,7 +127,7 @@ fn assert_line_with_initial(
 // `expected`: line status before enter key: strings before and after cursor
 fn assert_cursor(mode: EditMode, initial: (&str, &str), keys: &[KeyEvent], expected: (&str, &str)) {
     let mut editor = init_editor(mode, keys);
-    let actual_line = editor.readline_with_initial("", initial).unwrap();
+    let actual_line = editor.readline_with_initial("", "", initial).unwrap();
     assert_eq!(expected.0.to_owned() + expected.1, actual_line);
     assert_eq!(expected.0.len(), editor.term.cursor);
 }
@@ -146,7 +146,7 @@ fn assert_history(
     for entry in entries {
         editor.history.add(entry).unwrap();
     }
-    let actual_line = editor.readline(prompt).unwrap();
+    let actual_line = editor.readline(prompt, "").unwrap();
     assert_eq!(expected.0.to_owned() + expected.1, actual_line);
     if prompt.is_empty() {
         assert_eq!(expected.0.len(), editor.term.cursor);

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -54,6 +54,7 @@ pub trait Renderer {
         old_layout: &Layout,
         new_layout: &Layout,
         highlighter: Option<&dyn Highlighter>,
+        continuation: &str,
     ) -> Result<()>;
 
     /// Compute layout for rendering prompt + line + some info (either hint,
@@ -65,18 +66,19 @@ pub trait Renderer {
         default_prompt: bool,
         line: &LineBuffer,
         info: Option<&str>,
+        continuation: &str,
     ) -> Layout {
         // calculate the desired position of the cursor
         let pos = line.pos();
-        let cursor = self.calculate_position(&line[..pos], prompt_size);
+        let cursor = self.calculate_position(&line[..pos], prompt_size, continuation);
         // calculate the position of the end of the input line
         let mut end = if pos == line.len() {
             cursor
         } else {
-            self.calculate_position(&line[pos..], cursor)
+            self.calculate_position(&line[pos..], cursor, continuation)
         };
         if let Some(info) = info {
-            end = self.calculate_position(info, end);
+            end = self.calculate_position(info, end, continuation);
         }
 
         let new_layout = Layout {
@@ -92,7 +94,7 @@ pub trait Renderer {
 
     /// Calculate the number of columns and rows used to display `s` on a
     /// `cols` width terminal starting at `orig`.
-    fn calculate_position(&self, s: &str, orig: Position) -> Position;
+    fn calculate_position(&self, s: &str, orig: Position, continuation: &str) -> Position;
 
     fn write_and_flush(&mut self, buf: &str) -> Result<()>;
 

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -108,11 +108,12 @@ impl Renderer for Sink {
         _old_layout: &Layout,
         _new_layout: &Layout,
         _highlighter: Option<&dyn Highlighter>,
+        _continuation: &str,
     ) -> Result<()> {
         Ok(())
     }
 
-    fn calculate_position(&self, s: &str, orig: Position) -> Position {
+    fn calculate_position(&self, s: &str, orig: Position, _c: &str) -> Position {
         let mut pos = orig;
         pos.col += s.len();
         pos


### PR DESCRIPTION
Adds support for line continuation in prompts, which can be used to achieve rectangular prompts.

Supersedes #338 & #372

![image](https://github.com/user-attachments/assets/b70f43bf-4fc0-4033-8949-160cf5cb7a00)

Review notes:
- I suggest reviewing commits separately,
- To check the thing out, run `input_multiline` example,
- The `breaking:` commit is the only breaking change that adds `continuation` param to `fn readline`. I'm not fully confident that this feature is worth breaking the API over, but it seems most reasonable public API to me. That's because the continuation is usually dependent on the prompt.
- Alternative public API would `fn Editor::set_continuation` function. In that case, I can revert last two commits.

I'm very invested in landing this PR and I'm willing to make changes.

TODO:

- [ ] windows support
- [ ] documentation
- [ ] tests