### PR TITLE
Add Cmd::Macro for keystroke replay functionality

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -47,6 +47,18 @@ pub fn execute<H: Helper, P: Prompt + ?Sized>(
         Cmd::Macro(macro_str) => {
             s.start_macro(macro_str);
         }
+        Cmd::MacroClearLine(macro_str) => {
+            // Save the current line content for restoration after macro execution
+            if !s.line.is_empty() {
+                let line_content = s.line.as_str().to_string();
+                s.macro_player_mut().set_pending_restore(line_content);
+            }
+            // Clear the current line
+            s.edit_kill(&Movement::WholeLine, kill_ring)?;
+            s.changes.end();
+            // Then start the macro
+            s.start_macro(macro_str);
+        }
         Cmd::Move(Movement::BeginningOfLine) => {
             // Move to the beginning of line.
             s.edit_move_home()?;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -88,6 +88,11 @@ impl<'out, 'prompt, H: Helper, P: Prompt + ?Sized> State<'out, 'prompt, H, P> {
         self.macro_player.start(macro_str);
     }
 
+    /// Get mutable access to the macro player
+    pub fn macro_player_mut(&mut self) -> &mut MacroPlayer {
+        &mut self.macro_player
+    }
+
     pub fn highlighter(&self) -> Option<&dyn Highlighter> {
         if self.out.colors_enabled() {
             self.helper.map(|h| h as &dyn Highlighter)

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -132,6 +132,26 @@ pub enum Cmd {
     /// character. Newline characters (`\n`) are converted to `AcceptLine` commands
     /// to automatically submit the input.
     Macro(String),
+    /// Execute a macro after clearing the current line
+    ///
+    /// Clears the current line content, then replays the given string
+    /// character-by-character as if the user typed each character.
+    /// Newline characters (`\n`) are converted to `AcceptLine` commands
+    /// to automatically submit the input.
+    ///
+    /// The cleared line content is saved and can be restored by the application
+    /// on the next readline call. See [`Editor::take_pending_restore`] for details.
+    ///
+    /// # Example
+    /// ```ignore
+    /// // Check for pending restore before each readline
+    /// let result = if let Some(restore) = rl.take_pending_restore() {
+    ///     rl.readline_with_initial("> ", (&restore, ""))
+    /// } else {
+    ///     rl.readline("> ")
+    /// };
+    /// ```
+    MacroClearLine(String),
 }
 
 impl Cmd {
@@ -147,7 +167,7 @@ impl Cmd {
             | Self::Suspend
             | Self::Yank(..)
             | Self::YankPop => false,
-            Self::Macro(_) => true,
+            Self::Macro(_) | Self::MacroClearLine(_) => true,
             _ => true,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,6 +596,7 @@ pub struct Editor<H: Helper, I: History> {
     kill_ring: KillRing,
     config: Config,
     custom_bindings: Bindings,
+    pending_restore: Option<String>,
 }
 
 /// Default editor with no helper and `DefaultHistory`
@@ -626,7 +627,35 @@ impl<H: Helper, I: History> Editor<H, I> {
             kill_ring: KillRing::new(60),
             config,
             custom_bindings: Bindings::new(),
+            pending_restore: None,
         })
+    }
+
+    /// Set content to be restored on the next readline call
+    ///
+    /// This is used by MacroClearLine to restore the cleared line after the macro executes.
+    /// Generally, applications don't need to call this directly.
+    pub fn set_pending_restore(&mut self, content: String) {
+        self.pending_restore = Some(content);
+    }
+
+    /// Get and clear any pending restore content
+    ///
+    /// Returns the saved content that should be restored on the next readline call.
+    /// This is set by [`Cmd::MacroClearLine`] when it clears the current line.
+    ///
+    /// Applications should check this before each readline call and use
+    /// [`Editor::readline_with_initial`] to restore the content:
+    ///
+    /// ```ignore
+    /// let result = if let Some(restore) = rl.take_pending_restore() {
+    ///     rl.readline_with_initial("> ", (&restore, ""))
+    /// } else {
+    ///     rl.readline("> ")
+    /// };
+    /// ```
+    pub fn take_pending_restore(&mut self) -> Option<String> {
+        self.pending_restore.take()
     }
 
     /// This method will read a line from STDIN and will display a `prompt`.
@@ -807,6 +836,12 @@ impl<H: Helper, I: History> Editor<H, I> {
             let _ = original_mode; // silent warning
         }
         self.buffer = rdr.unbuffer();
+
+        // Transfer pending_restore from MacroPlayer to Editor for next readline call
+        if let Some(restore_content) = s.macro_player_mut().take_pending_restore() {
+            self.pending_restore = Some(restore_content);
+        }
+
         Ok(s.line.into_string())
     }
 

--- a/src/macro_player.rs
+++ b/src/macro_player.rs
@@ -4,6 +4,7 @@
 pub struct MacroPlayer {
     buffer: Vec<char>,
     position: usize,
+    pending_restore: Option<String>,
 }
 
 impl MacroPlayer {
@@ -11,6 +12,22 @@ impl MacroPlayer {
     pub fn start(&mut self, macro_str: String) {
         self.buffer = macro_str.chars().filter(|&c| c != '\r').collect();
         self.position = 0;
+    }
+
+    /// Set content to be restored on the next readline call
+    ///
+    /// This is called by [`Cmd::MacroClearLine`] to save the cleared line content.
+    /// The content is transferred to [`Editor`] at the end of the readline session.
+    pub fn set_pending_restore(&mut self, content: String) {
+        self.pending_restore = Some(content);
+    }
+
+    /// Get and clear any pending restore content
+    ///
+    /// This is called internally to transfer the pending restore to [`Editor`]
+    /// at the end of the readline session.
+    pub fn take_pending_restore(&mut self) -> Option<String> {
+        self.pending_restore.take()
     }
 }
 


### PR DESCRIPTION
This commit implements a new Cmd::Macro variant that allows replaying sequences of keystrokes character-by-character, enabling function key bindings to execute commands automatically.

Since this is replaying a command, it integrates with the command processing pipeline seamlessly, without allowing for completely arbitrary commands to be execute.

Example usage:
```rust
// Bind F1 to execute "help" command automatically
rl.bind_sequence(
    KeyEvent(KeyCode::F(1), Modifiers::NONE),
    Cmd::Macro("help\n".to_string())
);
```

When triggered, the macro replays each character as if the user typed it, and the trailing newline triggers AcceptLine to submit the command automatically.

It is related to issue #418: Execute Arbitrary Command Via Keybinding, I took insipration from that issue's name as I needed to "execute" arbitrary command (and not executable) in my application.