### PR TITLE
Added noline to comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,19 +213,21 @@ $ infocmp
 
 ## Similar projects
 
-| Library            | Lang    | OS     | Term | Unicode | History       | Completion | Keymap        | Kill Ring | Undo | Colors     | Hint/Auto suggest |
-| ------------------ | ------- | ------ | ---- | ------- | ------------- | ---------- | ------------- | --------- | ---- | ---------- | ----------------- |
-| [go-prompt][]      | Go      | Ux/win | ANSI | Yes     | Yes           | any        | Emacs/prog    | No        | No   | Yes        | Yes               |
-| [Haskeline][]      | Haskell | Ux/Win | Any  | Yes     | Yes           | any        | Emacs/vi/conf | Yes       | Yes  | ?          | ?                 |
-| [isocline][]       | C       | Ux/Win | ANSI | Yes     | Yes           | any        | Emacs         | No        | Yes  | Yes        | Yes               |
-| [linefeed][]       | Rust    | Ux/Win | Any  |         | Yes           | any        | Emacs/conf    | Yes       | No   | ?          | No                |
-| [linenoise][]      | C       | Ux     | ANSI | No      | Yes           | only line  | Emacs         | No        | No   | Ux         | Yes               |
-| [Liner][]          | Rust    | Ux     | ANSI |         | No inc search | only word  | Emacs/vi/prog | No        | Yes  | Ux         | History based     |
-| [prompt_toolkit][] | Python  | Ux/Win | ANSI | Yes     | Yes           | any        | Emacs/vi/conf | Yes       | Yes  | Ux/Win     | Yes               |
-| [reedline][]       | Rust    | Ux/Win | ANSI | Yes     | Yes           | any        | Emacs/vi/bind | No        | Yes  | Ux/Win     | Yes               |
-| [replxx][]         | C/C++   | Ux/Win | ANSI | Yes     | Yes           | only line  | Emacs         | Yes       | No   | Ux/Win     | Yes               |
-| Rustyline          | Rust    | Ux/Win | ANSI | Yes     | Yes           | any        | Emacs/vi/bind | Yes       | Yes  | Ux/Win 10+ | Yes               |
-| [termwiz][]        | Rust    | Ux/Win | Any  | ?       | Yes           | any        | Emacs         | No        | No   | Ux/Win     | No                |
+| Library            | Lang    | OS      | Term | Unicode | History       | Completion | Keymap        | Kill Ring | Undo | Colors     | Hint/Auto suggest |
+|--------------------|---------|---------|------|---------|---------------|------------|---------------|-----------|------|------------|-------------------|
+| [go-prompt][]      | Go      | Ux/win  | ANSI | Yes     | Yes           | any        | Emacs/prog    | No        | No   | Yes        | Yes               |
+| [Haskeline][]      | Haskell | Ux/Win  | Any  | Yes     | Yes           | any        | Emacs/vi/conf | Yes       | Yes  | ?          | ?                 |
+| [isocline][]       | C       | Ux/Win  | ANSI | Yes     | Yes           | any        | Emacs         | No        | Yes  | Yes        | Yes               |
+| [linefeed][]       | Rust    | Ux/Win  | Any  |         | Yes           | any        | Emacs/conf    | Yes       | No   | ?          | No                |
+| [linenoise][]      | C       | Ux      | ANSI | No      | Yes           | only line  | Emacs         | No        | No   | Ux         | Yes               |
+| [Liner][]          | Rust    | Ux      | ANSI |         | No inc search | only word  | Emacs/vi/prog | No        | Yes  | Ux         | History based     |
+| [noline][]         | Rust    | no\_std | ANSI | Yes     | Yes           | No         | Emacs         | No        | No   | Yes        | No                |
+| [prompt_toolkit][] | Python  | Ux/Win  | ANSI | Yes     | Yes           | any        | Emacs/vi/conf | Yes       | Yes  | Ux/Win     | Yes               |
+| [reedline][]       | Rust    | Ux/Win  | ANSI | Yes     | Yes           | any        | Emacs/vi/bind | No        | Yes  | Ux/Win     | Yes               |
+| [replxx][]         | C/C++   | Ux/Win  | ANSI | Yes     | Yes           | only line  | Emacs         | Yes       | No   | Ux/Win     | Yes               |
+| Rustyline          | Rust    | Ux/Win  | ANSI | Yes     | Yes           | any        | Emacs/vi/bind | Yes       | Yes  | Ux/Win 10+ | Yes               |
+| [termwiz][]        | Rust    | Ux/Win  | Any  | ?       | Yes           | any        | Emacs         | No        | No   | Ux/Win     | No                |
+
 
 [go-prompt]: https://github.com/c-bata/go-prompt
 [haskeline]: https://github.com/judah/haskeline
@@ -237,6 +239,7 @@ $ infocmp
 [reedline]: https://github.com/nushell/reedline
 [replxx]: https://github.com/AmokHuginnsson/replxx
 [termwiz]: https://github.com/wez/wezterm/tree/main/termwiz
+[noline]: https://github.com/rustne-kretser/noline
 
 ## Multi line support
 


### PR DESCRIPTION
`noline` is a `no_std` line editor written in Rust. I'm the maintainer, so this is shameless promotion on my part.