### PR TITLE
Implement vi `o`/`O` (open line below/above) in command mode

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -124,6 +124,21 @@ pub fn execute<H: Helper, P: Prompt + ?Sized>(
                 kill_ring.kill(&text, Mode::Append);
             }
         }
+        Cmd::OpenLine(anchor) => {
+            // vi `o` / `O`: open a new line below / above the current one and
+            // enter input mode (the vi keymap already switched to Insert).
+            match anchor {
+                Anchor::After => {
+                    s.edit_move_end()?;
+                    s.edit_insert('\n', 1)?;
+                }
+                Anchor::Before => {
+                    s.edit_move_home()?;
+                    s.edit_insert('\n', 1)?;
+                    s.edit_move_backward(1)?;
+                }
+            }
+        }
         Cmd::Newline => {
             s.edit_insert('\n', 1)?;
         }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -111,6 +111,9 @@ pub enum Cmd {
     LineDownOrNextHistory(RepeatCount),
     /// Inserts a newline
     Newline,
+    /// vi-open-line: open a new line and enter input mode — `Anchor::After`
+    /// for `o` (below the current line), `Anchor::Before` for `O` (above).
+    OpenLine(Anchor),
     /// Either accepts or inserts a newline
     ///
     /// Always inserts newline if input is non-valid. Can also insert newline
@@ -744,6 +747,18 @@ impl<'b> InputState<'b> {
                 self.input_mode = InputMode::Insert;
                 wrt.doing_insert();
                 Cmd::Move(Movement::EndOfLine)
+            }
+            E(K::Char('o'), M::NONE) => {
+                // vi-open-below
+                self.input_mode = InputMode::Insert;
+                wrt.doing_insert();
+                Cmd::OpenLine(Anchor::After)
+            }
+            E(K::Char('O'), M::NONE) => {
+                // vi-open-above
+                self.input_mode = InputMode::Insert;
+                wrt.doing_insert();
+                Cmd::OpenLine(Anchor::Before)
             }
             E(K::Char('b'), M::NONE) => Cmd::Move(Movement::BackwardWord(n, Word::Vi)), /* vi-prev-word */
             E(K::Char('B'), M::NONE) => Cmd::Move(Movement::BackwardWord(n, Word::Big)),

--- a/src/test/vi_cmd.rs
+++ b/src/test/vi_cmd.rs
@@ -94,6 +94,30 @@ fn uppercase_a() {
 }
 
 #[test]
+fn o() {
+    // vi-open-below: `o` opens a new line after the current one (regardless of
+    // cursor column) and enters insert mode.
+    assert_cursor(
+        EditMode::Vi,
+        ("Hel", "lo"),
+        &[E::ESC, E::from('o'), E::from('x'), E::ENTER],
+        ("Hello\nx", ""),
+    );
+}
+
+#[test]
+fn uppercase_o() {
+    // vi-open-above: `O` opens a new line before the current one and enters
+    // insert mode on it.
+    assert_cursor(
+        EditMode::Vi,
+        ("Hel", "lo"),
+        &[E::ESC, E::from('O'), E::from('x'), E::ENTER],
+        ("x", "\nHello"),
+    );
+}
+
+#[test]
 fn b() {
     assert_cursor(
         EditMode::Vi,


### PR DESCRIPTION
vi command mode had no `o`/`O` (open a new line and enter input mode) — they were silently no-ops. This adds them.

**What**
- `o` → open a line **below** the current one, enter insert mode.
- `O` → open a line **above**, enter insert mode.

**How**
A new `Cmd::OpenLine(Anchor)` (reusing `Anchor::After`/`Before`), implemented in `command::execute` (`o` = `edit_move_end` + insert `\n`; `O` = `edit_move_home` + insert `\n` + `edit_move_backward`). The `vi_command` arms set `InputMode::Insert` + `doing_insert()`, mirroring `a`/`A`/`i`/`I`. A new `Cmd` variant is needed because no existing one composes "move + insert newline" and a `vi_command` arm returns a single `Cmd`. Like `a`/`i`, `OpenLine` is intentionally not in `is_repeatable_change` (the `Cmd::redo` catch-all is `unreachable!()`).

**Tests:** `o` / `uppercase_o` in `src/test/vi_cmd.rs`. Full suite green; CI green on my fork (ubuntu / windows / min-versions).

**Out of scope** (happy to follow up): a count (`3o` repeats the typed text on `<Esc>` in vim — here it opens one line); and `.` dot-redo of an open (same as `a`/`i` today).

Authored with AI assistance, human-reviewed and tested (`Assisted-by:` trailer on the commit).

Closes #946.