### PR TITLE
Fix edit_kill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustyline"
-version = "17.0.0"
+version = "17.0.1"
 authors = ["Katsu Kawakami <kkawa1570@gmail.com>"]
 edition = "2021"
 description = "Rustyline, a readline implementation based on Antirez's Linenoise"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rustyline = "17.0.0"
+rustyline = "17.0.1"
 ```
 
 ## Features

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -361,7 +361,7 @@ fn normalize(s: &str) -> Cow<'_, str> {
 }
 
 #[cfg(not(any(windows, target_os = "macos")))]
-fn normalize(s: &str) -> Cow<str> {
+fn normalize(s: &str) -> Cow<'_, str> {
     Cow::Borrowed(s)
 }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -359,12 +359,13 @@ impl<H: Helper> State<'_, '_, H> {
             if push {
                 let no_previous_hint = self.hint.is_none();
                 self.hint();
+                let highlight_char = self.highlight_char(CmdKind::Other);
                 let width = cwidh(ch);
                 if n == 1
                     && width != 0 // Ctrl-V + \t or \n ...
                     && self.layout.cursor.col + width < self.out.get_columns()
                     && (self.hint.is_none() && no_previous_hint) // TODO refresh only current line
-                    && !self.highlight_char(CmdKind::Other)
+                    && !highlight_char
                 {
                     // Avoid a full update of the line in the trivial case.
                     self.layout.cursor.col += width;
@@ -565,11 +566,12 @@ impl<H: Helper> State<'_, '_, H> {
                 (proxy.trivial, proxy.cursor_shift, proxy.end_shift);
             let no_previous_hint = self.hint.is_none();
             self.hint();
+            let highlight_char = self.highlight_char(CmdKind::Other);
             if trivial
                 && cursor_shift <= self.layout.cursor.col
                 && end_shift <= self.layout.end.col
                 && (self.hint.is_none() && no_previous_hint)
-                && !self.highlight_char(CmdKind::Other)
+                && !highlight_char
             {
                 // Avoid a full update of the line in the trivial case.
                 debug_assert!(self.line.is_cursor_at_end());


### PR DESCRIPTION
`Highlighter#highligh_char` must be called in all cases, to avoid leaving an invalid index in `MatchingBracketHighlighter#bracket`.
Fix #885