### PR TITLE
Update README.md example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
         let readline = rl.readline(">> ");
         match readline {
             Ok(line) => {
-                rl.add_history_entry(line.as_str());
+                rl.add_history_entry(line.as_str())?;
                 println!("Line: {}", line);
             },
             Err(ReadlineError::Interrupted) => {


### PR DESCRIPTION
Missing following `?` or leading `let _ = ` , will get warning "unused `Result` that must be used"