### PR TITLE
Implement EventHandler::Macro for command sequence bindings

### DIFF
--- a/CustomBinding.md
+++ b/CustomBinding.md
@@ -37,11 +37,11 @@ I am not sure if this point should be tackled here.
 
 ## Multiple / complex actions
 
-For one key/command, we may want to perform multiple actions.
-We should ask the undo manager to start a "transaction" before first action and commit it after the last action.
-Should we do something specific with the kill ring ?
-We should refresh / repaint only when all actions are performed (or if ask explicitly?) depending on cumulated action impacts.
-...
+`EventHandler::Macro(Vec<Cmd>)` executes a sequence of commands for a single key binding.
+
+- **Undo**: the sequence is wrapped in a single undo group (`Changeset::begin`/`end`), so one undo reverts all commands.
+- **Kill ring**: the kill ring is not reset between commands, preserving consecutive-kill semantics within the macro.
+- **Refresh**: a `refresh_line()` is called after the last command completes. Individual commands still refresh during execution; since they run back-to-back without I/O waits, there is no visible flicker.
 
 ## Misc
 

--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -4,8 +4,8 @@ use rustyline::highlight::Highlighter;
 use rustyline::hint::HistoryHinter;
 use rustyline::history::DefaultHistory;
 use rustyline::{
-    Cmd, ConditionalEventHandler, Editor, Event, EventContext, EventHandler, KeyEvent, RepeatCount,
-    Result,
+    Cmd, ConditionalEventHandler, Editor, Event, EventContext, EventHandler, KeyCode, KeyEvent,
+    Modifiers, RepeatCount, Result,
 };
 use rustyline::{Completer, Helper, Hinter, Validator};
 
