### PR TITLE
Use is_unsupported_term on both unix and windows

### DIFF
--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -718,9 +718,8 @@ impl Term for Console {
         })
     }
 
-    /// Checking for an unsupported TERM in windows is a no-op
     fn is_unsupported(&self) -> bool {
-        false
+        super::is_unsupported_term()
     }
 
     fn is_input_tty(&self) -> bool {


### PR DESCRIPTION
Fix #832 