### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 description = "Rustyline, a readline implementation based on Antirez's Linenoise"
 documentation = "https://docs.rs/rustyline"
 repository = "https://github.com/kkawakam/rustyline"
-readme = "README.md"
 keywords = ["readline"]
 license = "MIT"
 categories = ["command-line-interface"]

--- a/rustyline-derive/Cargo.toml
+++ b/rustyline-derive/Cargo.toml
@@ -27,3 +27,6 @@ syn = { version = "3.0.2", default-features = false, features = [
 ] }
 quote = { version = "1.0.44", default-features = false }
 proc-macro2 = { version = "1.0.106", default-features = false }
+
+[lints]
+workspace = true


### PR DESCRIPTION
explicit `package.readme` can be inferred
missing `[lints]` to inherit `[workspace.lints]`