@@ -86,6 +86,14 @@ fn main() -> Result<()> {
     rl.bind_sequence(
         Event::KeySeq(vec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]),
         EventHandler::Simple(Cmd::Suspend), // TODO external editor
+    );
+    // Bind F1 to insert "help" and accept the line
+    rl.bind_sequence(
+        KeyEvent(KeyCode::F(1), Modifiers::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Insert(1, "help".to_owned()),
+            Cmd::AcceptLine,
+        ]),
     );
 
     loop {

--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -4,7 +4,7 @@ use rustyline::highlight::Highlighter;
 use rustyline::hint::HistoryHinter;
 use rustyline::{
     Cmd, Completer, ConditionalEventHandler, Editor, Event, EventContext, EventHandler, Helper,
-    Hinter, KeyEvent, RepeatCount, Result, Validator,
+    Hinter, KeyCode, KeyEvent, Modifiers, RepeatCount, Result, Validator,
 };
 
 #[derive(Completer, Default, Helper, Hinter, Validator)]
@@ -83,6 +83,11 @@ fn main() -> Result<()> {
     rl.bind_sequence(
         Event::KeySeq(vec![KeyEvent::ctrl('X'), KeyEvent::ctrl('E')]),
         EventHandler::Simple(Cmd::Suspend), // TODO external editor
+    );
+    // Bind F1 to insert "help" and accept the line
+    rl.bind_sequence(
+        KeyEvent(KeyCode::F(1), Modifiers::NONE),
+        EventHandler::Macro(vec![Cmd::Insert(1, "help".to_owned()), Cmd::AcceptLine]),
     );
 
     loop {

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -125,13 +125,25 @@ pub enum EventHandler {
     Simple(Cmd),
     /// handler behaviour depends on input state
     Conditional(Box<dyn ConditionalEventHandler>),
-    /* invoke multiple actions
-     * TODO Macro(), */
+    /// Invoke multiple commands in sequence.
+    ///
+    /// Commands are executed in order. Sequences of two or more commands
+    /// are wrapped in a single undo group so that one undo reverts the
+    /// entire sequence; the kill ring is not reset between commands.
+    /// Commands after a line-terminating command (`AcceptLine`,
+    /// `EndOfFile`, …) are not executed.
+    Macro(Vec<Cmd>),
 }
 
 impl From<Cmd> for EventHandler {
     fn from(c: Cmd) -> Self {
         Self::Simple(c)
+    }
+}
+
+impl From<Vec<Cmd>> for EventHandler {
+    fn from(cmds: Vec<Cmd>) -> Self {
+        Self::Macro(cmds)
     }
 }
 
@@ -250,5 +262,21 @@ mod test {
     fn size_of_event() {
         use core::mem::size_of;
         assert_eq!(size_of::<Event>(), 32);
+    }
+
+    #[test]
+    fn macro_handler() {
+        let mut trie = Trie::new();
+        let cmds = vec![Cmd::Insert(1, "help".to_string()), Cmd::AcceptLine];
+        let evt = Event::from(KeyEvent(KeyCode::F(1), Modifiers::NONE));
+        trie.insert(evt.clone(), EventHandler::Macro(cmds));
+        let handler = trie.get(&evt).unwrap();
+        assert!(matches!(handler, EventHandler::Macro(v) if v.len() == 2));
+    }
+
+    #[test]
+    fn from_vec_cmd() {
+        let handler: EventHandler = vec![Cmd::Noop, Cmd::AcceptLine].into();
+        assert!(matches!(handler, EventHandler::Macro(v) if v.len() == 2));
     }
 }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -125,13 +125,25 @@ pub enum EventHandler {
     Simple(Cmd),
     /// handler behaviour depends on input state
     Conditional(Box<dyn ConditionalEventHandler>),
-    /* invoke multiple actions
-     * TODO Macro(), */
+    /// Invoke multiple commands in sequence.
+    ///
+    /// Commands are executed in order. Sequences of two or more commands
+    /// are wrapped in a single undo group so that one undo reverts the
+    /// entire sequence; the kill ring is not reset between commands.
+    /// Commands after a line-terminating command (`AcceptLine`,
+    /// `EndOfFile`, …) are not executed.
+    Macro(Vec<Cmd>),
 }
 
 impl From<Cmd> for EventHandler {
     fn from(c: Cmd) -> Self {
         Self::Simple(c)
+    }
+}
+
+impl From<Vec<Cmd>> for EventHandler {
+    fn from(cmds: Vec<Cmd>) -> Self {
+        Self::Macro(cmds)
     }
 }
 
@@ -252,5 +264,22 @@ mod test {
     fn size_of_event() {
         use core::mem::size_of;
         assert_eq!(size_of::<Event>(), 32);
+    }
+
+    #[test]
+    fn macro_handler() {
+        use crate::{KeyCode, Modifiers};
+        let mut trie = Trie::new();
+        let cmds = vec![Cmd::Insert(1, "help".to_string()), Cmd::AcceptLine];
+        let evt = Event::from(KeyEvent(KeyCode::F(1), Modifiers::NONE));
+        trie.insert(evt.clone(), EventHandler::Macro(cmds));
+        let handler = trie.get(&evt).unwrap();
+        assert!(matches!(handler, EventHandler::Macro(v) if v.len() == 2));
+    }
+
+    #[test]
+    fn from_vec_cmd() {
+        let handler: EventHandler = vec![Cmd::Noop, Cmd::AcceptLine].into();
+        assert!(matches!(handler, EventHandler::Macro(v) if v.len() == 2));
     }
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -96,6 +96,11 @@ pub enum Cmd {
     TransposeWords(RepeatCount),
     /// undo
     Undo(RepeatCount),
+    /// Save the current line buffer so it can be restored later via
+    /// take_stashed_line. Typically used as the first command in an
+    /// `EventHandler::Macro` to preserve the in-progress input before
+    /// clearing and submitting a different command.
+    Stash,
     /// Unsupported / unexpected
     Unknown,
     /// upcase-word

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -355,6 +355,14 @@ pub enum InputMode {
     Replace,
 }
 
+#[cfg(feature = "custom-bindings")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MacroState {
+    Idle,
+    Starting,
+    Active,
+}
+
 /// Transform key(s) to commands based on current input mode
 pub struct InputState<'b> {
     pub(crate) mode: EditMode,
@@ -368,9 +376,7 @@ pub struct InputState<'b> {
     #[cfg(feature = "custom-bindings")]
     macro_queue: VecDeque<Cmd>,
     #[cfg(feature = "custom-bindings")]
-    macro_active: bool,
-    #[cfg(feature = "custom-bindings")]
-    macro_just_started: bool,
+    macro_state: MacroState,
 }
 
 /// Provide indirect mutation to user input.
@@ -429,9 +435,7 @@ impl<'b> InputState<'b> {
             #[cfg(feature = "custom-bindings")]
             macro_queue: VecDeque::new(),
             #[cfg(feature = "custom-bindings")]
-            macro_active: false,
-            #[cfg(feature = "custom-bindings")]
-            macro_just_started: false,
+            macro_state: MacroState::Idle,
         }
     }
 
@@ -445,14 +449,17 @@ impl<'b> InputState<'b> {
 
     #[cfg(feature = "custom-bindings")]
     pub(crate) fn macro_active(&self) -> bool {
-        self.macro_active
+        self.macro_state != MacroState::Idle
     }
 
     #[cfg(feature = "custom-bindings")]
     pub(crate) fn take_macro_just_started(&mut self) -> bool {
-        let started = self.macro_just_started;
-        self.macro_just_started = false;
-        started
+        if self.macro_state == MacroState::Starting {
+            self.macro_state = MacroState::Active;
+            true
+        } else {
+            false
+        }
     }
 
     #[cfg(feature = "custom-bindings")]
@@ -461,8 +468,7 @@ impl<'b> InputState<'b> {
         let first = iter.next();
         self.macro_queue.extend(iter);
         if !self.macro_queue.is_empty() {
-            self.macro_active = true;
-            self.macro_just_started = true;
+            self.macro_state = MacroState::Starting;
         }
         Some(first.unwrap_or(Cmd::Noop))
     }
@@ -480,7 +486,7 @@ impl<'b> InputState<'b> {
         #[cfg(feature = "custom-bindings")]
         if let Some(cmd) = self.macro_queue.pop_front() {
             if self.macro_queue.is_empty() {
-                self.macro_active = false;
+                self.macro_state = MacroState::Idle;
             }
             return Ok(cmd);
         }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,6 +1,9 @@
 //! Bindings from keys to command for Emacs and Vi modes
 use log::debug;
 
+#[cfg(feature = "custom-bindings")]
+use std::collections::VecDeque;
+
 use super::Result;
 use crate::highlight::CmdKind;
 use crate::keys::{KeyCode as K, KeyEvent, KeyEvent as E, Modifiers as M};
@@ -357,6 +360,8 @@ pub struct InputState<'b> {
     num_args: i16,
     last_cmd: Cmd,                        // vi only
     last_char_search: Option<CharSearch>, // vi only
+    #[cfg(feature = "custom-bindings")]
+    macro_queue: VecDeque<Cmd>,
 }
 
 /// Provide indirect mutation to user input.
@@ -412,6 +417,8 @@ impl<'b> InputState<'b> {
             num_args: 0,
             last_cmd: Cmd::Noop,
             last_char_search: None,
+            #[cfg(feature = "custom-bindings")]
+            macro_queue: VecDeque::new(),
         }
     }
 
@@ -433,6 +440,10 @@ impl<'b> InputState<'b> {
         single_esc_abort: bool,
         ignore_external_print: bool,
     ) -> Result<Cmd> {
+        #[cfg(feature = "custom-bindings")]
+        if let Some(cmd) = self.macro_queue.pop_front() {
+            return Ok(cmd);
+        }
         let single_esc_abort = self.single_esc_abort(single_esc_abort);
         let key;
         if ignore_external_print {
@@ -1137,7 +1148,7 @@ impl InputState<'_> {
     /// Application customized binding
     #[allow(unused_variables)]
     fn custom_binding(
-        &self,
+        &mut self,
         wrt: &dyn Refresher,
         evt: &Event,
         n: RepeatCount,
@@ -1154,6 +1165,12 @@ impl InputState<'_> {
                             let ctx = EventContext::new(self, wrt);
                             handler.handle(evt, n, positive, &ctx)
                         }
+                        EventHandler::Macro(cmds) => {
+                            let mut iter = cmds.iter().cloned();
+                            let first = iter.next();
+                            self.macro_queue.extend(iter);
+                            first
+                        }
                     }
                 } else {
                     None
@@ -1165,7 +1182,7 @@ impl InputState<'_> {
 
     #[allow(unused_variables)]
     fn custom_seq_binding<R: RawReader>(
-        &self,
+        &mut self,
         rdr: &mut R,
         wrt: &dyn Refresher,
         evt: &mut Event,
@@ -1188,6 +1205,12 @@ impl InputState<'_> {
                             EventHandler::Conditional(handler) => {
                                 let ctx = EventContext::new(self, wrt);
                                 handler.handle(evt, n, positive, &ctx)
+                            }
+                            EventHandler::Macro(cmds) => {
+                                let mut iter = cmds.iter().cloned();
+                                let first = iter.next();
+                                self.macro_queue.extend(iter);
+                                first
                             }
                         };
                         if cmd.is_some() {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -362,6 +362,10 @@ pub struct InputState<'b> {
     last_char_search: Option<CharSearch>, // vi only
     #[cfg(feature = "custom-bindings")]
     macro_queue: VecDeque<Cmd>,
+    #[cfg(feature = "custom-bindings")]
+    macro_active: bool,
+    #[cfg(feature = "custom-bindings")]
+    macro_just_started: bool,
 }
 
 /// Provide indirect mutation to user input.
@@ -419,6 +423,10 @@ impl<'b> InputState<'b> {
             last_char_search: None,
             #[cfg(feature = "custom-bindings")]
             macro_queue: VecDeque::new(),
+            #[cfg(feature = "custom-bindings")]
+            macro_active: false,
+            #[cfg(feature = "custom-bindings")]
+            macro_just_started: false,
         }
     }
 
@@ -428,6 +436,30 @@ impl<'b> InputState<'b> {
 
     pub fn is_vi_cmd_mode(&self) -> bool {
         self.input_mode == InputMode::Command && self.mode == EditMode::Vi
+    }
+
+    #[cfg(feature = "custom-bindings")]
+    pub(crate) fn macro_active(&self) -> bool {
+        self.macro_active
+    }
+
+    #[cfg(feature = "custom-bindings")]
+    pub(crate) fn take_macro_just_started(&mut self) -> bool {
+        let started = self.macro_just_started;
+        self.macro_just_started = false;
+        started
+    }
+
+    #[cfg(feature = "custom-bindings")]
+    fn dispatch_macro(&mut self, cmds: &[Cmd]) -> Option<Cmd> {
+        let mut iter = cmds.iter().cloned();
+        let first = iter.next();
+        self.macro_queue.extend(iter);
+        if !self.macro_queue.is_empty() {
+            self.macro_active = true;
+            self.macro_just_started = true;
+        }
+        Some(first.unwrap_or(Cmd::Noop))
     }
 
     /// Parse user input into one command
@@ -442,6 +474,9 @@ impl<'b> InputState<'b> {
     ) -> Result<Cmd> {
         #[cfg(feature = "custom-bindings")]
         if let Some(cmd) = self.macro_queue.pop_front() {
+            if self.macro_queue.is_empty() {
+                self.macro_active = false;
+            }
             return Ok(cmd);
         }
         let single_esc_abort = self.single_esc_abort(single_esc_abort);
@@ -1165,12 +1200,7 @@ impl InputState<'_> {
                             let ctx = EventContext::new(self, wrt);
                             handler.handle(evt, n, positive, &ctx)
                         }
-                        EventHandler::Macro(cmds) => {
-                            let mut iter = cmds.iter().cloned();
-                            let first = iter.next();
-                            self.macro_queue.extend(iter);
-                            first
-                        }
+                        EventHandler::Macro(cmds) => self.dispatch_macro(cmds),
                     }
                 } else {
                     None
@@ -1206,12 +1236,7 @@ impl InputState<'_> {
                                 let ctx = EventContext::new(self, wrt);
                                 handler.handle(evt, n, positive, &ctx)
                             }
-                            EventHandler::Macro(cmds) => {
-                                let mut iter = cmds.iter().cloned();
-                                let first = iter.next();
-                                self.macro_queue.extend(iter);
-                                first
-                            }
+                            EventHandler::Macro(cmds) => self.dispatch_macro(cmds),
                         };
                         if cmd.is_some() {
                             return Ok(cmd);

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -96,6 +96,11 @@ pub enum Cmd {
     TransposeWords(RepeatCount),
     /// undo
     Undo(RepeatCount),
+    /// Save the current line buffer so it can be restored later via
+    /// take_stashed_line. Typically used as the first command in an
+    /// `EventHandler::Macro` to preserve the in-progress input before
+    /// clearing and submitting a different command.
+    Stash,
     /// Unsupported / unexpected
     Unknown,
     /// upcase-word
@@ -141,6 +146,7 @@ impl Cmd {
             | Self::Kill(_)
             | Self::Replace(..)
             | Self::Noop
+            | Self::Stash
             | Self::Suspend
             | Self::Yank(..)
             | Self::YankPop => false,

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,4 +1,7 @@
 //! Bindings from keys to command for Emacs and Vi modes
+#[cfg(feature = "custom-bindings")]
+use std::collections::VecDeque;
+
 use log::debug;
 
 use super::Result;
@@ -357,6 +360,8 @@ pub struct InputState<'b> {
     num_args: i16,
     last_cmd: Cmd,                        // vi only
     last_char_search: Option<CharSearch>, // vi only
+    #[cfg(feature = "custom-bindings")]
+    macro_queue: VecDeque<Cmd>,
 }
 
 /// Provide indirect mutation to user input.
@@ -412,6 +417,8 @@ impl<'b> InputState<'b> {
             num_args: 0,
             last_cmd: Cmd::Noop,
             last_char_search: None,
+            #[cfg(feature = "custom-bindings")]
+            macro_queue: VecDeque::new(),
         }
     }
 
@@ -433,6 +440,10 @@ impl<'b> InputState<'b> {
         single_esc_abort: bool,
         ignore_external_print: bool,
     ) -> Result<Cmd> {
+        #[cfg(feature = "custom-bindings")]
+        if let Some(cmd) = self.macro_queue.pop_front() {
+            return Ok(cmd);
+        }
         let single_esc_abort = self.single_esc_abort(single_esc_abort);
         let key;
         if ignore_external_print {
@@ -1137,7 +1148,7 @@ impl InputState<'_> {
     /// Application customized binding
     #[allow(unused_variables)]
     fn custom_binding(
-        &self,
+        &mut self,
         wrt: &dyn Refresher,
         evt: &Event,
         n: RepeatCount,
@@ -1154,6 +1165,12 @@ impl InputState<'_> {
                             let ctx = EventContext::new(self, wrt);
                             handler.handle(evt, n, positive, &ctx)
                         }
+                        EventHandler::Macro(cmds) => {
+                            let mut iter = cmds.iter().cloned();
+                            let first = iter.next();
+                            self.macro_queue.extend(iter);
+                            first
+                        }
                     }
                 } else {
                     None
@@ -1165,7 +1182,7 @@ impl InputState<'_> {
 
     #[allow(unused_variables)]
     fn custom_seq_binding<R: RawReader>(
-        &self,
+        &mut self,
         rdr: &mut R,
         wrt: &dyn Refresher,
         evt: &mut Event,
@@ -1188,6 +1205,12 @@ impl InputState<'_> {
                             EventHandler::Conditional(handler) => {
                                 let ctx = EventContext::new(self, wrt);
                                 handler.handle(evt, n, positive, &ctx)
+                            }
+                            EventHandler::Macro(cmds) => {
+                                let mut iter = cmds.iter().cloned();
+                                let first = iter.next();
+                                self.macro_queue.extend(iter);
+                                first
                             }
                         };
                         if cmd.is_some() {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -350,6 +350,14 @@ pub enum InputMode {
     Replace,
 }
 
+#[cfg(feature = "custom-bindings")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MacroState {
+    Idle,
+    Starting,
+    Active,
+}
+
 /// Transform key(s) to commands based on current input mode
 pub struct InputState<'b> {
     pub(crate) mode: EditMode,
@@ -362,6 +370,8 @@ pub struct InputState<'b> {
     last_char_search: Option<CharSearch>, // vi only
     #[cfg(feature = "custom-bindings")]
     macro_queue: VecDeque<Cmd>,
+    #[cfg(feature = "custom-bindings")]
+    macro_state: MacroState,
 }
 
 /// Provide indirect mutation to user input.
@@ -419,6 +429,8 @@ impl<'b> InputState<'b> {
             last_char_search: None,
             #[cfg(feature = "custom-bindings")]
             macro_queue: VecDeque::new(),
+            #[cfg(feature = "custom-bindings")]
+            macro_state: MacroState::Idle,
         }
     }
 
