### PR TITLE
Keep track of layout of input buffer spans

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -21,13 +21,135 @@ impl Ord for Position {
     }
 }
 
+/// Layout of a substring of the input buffer
+#[derive(Debug)]
+pub struct SpanLayout {
+    /// Offset of the start of the substring in the input buffer
+    pub offset: usize,
+
+    /// Position on of the start of the span
+    pub pos: Position,
+}
+
+/// All positions are relative to start of the prompt == origin (col: 0, row: 0)
 #[derive(Debug, Default)]
 pub struct Layout {
-    /// Prompt Unicode/visible width and height
-    pub prompt_size: Position,
     pub default_prompt: bool,
+
     /// Cursor position (relative to the start of the prompt)
+    /// - cursor.row >= spans[0].pos.row
+    /// - if cursor.row > spans[0].pos.row then cursor.col >= spans[0].pos.col
     pub cursor: Position,
-    /// Number of rows used so far (from start of prompt to end of input)
+
+    /// Number of rows used so far (from start of prompt to end
+    /// of input or hint)
+    /// - cursor <= end
     pub end: Position,
+
+    /// Layout of the input buffer, broken into spans.
+    /// - non-empty,
+    /// - first element has offset 0,
+    pub spans: Vec<SpanLayout>,
+}
+
+impl Layout {
+    pub fn find_span_by_row(&self, row: usize) -> Option<(usize, &SpanLayout)> {
+        match self.spans.binary_search_by_key(&row, |span| span.pos.row) {
+            Ok(i) => Some((i, &self.spans[i])),
+            Err(_) => None,
+        }
+    }
+
+    /// Find the span of an offset in input buffer.
+    pub fn find_span_by_offset(&self, offset: usize) -> (usize, &SpanLayout) {
+        match self.spans.binary_search_by_key(&offset, |span| span.offset) {
+            Ok(i) => (i, &self.spans[i]),
+            Err(mut i) => {
+                if i == 0 {
+                    unreachable!("first span must have offset 0")
+                }
+                i -= 1;
+                (i, &self.spans[i])
+            }
+        }
+    }
+
+    /// Compute layout for rendering prompt + line + some info (either hint,
+    /// validation msg, ...). on the screen. Depending on screen width, line
+    /// wrapping may be applied.
+    pub fn compute(
+        renderer: &impl crate::tty::Renderer,
+        prompt_size: Position,
+        default_prompt: bool,
+        line: &crate::line_buffer::LineBuffer,
+        info: Option<&str>,
+    ) -> Layout {
+        let mut spans = Vec::with_capacity(line.len());
+
+        let buf = line.as_str();
+        let cursor_offset = line.pos();
+
+        let mut cursor = None;
+        let mut curr_position = prompt_size;
+
+        // iterate over input buffer lines
+        let mut line_start_offset = 0;
+        let end = loop {
+            spans.push(SpanLayout {
+                offset: line_start_offset,
+                pos: curr_position,
+            });
+
+            // find the end of input line
+            let line_end_offset = buf[line_start_offset..]
+                .find('\n')
+                .map_or(buf.len(), |x| x + line_start_offset);
+
+            // find cursor position
+            if line_start_offset <= cursor_offset {
+                cursor = Some(
+                    renderer
+                        .calculate_position(&line[line_start_offset..cursor_offset], curr_position),
+                );
+            }
+
+            // find end of line position
+            let line_end = if cursor_offset == line_end_offset {
+                // optimization
+                cursor.unwrap()
+            } else {
+                renderer
+                    .calculate_position(&line[line_start_offset..line_end_offset], curr_position)
+            };
+
+            if line_end_offset == buf.len() {
+                break line_end;
+            } else {
+                curr_position = Position {
+                    row: line_end.row + 1,
+                    col: 0,
+                };
+                line_start_offset = line_end_offset + 1;
+            }
+        };
+        let cursor = cursor.unwrap_or(end);
+
+        // layout info after the input
+        let end = if let Some(info) = info {
+            renderer.calculate_position(info, end)
+        } else {
+            end
+        };
+
+        let new_layout = Layout {
+            default_prompt,
+            cursor,
+            end,
+            spans,
+        };
+        debug_assert!(!new_layout.spans.is_empty());
+        debug_assert!(new_layout.spans[0].offset == 0);
+        debug_assert!(new_layout.cursor <= new_layout.end);
+        new_layout
+    }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -129,7 +129,10 @@ fn assert_cursor(mode: EditMode, initial: (&str, &str), keys: &[KeyEvent], expec
     let mut editor = init_editor(mode, keys);
     let actual_line = editor.readline_with_initial("", initial).unwrap();
     assert_eq!(expected.0.to_owned() + expected.1, actual_line);
-    assert_eq!(expected.0.len(), editor.term.cursor);
+    assert_eq!(
+        expected.0.len() - expected.0.rfind('\n').map_or(0, |x| x + 1),
+        editor.term.cursor
+    );
 }
 
 // `entries`: history entries before `keys` pressed

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -56,42 +56,9 @@ pub trait Renderer {
         highlighter: Option<&dyn Highlighter>,
     ) -> Result<()>;
 
-    /// Compute layout for rendering prompt + line + some info (either hint,
-    /// validation msg, ...). on the screen. Depending on screen width, line
-    /// wrapping may be applied.
-    fn compute_layout(
-        &self,
-        prompt_size: Position,
-        default_prompt: bool,
-        line: &LineBuffer,
-        info: Option<&str>,
-    ) -> Layout {
-        // calculate the desired position of the cursor
-        let pos = line.pos();
-        let cursor = self.calculate_position(&line[..pos], prompt_size);
-        // calculate the position of the end of the input line
-        let mut end = if pos == line.len() {
-            cursor
-        } else {
-            self.calculate_position(&line[pos..], cursor)
-        };
-        if let Some(info) = info {
-            end = self.calculate_position(info, end);
-        }
-
-        let new_layout = Layout {
-            prompt_size,
-            default_prompt,
-            cursor,
-            end,
-        };
-        debug_assert!(new_layout.prompt_size <= new_layout.cursor);
-        debug_assert!(new_layout.cursor <= new_layout.end);
-        new_layout
-    }
-
     /// Calculate the number of columns and rows used to display `s` on a
     /// `cols` width terminal starting at `orig`.
+    // FIXME
     fn calculate_position(&self, s: &str, orig: Position) -> Position;
 
     fn write_and_flush(&mut self, buf: &str) -> Result<()>;

--- a/src/tty/unix.rs
+++ b/src/tty/unix.rs
@@ -1642,6 +1642,7 @@ mod termios_ {
 mod test {
     use super::{Position, PosixRenderer, PosixTerminal, Renderer};
     use crate::config::BellStyle;
+    use crate::layout::Layout;
     use crate::line_buffer::{LineBuffer, NoListener};
 
     #[test]
@@ -1682,7 +1683,7 @@ mod test {
         let prompt_size = out.calculate_position(prompt, Position::default());
 
         let mut line = LineBuffer::init("", 0);
-        let old_layout = out.compute_layout(prompt_size, default_prompt, &line, None);
+        let old_layout = Layout::compute(&out, prompt_size, default_prompt, &line, None);
         assert_eq!(Position { col: 2, row: 0 }, old_layout.cursor);
         assert_eq!(old_layout.cursor, old_layout.end);
 
@@ -1690,7 +1691,7 @@ mod test {
             Some(true),
             line.insert('a', out.cols - prompt_size.col + 1, &mut NoListener)
         );
-        let new_layout = out.compute_layout(prompt_size, default_prompt, &line, None);
+        let new_layout = Layout::compute(&out, prompt_size, default_prompt, &line, None);
         assert_eq!(Position { col: 1, row: 1 }, new_layout.cursor);
         assert_eq!(new_layout.cursor, new_layout.end);
         out.refresh_line(prompt, &line, None, &old_layout, &new_layout, None)


### PR DESCRIPTION
Builds on top of https://github.com/gwenn/rustyline/pull/2/files

When moving cursor up or down a line, it should not change *columns*. To be precise, it should not change *columns on the screen*.

Current implementation was making sure it was not changing number of graphemes from the beginning of the line. This works correctly, as long as prompt is empty. If it so not empty, the cursor moves up and down like this:

```
> c_mmand \
argument1
```
```
> command \
a_gument1
```

This PR changes this behavior to this:

```
> c_mmand \
argument1
```
```
> command \
arg_ment1
```

This change is also needed for continuation prompts.

---

To make this happen, I had to:
- keep track of layout of input buffer spans (one for each line in the input buffer),
- refactor `Renderer::compute_layout` into `Layout::compute`,
- change `LineBuffer::move_to_line` to take `Layout` as a parameter,
- fix `State::move_cursor`.