### PR TITLE
Fix SIGWINCH for signal-hook

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -89,6 +89,8 @@ impl Signal {
         match b {
             b'I' => Self::Interrupt,
             b'W' => Self::Resize,
+            #[cfg(feature = "signal-hook")]
+            b'X' => Self::Resize,
             _ => unreachable!(),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,14 +85,18 @@ pub enum Signal {
 
 #[cfg(unix)]
 impl Signal {
+    #[cfg(not(feature = "signal-hook"))]
     pub(crate) fn from(b: u8) -> Self {
         match b {
             b'I' => Self::Interrupt,
             b'W' => Self::Resize,
-            #[cfg(feature = "signal-hook")]
-            b'X' => Self::Resize,
             _ => unreachable!(),
         }
+    }
+
+    #[cfg(feature = "signal-hook")]
+    pub(crate) fn from(_: u8) -> Self {
+        Self::Resize
     }
 
     #[cfg(not(feature = "signal-hook"))]


### PR DESCRIPTION
With `features = ["signal-hook"]`, rustyline currently panics when the window is resized.

Repro:

```
use rustyline::DefaultEditor;
use rustyline::Result;

fn main() -> Result<()> {
    let mut rl = DefaultEditor::new()?;

    loop {
        let line = rl.readline("")?;
        rl.add_history_entry(line.as_str())?;

        println!("Line: {line}");
    }
}
```

Compile with `signal-hook` feature.

Run and resize window (on linux/unix).

This is because signal_hook sends `X` to the pipe, but we only process `I`/`W`, i.e. the custom signals we produce in the non-signal-hook feature.