@@ -428,6 +440,32 @@ impl<'b> InputState<'b> {
 
     pub fn is_vi_cmd_mode(&self) -> bool {
         self.input_mode == InputMode::Command && self.mode == EditMode::Vi
+    }
+
+    #[cfg(feature = "custom-bindings")]
+    pub(crate) fn macro_active(&self) -> bool {
+        self.macro_state != MacroState::Idle
+    }
+
+    #[cfg(feature = "custom-bindings")]
+    pub(crate) fn take_macro_just_started(&mut self) -> bool {
+        if self.macro_state == MacroState::Starting {
+            self.macro_state = MacroState::Active;
+            true
+        } else {
+            false
+        }
+    }
+
+    #[cfg(feature = "custom-bindings")]
+    fn dispatch_macro(&mut self, cmds: &[Cmd]) -> Option<Cmd> {
+        let mut iter = cmds.iter().cloned();
+        let first = iter.next();
+        self.macro_queue.extend(iter);
+        if !self.macro_queue.is_empty() {
+            self.macro_state = MacroState::Starting;
+        }
+        Some(first.unwrap_or(Cmd::Noop))
     }
 
     /// Parse user input into one command
@@ -440,8 +478,14 @@ impl<'b> InputState<'b> {
         single_esc_abort: bool,
         ignore_external_print: bool,
     ) -> Result<Cmd> {
+        // A queued macro command that itself reads more input (e.g. Complete,
+        // ReverseSearchHistory) consumes the following queued commands as that
+        // input rather than running them as macro steps.
         #[cfg(feature = "custom-bindings")]
         if let Some(cmd) = self.macro_queue.pop_front() {
+            if self.macro_queue.is_empty() {
+                self.macro_state = MacroState::Idle;
+            }
             return Ok(cmd);
         }
         let single_esc_abort = self.single_esc_abort(single_esc_abort);
@@ -544,6 +588,13 @@ impl<'b> InputState<'b> {
 
         let mut evt = key.into();
         if let Some(cmd) = self.custom_binding(wrt, &evt, n, positive) {
+            // Repeat-count semantics for macros are deferred: ignore the count
+            // for a dispatched (multi-command) macro instead of misapplying it
+            // to the first command only.
+            #[cfg(feature = "custom-bindings")]
+            if self.macro_state == MacroState::Starting {
+                return Ok(cmd);
+            }
             return Ok(if cmd.is_repeatable() {
                 cmd.redo(Some(n), wrt)
             } else {
@@ -1165,12 +1216,7 @@ impl InputState<'_> {
                             let ctx = EventContext::new(self, wrt);
                             handler.handle(evt, n, positive, &ctx)
                         }
-                        EventHandler::Macro(cmds) => {
-                            let mut iter = cmds.iter().cloned();
-                            let first = iter.next();
-                            self.macro_queue.extend(iter);
-                            first
-                        }
+                        EventHandler::Macro(cmds) => self.dispatch_macro(cmds),
                     }
                 } else {
                     None
@@ -1206,12 +1252,7 @@ impl InputState<'_> {
                                 let ctx = EventContext::new(self, wrt);
                                 handler.handle(evt, n, positive, &ctx)
                             }
-                            EventHandler::Macro(cmds) => {
-                                let mut iter = cmds.iter().cloned();
-                                let first = iter.next();
-                                self.macro_queue.extend(iter);
-                                first
-                            }
+                            EventHandler::Macro(cmds) => self.dispatch_macro(cmds),
                         };
                         if cmd.is_some() {
                             return Ok(cmd);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -728,10 +728,22 @@ impl<H: Helper, I: History> Editor<H, I> {
         }
         s.refresh_line()?;
 
+        #[cfg(feature = "custom-bindings")]
+        let mut macro_undo_group_active = false;
         loop {
             let mut cmd = s.next_cmd(&mut input_state, &mut rdr, false, false)?;
 
-            if cmd.should_reset_kill_ring() {
+            #[cfg(feature = "custom-bindings")]
+            if input_state.take_macro_just_started() {
+                macro_undo_group_active = true;
+                self.kill_ring.reset();
+                s.changes.begin();
+            }
+
+            let should_reset = cmd.should_reset_kill_ring();
+            #[cfg(feature = "custom-bindings")]
+            let should_reset = should_reset && !macro_undo_group_active;
+            if should_reset {
                 self.kill_ring.reset();
             }
 
@@ -791,7 +803,19 @@ impl<H: Helper, I: History> Editor<H, I> {
             }
 
             // Execute things can be done solely on a state object
-            match command::execute(cmd, &mut s, &input_state, &mut self.kill_ring, &self.config)? {
+            let result =
+                command::execute(cmd, &mut s, &input_state, &mut self.kill_ring, &self.config);
+
+            #[cfg(feature = "custom-bindings")]
+            if macro_undo_group_active && (result.is_err() || !input_state.macro_active()) {
+                macro_undo_group_active = false;
+                s.changes.end();
+                if matches!(result, Ok(command::Status::Proceed)) {
+                    s.refresh_line()?;
+                }
+            }
+
+            match result? {
                 command::Status::Proceed => continue,
                 command::Status::Submit => break,
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,7 +736,6 @@ impl<H: Helper, I: History> Editor<H, I> {
             }
 
             // First trigger commands that need extra input
-
             if cmd == Cmd::Complete && s.helper.is_some() {
                 let next = complete_line(&mut rdr, &mut s, &mut input_state, &self.config)?;
                 if let Some(next) = next {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,6 +595,7 @@ pub struct Editor<H: Helper, I: History> {
     kill_ring: KillRing,
     config: Config,
     custom_bindings: Bindings,
+    stashed_line: Option<String>,
 }
 
 /// Default editor with no helper and `DefaultHistory`
@@ -625,6 +626,7 @@ impl<H: Helper, I: History> Editor<H, I> {
             kill_ring: KillRing::new(60),
             config,
             custom_bindings: Bindings::new(),
+            stashed_line: None,
         })
     }
 
@@ -745,6 +747,17 @@ impl<H: Helper, I: History> Editor<H, I> {
             let should_reset = should_reset && !macro_undo_group_active;
             if should_reset {
                 self.kill_ring.reset();
+            }
+
+            if cmd == Cmd::Stash {
+                self.stashed_line = Some(s.line.as_str().to_owned());
+                #[cfg(feature = "custom-bindings")]
+                if macro_undo_group_active && !input_state.macro_active() {
+                    macro_undo_group_active = false;
+                    s.changes.end();
+                    s.refresh_line()?;
+                }
+                continue;
             }
 
             // First trigger commands that need extra input
@@ -899,6 +912,16 @@ impl<H: Helper, I: History> Editor<H, I> {
     pub fn unbind_sequence<E: Into<Event>>(&mut self, key_seq: E) -> Option<EventHandler> {
         self.custom_bindings
             .remove(&Event::normalize(key_seq.into()))
+    }
+
+    /// Returns and clears the line saved by a previous `Cmd::Stash`.
+    ///
+    /// Typical usage: after a macro that stashes the current input, clears
+    /// the line, submits a different command, and accepts — call this to
+    /// recover the original input and pass it as `initial` to the next
+    /// `readline_with_initial`.
+    pub fn take_stashed_line(&mut self) -> Option<String> {
+        self.stashed_line.take()
     }
 
     /// Returns an iterator over edited lines.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,6 +597,7 @@ pub struct Editor<H: Helper, I: History> {
     kill_ring: KillRing,
     config: Config,
     custom_bindings: Bindings,
+    stashed_line: Option<String>,
 }
 
 /// Default editor with default helper and `DefaultHistory`
@@ -652,6 +653,7 @@ impl<H: Helper, I: History> Editor<H, I> {
             kill_ring: KillRing::new(60),
             config,
             custom_bindings: Bindings::new(),
+            stashed_line: None,
         })
     }
 
@@ -734,6 +736,7 @@ impl<H: Helper, I: History> Editor<H, I> {
         let mut stdout = self.term.create_writer(&self.config);
 
         self.kill_ring.reset(); // TODO recreate a new kill ring vs reset
+        self.stashed_line = None; // drop any stash the caller did not consume
         let ctx = Context::new(&self.history);
         let mut s = State::new(&mut stdout, prompt, self.helper.as_ref(), ctx);
 
@@ -796,6 +799,12 @@ impl<H: Helper, I: History> Editor<H, I> {
             let should_reset = should_reset && (macro_just_started || !macro_undo_group_active);
             if should_reset {
                 self.kill_ring.reset();
+            }
+
+            if cmd == Cmd::Stash {
+                self.stashed_line = Some(s.line.as_str().to_owned());
+                close_macro_group!();
+                continue;
             }
 
             // First trigger commands that need extra input
@@ -969,6 +978,16 @@ impl<H: Helper, I: History> Editor<H, I> {
     pub fn unbind_sequence<E: Into<Event>>(&mut self, key_seq: E) -> Option<EventHandler> {
         self.custom_bindings
             .remove(&Event::normalize(key_seq.into()))
+    }
+
+    /// Returns and clears the line saved by a previous `Cmd::Stash`.
+    ///
+    /// Typical usage: after a macro that stashes the current input, clears
+    /// the line, submits a different command, and accepts — call this to
+    /// recover the original input and pass it as `initial` to the next
+    /// `readline_with_initial`.
+    pub fn take_stashed_line(&mut self) -> Option<String> {
+        self.stashed_line.take()
     }
 
     /// Returns an iterator over edited lines.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,10 +762,39 @@ impl<H: Helper, I: History> Editor<H, I> {
         }
         s.refresh_line()?;
 
+        #[cfg(feature = "custom-bindings")]
+        let mut macro_undo_group_active = false;
+
+        // Close the macro's undo group once its last command has been drained.
+        // Must run on every path that leaves the loop body early, since the
+        // queue is emptied (and `macro_active` cleared) before the command runs.
+        macro_rules! close_macro_group {
+            () => {
+                #[cfg(feature = "custom-bindings")]
+                if macro_undo_group_active && !input_state.macro_active() {
+                    macro_undo_group_active = false;
+                    s.changes.end();
+                }
+            };
+        }
+
         loop {
             let mut cmd = s.next_cmd(&mut input_state, &mut rdr, false, false)?;
 
-            if cmd.should_reset_kill_ring() {
+            #[cfg(feature = "custom-bindings")]
+            let macro_just_started = input_state.take_macro_just_started();
+            #[cfg(feature = "custom-bindings")]
+            if macro_just_started {
+                macro_undo_group_active = true;
+                s.changes.begin();
+            }
+
+            // Inside a macro, suppress the kill-ring reset between commands so
+            // consecutive kills coalesce; the first command still honors its own.
+            let should_reset = cmd.should_reset_kill_ring();
+            #[cfg(feature = "custom-bindings")]
+            let should_reset = should_reset && (macro_just_started || !macro_undo_group_active);
+            if should_reset {
                 self.kill_ring.reset();
             }
 
@@ -775,6 +804,7 @@ impl<H: Helper, I: History> Editor<H, I> {
                 if let Some(next) = next {
                     cmd = next;
                 } else {
+                    close_macro_group!();
                     continue;
                 }
             }
@@ -786,6 +816,7 @@ impl<H: Helper, I: History> Editor<H, I> {
                 if let Some(next) = next {
                     cmd = next;
                 } else {
+                    close_macro_group!();
                     continue;
                 }
             }
@@ -798,6 +829,7 @@ impl<H: Helper, I: History> Editor<H, I> {
                 let _ = self.term.enable_raw_mode(&self.config)?; // TODO original_mode may have changed
                 s.out.update_size(); // window may have been resized
                 s.refresh_line()?;
+                close_macro_group!();
                 continue;
             }
 
@@ -806,6 +838,7 @@ impl<H: Helper, I: History> Editor<H, I> {
                 // Quoted insert
                 let c = rdr.next_char()?;
                 s.edit_insert(c, 1)?;
+                close_macro_group!();
                 continue;
             }
 
@@ -825,7 +858,19 @@ impl<H: Helper, I: History> Editor<H, I> {
             }
 
             // Execute things can be done solely on a state object
-            match command::execute(cmd, &mut s, &input_state, &mut self.kill_ring, &self.config)? {
+            let result =
+                command::execute(cmd, &mut s, &input_state, &mut self.kill_ring, &self.config);
+
+            #[cfg(feature = "custom-bindings")]
+            if macro_undo_group_active && (result.is_err() || !input_state.macro_active()) {
+                macro_undo_group_active = false;
+                s.changes.end();
+                if matches!(result, Ok(command::Status::Proceed)) {
+                    s.refresh_line()?;
+                }
+            }
+
+            match result? {
                 command::Status::Proceed => continue,
                 command::Status::Submit => break,
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -770,7 +770,6 @@ impl<H: Helper, I: History> Editor<H, I> {
             }
 
             // First trigger commands that need extra input
-
             if cmd == Cmd::Complete && s.helper.is_some() {
                 let next = complete_line(&mut rdr, &mut s, &mut input_state, &self.config)?;
                 if let Some(next) = next {

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -451,6 +451,31 @@ fn macro_single_cmd_undo() {
 }
 
 #[test]
+fn macro_stash_and_restore() {
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[
+            E::from('f'),
+            E::from('o'),
+            E::from('o'),
+            E(K::F(1), M::NONE),
+        ],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Stash,
+            Cmd::Kill(Movement::WholeLine),
+            Cmd::Insert(1, "bar".to_string()),
+            Cmd::AcceptLine,
+        ]),
+    );
+    assert_eq!("bar", editor.readline(">>").unwrap());
+    assert_eq!(Some("foo".to_string()), editor.take_stashed_line());
+    assert_eq!(None, editor.take_stashed_line());
+}
+
+#[test]
 fn macro_kill_ring_coalesce() {
     // Two consecutive kills inside a macro should coalesce: Yank pastes both.
     // "hello world", 2x Kill(BackwardWord) removes both words. Yank restores both.

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -2,7 +2,9 @@
 use super::{assert_cursor, assert_line, assert_line_with_initial, init_editor};
 use crate::config::EditMode;
 use crate::error::ReadlineError;
+use crate::keymap::{Cmd, Movement};
 use crate::keys::{KeyCode as K, KeyEvent as E, Modifiers as M};
+use crate::EventHandler;
 
 #[test]
 fn home_key() {
@@ -358,4 +360,114 @@ fn paste() {
             );
         }
     }
+}
+
+#[test]
+fn macro_insert_and_accept() {
+    let mut editor = init_editor(EditMode::Emacs, &[E(K::F(1), M::NONE)]);
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Insert(1, "hello".to_string()),
+            Cmd::AcceptLine,
+        ]),
+    );
+    assert_eq!("hello", editor.readline(">>").unwrap());
+}
+
+#[test]
+fn macro_clear_and_replace() {
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[E::from('f'), E::from('o'), E::from('o'), E(K::F(2), M::NONE)],
+    );
+    editor.bind_sequence(
+        E(K::F(2), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Kill(Movement::WholeLine),
+            Cmd::Insert(1, "bar".to_string()),
+            Cmd::AcceptLine,
+        ]),
+    );
+    assert_eq!("bar", editor.readline(">>").unwrap());
+}
+
+#[test]
+fn macro_undo_group() {
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[E(K::F(1), M::NONE), E::ctrl('_'), E::ENTER],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Insert(1, "hello".to_string()),
+            Cmd::Insert(1, " world".to_string()),
+        ]),
+    );
+    assert_eq!("", editor.readline(">>").unwrap());
+}
+
+#[test]
+fn macro_empty() {
+    let mut editor = init_editor(EditMode::Emacs, &[E(K::F(3), M::NONE), E::ENTER]);
+    editor.bind_sequence(E(K::F(3), M::NONE), EventHandler::Macro(vec![]));
+    assert_eq!("", editor.readline(">>").unwrap());
+}
+
+#[test]
+fn macro_vi_insert_and_accept() {
+    let mut editor = init_editor(EditMode::Vi, &[E(K::F(1), M::NONE)]);
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Insert(1, "hello".to_string()),
+            Cmd::AcceptLine,
+        ]),
+    );
+    assert_eq!("hello", editor.readline(">>").unwrap());
+}
+
+#[test]
+fn macro_single_cmd_undo() {
+    // 'a', F1 (single-cmd macro: insert "X"), undo "X", undo 'a', enter
+    // Both undos must take effect; an orphaned "Begin" would silently eat the
+    // second undo, leaving 'a' in the buffer.
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[
+            E::from('a'),
+            E(K::F(1), M::NONE),
+            E::ctrl('_'),
+            E::ctrl('_'),
+            E::ENTER,
+        ],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![Cmd::Insert(1, "X".to_string())]),
+    );
+    assert_eq!("", editor.readline(">>").unwrap());
+}
+
+#[test]
+fn macro_kill_ring_coalesce() {
+    // Two consecutive kills inside a macro should coalesce: Yank pastes both.
+    // "hello world", 2x Kill(BackwardWord) removes both words. Yank restores both.
+    use crate::keymap::Word;
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[E(K::F(1), M::NONE), E::ctrl('Y'), E::ENTER],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Kill(Movement::BackwardWord(1, Word::Big)),
+            Cmd::Kill(Movement::BackwardWord(1, Word::Big)),
+        ]),
+    );
+    assert_eq!(
+        "hello world",
+        editor.readline_with_initial(">>", ("hello world", "")).unwrap()
+    );
 }

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -499,6 +499,32 @@ fn macro_single_cmd_undo() {
 
 #[cfg(feature = "custom-bindings")]
 #[test]
+fn macro_stash_and_restore() {
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[
+            E::from('f'),
+            E::from('o'),
+            E::from('o'),
+            E(K::F(1), M::NONE),
+        ],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Stash,
+            Cmd::Kill(Movement::WholeLine),
+            Cmd::Insert(1, "bar".to_string()),
+            Cmd::AcceptLine,
+        ]),
+    );
+    assert_eq!("bar", editor.readline(">>").unwrap());
+    assert_eq!(Some("foo".to_string()), editor.take_stashed_line());
+    assert_eq!(None, editor.take_stashed_line());
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
 fn macro_kill_ring_coalesce() {
     // Two consecutive kills inside a macro should coalesce: Yank pastes both.
     // "hello world", 2x Kill(BackwardWord) removes both words. Yank restores both.

--- a/src/test/common.rs
+++ b/src/test/common.rs
@@ -2,8 +2,12 @@
 use std::assert_matches;
 
 use super::{assert_cursor, assert_line, assert_line_with_initial, init_editor};
+#[cfg(feature = "custom-bindings")]
+use crate::EventHandler;
 use crate::config::EditMode;
 use crate::error::ReadlineError;
+#[cfg(feature = "custom-bindings")]
+use crate::keymap::{Cmd, Movement};
 use crate::keys::{KeyCode as K, KeyEvent as E, Modifiers as M};
 
 #[test]
@@ -360,4 +364,160 @@ fn paste() {
             );
         }
     }
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_insert_and_accept() {
+    let mut editor = init_editor(EditMode::Emacs, &[E(K::F(1), M::NONE)]);
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![Cmd::Insert(1, "hello".to_string()), Cmd::AcceptLine]),
+    );
+    assert_eq!("hello", editor.readline(">>").unwrap());
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_clear_and_replace() {
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[
+            E::from('f'),
+            E::from('o'),
+            E::from('o'),
+            E(K::F(2), M::NONE),
+        ],
+    );
+    editor.bind_sequence(
+        E(K::F(2), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Kill(Movement::WholeLine),
+            Cmd::Insert(1, "bar".to_string()),
+            Cmd::AcceptLine,
+        ]),
+    );
+    assert_eq!("bar", editor.readline(">>").unwrap());
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_undo_group() {
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[E(K::F(1), M::NONE), E::ctrl('_'), E::ENTER],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Insert(1, "hello".to_string()),
+            Cmd::Insert(1, " world".to_string()),
+        ]),
+    );
+    assert_eq!("", editor.readline(">>").unwrap());
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_undo_group_nested() {
+    // A macro command that opens its own undo group (TransposeChars) must not
+    // break the macro's single group: one undo reverts the whole macro.
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[E(K::F(1), M::NONE), E::ctrl('_'), E::ENTER],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![Cmd::TransposeChars, Cmd::Insert(1, "X".to_string())]),
+    );
+    assert_eq!(
+        "ab",
+        editor.readline_with_initial(">>", ("ab", "")).unwrap()
+    );
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_ignores_repeat_count() {
+    // A numeric prefix is ignored for macros (repeat semantics deferred), not
+    // misapplied to the first command.
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[E(K::Char('3'), M::ALT), E(K::F(1), M::NONE), E::ENTER],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Insert(1, "x".to_string()),
+            Cmd::Insert(1, "y".to_string()),
+        ]),
+    );
+    assert_eq!("xy", editor.readline(">>").unwrap());
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_empty() {
+    let mut editor = init_editor(EditMode::Emacs, &[E(K::F(3), M::NONE), E::ENTER]);
+    editor.bind_sequence(E(K::F(3), M::NONE), EventHandler::Macro(vec![]));
+    assert_eq!("", editor.readline(">>").unwrap());
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_vi_insert_and_accept() {
+    let mut editor = init_editor(EditMode::Vi, &[E(K::F(1), M::NONE)]);
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![Cmd::Insert(1, "hello".to_string()), Cmd::AcceptLine]),
+    );
+    assert_eq!("hello", editor.readline(">>").unwrap());
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_single_cmd_undo() {
+    // 'a', F1 (single-cmd macro: insert "X"), undo "X", undo 'a', enter
+    // Both undos must take effect; an orphaned "Begin" would silently eat the
+    // second undo, leaving 'a' in the buffer.
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[
+            E::from('a'),
+            E(K::F(1), M::NONE),
+            E::ctrl('_'),
+            E::ctrl('_'),
+            E::ENTER,
+        ],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![Cmd::Insert(1, "X".to_string())]),
+    );
+    assert_eq!("", editor.readline(">>").unwrap());
+}
+
+#[cfg(feature = "custom-bindings")]
+#[test]
+fn macro_kill_ring_coalesce() {
+    // Two consecutive kills inside a macro should coalesce: Yank pastes both.
+    // "hello world", 2x Kill(BackwardWord) removes both words. Yank restores both.
+    use crate::keymap::Word;
+    let mut editor = init_editor(
+        EditMode::Emacs,
+        &[E(K::F(1), M::NONE), E::ctrl('Y'), E::ENTER],
+    );
+    editor.bind_sequence(
+        E(K::F(1), M::NONE),
+        EventHandler::Macro(vec![
+            Cmd::Kill(Movement::BackwardWord(1, Word::Big)),
+            Cmd::Kill(Movement::BackwardWord(1, Word::Big)),
+        ]),
+    );
+    assert_eq!(
+        "hello world",
+        editor
+            .readline_with_initial(">>", ("hello world", ""))
+            .unwrap()
+    );
 }

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -122,21 +122,25 @@ impl Changeset {
 
     /// Returns `true` when changes happen between the last call to `begin` and
     /// this `end`.
+    ///
+    /// Closes exactly one group so that groups nest: an inner `begin`/`end`
+    /// pair (e.g. a command run inside a macro) no longer collapses an
+    /// enclosing group. [`Self::undo`] already walks nested markers.
     pub(crate) fn end(&mut self) -> bool {
         debug!(target: "rustyline", "Changeset::end");
         self.redos.clear();
-        let mut touched = false;
-        while self.undo_group_level > 0 {
-            self.undo_group_level -= 1;
-            if let Some(&Change::Begin) = self.undos.last() {
-                // empty Begin..End
-                self.undos.pop();
-            } else {
-                self.undos.push(Change::End);
-                touched = true;
-            }
+        if self.undo_group_level == 0 {
+            return false;
         }
-        touched
+        self.undo_group_level -= 1;
+        if let Some(&Change::Begin) = self.undos.last() {
+            // empty Begin..End
+            self.undos.pop();
+            false
+        } else {
+            self.undos.push(Change::End);
+            true
+        }
     }
 
     fn insert_char(idx: usize, c: char) -> Change {
@@ -289,6 +293,15 @@ impl Changeset {
 
     pub(crate) fn truncate(&mut self, len: usize) {
         debug!(target: "rustyline", "Changeset::truncate({len})");
+        // Keep the open-group counter consistent with the markers being
+        // dropped (e.g. an aborted completion truncates away its own `Begin`).
+        for change in &self.undos[len..] {
+            match change {
+                Change::Begin => self.undo_group_level -= 1,
+                Change::End => self.undo_group_level += 1,
+                _ => {}
+            }
+        }
         self.undos.truncate(len);
     }
 
@@ -500,5 +513,35 @@ mod tests {
         cs.begin();
         cs.insert_str(0, "Hi");
         assert!(cs.end());
+    }
+
+    #[test]
+    fn test_nested_group() {
+        // An inner group (e.g. a command run inside a macro) must not close the
+        // enclosing group: one undo still reverts everything.
+        let mut buf = LineBuffer::init("", 0);
+        let mut cs = Changeset::new();
+        cs.begin(); // outer (macro)
+        cs.begin(); // inner (a sub-command opening its own group)
+        cs.insert_str(0, "ab");
+        buf.insert_str(0, "ab", &mut NoListener);
+        cs.end(); // closes inner only, outer stays open
+        cs.insert_str(2, "c");
+        buf.insert_str(2, "c", &mut NoListener);
+        cs.end(); // closes outer
+
+        assert!(cs.undo(&mut buf, 1));
+        assert_eq!("", buf.as_str());
+    }
+
+    #[test]
+    fn test_truncate_group_level() {
+        // Truncating away a `Begin` (as an aborted completion does) must keep
+        // the open-group counter balanced so later `end`s stay in sync.
+        let mut cs = Changeset::new();
+        let mark = cs.begin();
+        cs.insert_str(0, "ab");
+        cs.truncate(mark);
+        assert_eq!(0, cs.undo_group_level);
     }
 }


### PR DESCRIPTION
This implements the existing TODO in `EventHandler` to support binding a key to a sequence of commands:

```rust
/* invoke multiple actions
 * TODO Macro(), */
```

## Motivation

Several issues and PRs have requested the ability to execute multiple actions from a single key binding (#306, #269, #418, #342). The current API only supports returning a single `Cmd` from a binding, making it impossible to compose actions like "insert text then accept line."

This is a rework of #895 based on @gwenn's feedback. Instead of adding `Cmd::Macro` variants, this implements the feature within the existing `EventHandler` architecture as the TODO in the code suggested.

## Design

When a `Macro` binding is triggered:

1. The first `Cmd` is returned immediately from `custom_binding`
2. Remaining commands are queued in a `VecDeque<Cmd>` on `InputState`
3. Subsequent `next_cmd` calls drain the queue before waiting for keyboard input

Each queued command passes through the normal main-loop path, so special-command handling (Complete, Suspend, etc.) and validation all work correctly.

### Undo transactions

The entire macro sequence is wrapped in a single undo group (`Changeset::begin`/`end`). One undo reverses all commands in the macro.

### Kill ring

The kill ring is not reset between macro commands, preserving consecutive kill semantics within a macro.

### Refresh

A `refresh_line()` is called after the last macro command completes. Individual commands still refresh during execution since the edit methods call `refresh_line()` internally; since they run back-to-back without terminal I/O, there is no visible flicker. Removing all refresh would require carrying a flag through the edit methods.

### Cmd::Stash

Adds a `Cmd::Stash` variant that saves the current line buffer to `Editor::stashed_line`. The application retrieves it after `readline()` returns via `Editor::take_stashed_line()` and can pass it to `readline_with_initial()` on the next call. This enables macros that clear the line and submit a different command while preserving the user's in-progress input.

## Usage

I'm using this in fs_cli-rs where F1–F12 are bound to commands. The macro stashes the current input, clears the line, submits the command, and the readline loop restores the stashed line on the next iteration:

```rust
// Binding setup
fn setup_function_key_bindings(
    rl: &mut Editor<FsCliCompleter, FileHistory>,
    macros: &HashMap<String, String>,
) -> Result<()> {
    for i in 1..=12 {
        let key = format!("f{}", i);
        if let Some(command) = macros.get(&key) {
            let f_key = KeyEvent(KeyCode::F(i as u8), Modifiers::NONE);
            rl.bind_sequence(
                f_key,
                EventHandler::Macro(vec![
                    Cmd::Stash,
                    Cmd::Kill(Movement::WholeLine),
                    Cmd::Insert(1, command.clone()),
                    Cmd::AcceptLine,
                ]),
            );
        }
    }
    Ok(())
}

// Readline loop with stash restore
let result = if let Some(stashed) = rl.take_stashed_line() {
    rl.readline_with_initial(&prompt, (&stashed, ""))
} else {
    rl.readline(&prompt)
};
```

A `From<Vec<Cmd>>` impl is also provided for ergonomic construction.

## Manual testing

Tested in fs_cli-rs with F1–F12 macro bindings:

- `text<F5>`: line cleared, command submitted, stashed line restored on next prompt
- `<F1>` on empty line: inserts and accepts cleanly
- `Ctrl-/` (undo) after a non-accepting macro: single undo reverts the entire macro
- `hello world<F5>`, then `Ctrl-y`: yanks the killed text from the macro, not pre-macro kills
- `Ctrl-k` to kill text, then `<F5>`, then `Ctrl-y`: kill ring reset at macro start, yank returns macro's kill
- `<F5>` on empty line: works without error
- Holding `<F5>` on a line with text: keeps restoring the same stashed line
- `Ctrl-c` after macro, works fine