### PR TITLE
reuse string

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -17,7 +17,7 @@ pub enum Status {
 
 pub fn execute<H: Helper>(
     cmd: Cmd,
-    s: &mut State<'_, '_, H>,
+    s: &mut State<'_, '_, '_, H>,
     input_state: &InputState,
     kill_ring: &mut KillRing,
     config: &Config,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -13,7 +13,8 @@ use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
 use crate::keymap::{InputState, Invoke, Refresher};
 use crate::layout::{cwidh, Layout, Position};
 use crate::line_buffer::{
-    ChangeListener, DeleteListener, Direction, LineBuffer, LineBufferKind, NoListener, WordAction, MAX_LINE,
+    ChangeListener, DeleteListener, Direction, LineBuffer, NoListener, WordAction,
+    MAX_LINE,
 };
 use crate::tty::{Renderer, Term, Terminal};
 use crate::undo::Changeset;
@@ -24,8 +25,8 @@ use crate::KillRing;
 /// Implement rendering.
 pub struct State<'buffer, 'out, 'prompt, H: Helper> {
     pub out: &'out mut <Terminal as Term>::Writer,
-    prompt: &'prompt str,  // Prompt to display (rl_prompt)
-    prompt_size: Position, // Prompt Unicode/visible width and height
+    prompt: &'prompt str,          // Prompt to display (rl_prompt)
+    prompt_size: Position,         // Prompt Unicode/visible width and height
     pub line: LineBuffer<'buffer>, // Edited line buffer
     pub layout: Layout,
     saved_line_for_history: LineBuffer<'buffer>, // Current edited line before history browsing

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -13,8 +13,7 @@ use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
 use crate::keymap::{InputState, Invoke, Refresher};
 use crate::layout::{cwidh, Layout, Position};
 use crate::line_buffer::{
-    ChangeListener, DeleteListener, Direction, LineBuffer, NoListener, WordAction,
-    MAX_LINE,
+    ChangeListener, DeleteListener, Direction, LineBuffer, NoListener, WordAction, MAX_LINE,
 };
 use crate::tty::{Renderer, Term, Terminal};
 use crate::undo::Changeset;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -13,7 +13,7 @@ use crate::keymap::{Anchor, At, CharSearch, Cmd, Movement, RepeatCount, Word};
 use crate::keymap::{InputState, Invoke, Refresher};
 use crate::layout::{cwidh, Layout, Position};
 use crate::line_buffer::{
-    ChangeListener, DeleteListener, Direction, LineBuffer, NoListener, WordAction, MAX_LINE,
+    ChangeListener, DeleteListener, Direction, LineBuffer, LineBufferKind, NoListener, WordAction, MAX_LINE,
 };
 use crate::tty::{Renderer, Term, Terminal};
 use crate::undo::Changeset;
@@ -22,13 +22,13 @@ use crate::KillRing;
 
 /// Represent the state during line editing.
 /// Implement rendering.
-pub struct State<'out, 'prompt, H: Helper> {
+pub struct State<'buffer, 'out, 'prompt, H: Helper> {
     pub out: &'out mut <Terminal as Term>::Writer,
     prompt: &'prompt str,  // Prompt to display (rl_prompt)
     prompt_size: Position, // Prompt Unicode/visible width and height
-    pub line: LineBuffer,  // Edited line buffer
+    pub line: LineBuffer<'buffer>, // Edited line buffer
     pub layout: Layout,
-    saved_line_for_history: LineBuffer, // Current edited line before history browsing
+    saved_line_for_history: LineBuffer<'buffer>, // Current edited line before history browsing
     byte_buffer: [u8; 4],
     pub changes: Changeset, // changes to line, for undo/redo
     pub helper: Option<&'out H>,
@@ -43,12 +43,13 @@ enum Info<'m> {
     Msg(Option<&'m str>),
 }
 
-impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
+impl<'buffer, 'out, 'prompt, H: Helper> State<'buffer, 'out, 'prompt, H> {
     pub fn new(
         out: &'out mut <Terminal as Term>::Writer,
         prompt: &'prompt str,
         helper: Option<&'out H>,
         ctx: Context<'out>,
+        line: Option<LineBuffer<'buffer>>,
     ) -> Self {
         let prompt_size = out.calculate_position(prompt, Position::default());
         let gcm = out.grapheme_cluster_mode();
@@ -56,7 +57,7 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
             out,
             prompt,
             prompt_size,
-            line: LineBuffer::with_capacity(MAX_LINE).can_growth(true),
+            line: line.unwrap_or_else(|| LineBuffer::with_capacity(MAX_LINE)).can_growth(true),
             layout: Layout::new(gcm),
             saved_line_for_history: LineBuffer::with_capacity(MAX_LINE).can_growth(true),
             byte_buffer: [0; 4],
@@ -262,13 +263,13 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
     }
 }
 
-impl<H: Helper> Invoke for State<'_, '_, H> {
+impl<H: Helper> Invoke for State<'_, '_, '_, H> {
     fn input(&self) -> &str {
         self.line.as_str()
     }
 }
 
-impl<H: Helper> Refresher for State<'_, '_, H> {
+impl<H: Helper> Refresher for State<'_, '_, '_, H> {
     fn refresh_line(&mut self) -> Result<()> {
         let prompt_size = self.prompt_size;
         self.hint();
@@ -334,7 +335,7 @@ impl<H: Helper> Refresher for State<'_, '_, H> {
     }
 }
 
-impl<H: Helper> fmt::Debug for State<'_, '_, H> {
+impl<H: Helper> fmt::Debug for State<'_, '_, '_, H> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("State")
             .field("prompt", &self.prompt)
@@ -347,7 +348,7 @@ impl<H: Helper> fmt::Debug for State<'_, '_, H> {
     }
 }
 
-impl<H: Helper> State<'_, '_, H> {
+impl<H: Helper> State<'_, '_, '_, H> {
     pub fn clear_screen(&mut self) -> Result<()> {
         self.out.clear_screen()?;
         self.layout.cursor = Position::default();

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -49,7 +49,7 @@ impl<'buffer, 'out, 'prompt, H: Helper> State<'buffer, 'out, 'prompt, H> {
         prompt: &'prompt str,
         helper: Option<&'out H>,
         ctx: Context<'out>,
-        line: Option<LineBuffer<'buffer>>,
+        line: LineBuffer<'buffer>,
     ) -> Self {
         let prompt_size = out.calculate_position(prompt, Position::default());
         let gcm = out.grapheme_cluster_mode();
@@ -57,7 +57,7 @@ impl<'buffer, 'out, 'prompt, H: Helper> State<'buffer, 'out, 'prompt, H> {
             out,
             prompt,
             prompt_size,
-            line: line.unwrap_or_else(|| LineBuffer::with_capacity(MAX_LINE)).can_growth(true),
+            line: line.can_growth(true),
             layout: Layout::new(gcm),
             saved_line_for_history: LineBuffer::with_capacity(MAX_LINE).can_growth(true),
             byte_buffer: [0; 4],
@@ -752,13 +752,13 @@ impl<H: Helper> State<'_, '_, '_, H> {
 }
 
 #[cfg(test)]
-pub fn init_state<'out, H: Helper>(
+pub fn init_state<'buffer, 'out, H: Helper>(
     out: &'out mut <Terminal as Term>::Writer,
     line: &str,
     pos: usize,
     helper: Option<&'out H>,
     history: &'out crate::history::DefaultHistory,
-) -> State<'out, 'static, H> {
+) -> State<'static, 'out, 'static, H> {
     State {
         out,
         prompt: "",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,8 +488,6 @@ fn readline_direct(
     validator: &Option<impl Validator>,
     input: &mut String,
 ) -> Result<()> {
-    //let mut input = String::new();
-
     loop {
         if reader.read_line(input)? == 0 {
             return Err(ReadlineError::Eof);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub type Result<T> = result::Result<T, ReadlineError>;
 /// Completes the line/word
 fn complete_line<H: Helper>(
     rdr: &mut <Terminal as Term>::Reader,
-    s: &mut State<'_, '_, H>,
+    s: &mut State<'_, '_, '_, H>,
     input_state: &mut InputState,
     config: &Config,
 ) -> Result<Option<Cmd>> {
@@ -264,7 +264,7 @@ fn complete_line<H: Helper>(
 }
 
 /// Completes the current hint
-fn complete_hint_line<H: Helper>(s: &mut State<'_, '_, H>) -> Result<()> {
+fn complete_hint_line<H: Helper>(s: &mut State<'_, '_, '_, H>) -> Result<()> {
     let Some(hint) = s.hint.as_ref() else {
         return Ok(());
     };
@@ -281,7 +281,7 @@ fn complete_hint_line<H: Helper>(s: &mut State<'_, '_, H>) -> Result<()> {
 
 fn page_completions<C: Candidate, H: Helper>(
     rdr: &mut <Terminal as Term>::Reader,
-    s: &mut State<'_, '_, H>,
+    s: &mut State<'_, '_, '_, H>,
     input_state: &mut InputState,
     candidates: &[C],
 ) -> Result<Option<Cmd>> {
@@ -363,7 +363,7 @@ fn page_completions<C: Candidate, H: Helper>(
 /// Incremental search
 fn reverse_incremental_search<H: Helper, I: History>(
     rdr: &mut <Terminal as Term>::Reader,
-    s: &mut State<'_, '_, H>,
+    s: &mut State<'_, '_, '_, H>,
     input_state: &mut InputState,
     history: &I,
 ) -> Result<Option<Cmd>> {
@@ -697,7 +697,7 @@ impl<H: Helper, I: History> Editor<H, I> {
 
         self.kill_ring.reset(); // TODO recreate a new kill ring vs reset
         let ctx = Context::new(&self.history);
-        let mut s = State::new(&mut stdout, prompt, self.helper.as_ref(), ctx);
+        let mut s = State::new(&mut stdout, prompt, self.helper.as_ref(), ctx, None);
 
         let mut input_state = InputState::new(&self.config, &self.custom_bindings);
 

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -77,16 +77,17 @@ pub(crate) enum LineBufferKind<'a> {
     Borrowed(&'a mut String),
     Owned(String),
 }
-impl<'a> Deref for LineBufferKind<'a> {
+impl Deref for LineBufferKind<'_> {
     type Target = String;
+
     fn deref(&self) -> &String {
         match self {
             Self::Borrowed(s) => s,
-            Self::Owned(s) => &s,
+            Self::Owned(s) => s,
         }
     }
 }
-impl<'a> DerefMut for LineBufferKind<'a> {
+impl DerefMut for LineBufferKind<'_> {
     fn deref_mut(&mut self) -> &mut String {
         match self {
             Self::Borrowed(s) => s,
@@ -96,7 +97,8 @@ impl<'a> DerefMut for LineBufferKind<'a> {
 }
 impl<'a> From<Option<&'a mut String>> for LineBufferKind<'a> {
     fn from(buffer: Option<&'a mut String>) -> Self {
-        buffer.map(Self::Borrowed)
+        buffer
+            .map(Self::Borrowed)
             .unwrap_or_else(|| Self::Owned(String::with_capacity(MAX_LINE)))
     }
 }
@@ -128,7 +130,8 @@ impl fmt::Debug for LineBuffer<'_> {
 }
 
 impl<'a> LineBuffer<'a> {
-    /// Create a new line buffer that uses the given `buffer` instead of allocating.
+    /// Create a new line buffer that uses the given `buffer` instead of
+    /// allocating.
     #[must_use]
     pub fn with_buffer(buffer: &'a mut String) -> Self {
         Self {
@@ -1227,6 +1230,7 @@ impl io::Write for LineBuffer<'_> {
             })
             .unwrap_or(0))
     }
+
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
@@ -1259,7 +1263,8 @@ fn is_other_char(grapheme: &str) -> bool {
 #[cfg(test)]
 mod test {
     use super::{
-        ChangeListener, DeleteListener, Direction, LineBuffer, LineBufferKind, NoListener, WordAction, MAX_LINE,
+        ChangeListener, DeleteListener, Direction, LineBuffer, LineBufferKind, NoListener,
+        WordAction, MAX_LINE,
     };
     use crate::{
         keymap::{At, CharSearch, Word},

--- a/src/line_buffer.rs
+++ b/src/line_buffer.rs
@@ -95,13 +95,6 @@ impl DerefMut for LineBufferKind<'_> {
         }
     }
 }
-impl<'a> From<Option<&'a mut String>> for LineBufferKind<'a> {
-    fn from(buffer: Option<&'a mut String>) -> Self {
-        buffer
-            .map(Self::Borrowed)
-            .unwrap_or_else(|| Self::Owned(String::with_capacity(MAX_LINE)))
-    }
-}
 impl From<LineBufferKind<'_>> for String {
     fn from(buffer: LineBufferKind) -> String {
         match buffer {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -191,7 +191,8 @@ fn test_readline_direct() {
         Cursor::new(&mut write_buf),
         &Some(crate::validate::MatchingBracketValidator::new()),
         &mut output,
-    ).unwrap();
+    )
+    .unwrap();
 
     assert_eq!(
         &write_buf,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -184,16 +184,18 @@ fn test_apply_backspace_direct() {
 fn test_readline_direct() {
     use std::io::Cursor;
 
+    let mut output = String::new();
     let mut write_buf = vec![];
-    let output = readline_direct(
+    readline_direct(
         Cursor::new("([)\n\u{0008}\n\n\r\n])".as_bytes()),
         Cursor::new(&mut write_buf),
         &Some(crate::validate::MatchingBracketValidator::new()),
-    );
+        &mut output,
+    ).unwrap();
 
     assert_eq!(
         &write_buf,
         b"Mismatched brackets: '[' is not properly closed"
     );
-    assert_eq!(&output.unwrap(), "([\n\n\r\n])");
+    assert_eq!(&output, "([\n\n\r\n])");
 }


### PR DESCRIPTION
# Reuse strings

Currently you cannot reuse your strings.

```rs
// from README.md
let mut rl = DefaultEditor::new()?;
loop {
    let readline = rl.readline(">> ");
    match readline {
        // new allocation every time
        Ok(line) => {
            rl.add_history_entry(line.as_str());
            println!("Line: {}", line);
        },
        _ => {}
    }
}
```

With this pr you would be able reuse your memory.

```rs
let mut rl = DefaultEditor::new()?;
let mut buffer = String::with_capacity(20);
loop {
    let readline = rl.readline(">> ");
    match readline.readline_into_buffer(&mut buffer) {
        Ok(line) => {
            rl.add_history_entry(line.as_str());
            println!("Line: {}", line);
        },
        _ => {},
    }
}
```

- **added way to use preallocated strings in `LineBuffer`**
- **add public api for using for reusing strings**
- **clippy and fmt**
- **removed unused code**
- **cargo fmt**
